### PR TITLE
Migrate precommit rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@schibstedspain/sui-lint": "2",
     "@schibstedspain/sui-mono": "1",
     "@schibstedspain/sui-precommit": "2",
-    "husky": "^0.13.4",
+    "husky": "0.13.4",
     "validate-commit-msg": "2.12.2"
   },
   "config": {

--- a/package.json
+++ b/package.json
@@ -11,14 +11,15 @@
     "co": "sui-mono commit",
     "release": "sui-mono release",
     "release:check": "sui-mono check",
-    "lint": "sui-lint js",
+    "lint": "sui-lint js && sui-lint sass",
     "commitmsg": "validate-commit-msg",
-    "precommit": "npm run lint"
+    "precommit": "sui-precommit run"
   },
   "devDependencies": {
-    "@schibstedspain/sui-mono": "1",
     "@schibstedspain/sui-lint": "2",
-    "husky": "0.13.4",
+    "@schibstedspain/sui-mono": "1",
+    "@schibstedspain/sui-precommit": "2",
+    "husky": "^0.13.4",
     "validate-commit-msg": "2.12.2"
   },
   "config": {

--- a/packages/sui-precommit/Readme.md
+++ b/packages/sui-precommit/Readme.md
@@ -1,10 +1,12 @@
 # sui-precommit
 > Effortless SUI precommit rules integration in your project
 
+
 Installs commit hook to ensure quality rules are executed before any commit (test, linting, consistent commit, etc)
+
 It provides:
-* Assurance that all code is compliant with schibsted's standards
-* Centralize precommit rules;  quality rules can be  improved and seemlessly inherited by all projects.
+* Assurance that all code is compliant with Schibsted's standards.
+* Centralize precommit rule:;  quality rules can be  improved and seemlessly inherited by all projects.
 
 
 ## Installation
@@ -14,26 +16,39 @@ It provides:
 $ npm install @schibstedspain/sui-precommit --save-dev
 ```
 
+## CLI
 
-## Usage
 
-Once installed, 3 new tasks are added to your project:
+### `$ sui-precommit run`
+
+
+Executes all rules:
+* `sui-lint` for both js and sass
+* Your own `test` command from package.json
+and your own "test" command.
+
+
+
+### `$ sui-precommit install`
+
+Installs `sui-precommit` as git pre-commit hook.
+
+Executes 3 actions:
+1. Install [husky](https://www.npmjs.com/package/husky) (if not installed yet) to your project.
+1. Add `sui-precommit run` as husky's precommit script.
+1. Add `sui-lint` as npm lint script  command so you can execute linting separately.
+
+Your package.json might be altered like that:
 
 ```json
 {
-  "name": "my-package",
-  "version": "1.0.0",
   "scripts": {
-    "lint:js": "sui-lint js",
-    "lint:sass": "sui-lint sass",
-    "lint": "npm run lint:js && npm run lint:sass"
+    "lint": "sui-lint js && sui-lint sass",
+    "precommit": "sui-precommit run"
   },
-  "pre-commit": [
-    "lint",
-    "test"
-  ],
   "devDependencies": {
-    "@schibstedspain/sui-precommit": "1"
+    "husky": "^0.13.4",
   }
 }
+
 ```

--- a/packages/sui-precommit/bin/sui-precommit-install.js
+++ b/packages/sui-precommit/bin/sui-precommit-install.js
@@ -14,7 +14,10 @@ installHuskyIfNotInstalled()
   })
 
 /* eslint-disable no-console */
-function log (...args) { args[0] = '[sui-precommit] ' + args[0]; console.log(...args) }
+function log (...args) {
+  args[0] = '[sui-precommit] ' + args[0]
+  console.log(...args)
+}
 
 /**
  * Installs script on package.json where command was executed

--- a/packages/sui-precommit/bin/sui-precommit-install.js
+++ b/packages/sui-precommit/bin/sui-precommit-install.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+const {spawn} = require('child_process')
+const Validate = require('git-validate')
+
+installHuskyIfNotInstalled()
+  .then(function () {
+    installScript('lint', 'sui-lint js && sui-lint sass')
+    installScript('precommit', 'sui-precommit run')
+  })
+  .catch(function () {
+    log('sui-precommit could not be properly installed')
+    process.exit(1)
+  })
+
+/* eslint-disable no-console */
+function log (...args) { args[0] = '[sui-precommit] ' + args[0]; console.log(...args) }
+
+/**
+ * Installs script on package.json where command was executed
+ * @param  {String} key   script name
+ * @param  {String} value command to execute
+ */
+function installScript (key, value) {
+  log('Installing "' + value + '" npm script on "' + key + '".')
+  Validate.installScript(key, value, { overwrite: 1 }, process.cwd())
+}
+
+/**
+ * Installs husky on project
+ * @return {Promise}
+ */
+function installHuskyIfNotInstalled () {
+  return new Promise(function (resolve, reject) {
+    if (!isHuskyInstalled()) {
+      log('husky will be installed as git hook integration with node')
+      spawn('npm', ['install', 'husky@0.13.4', '--save-dev'], { shell: true, stdio: 'inherit' })
+        .on('exit', code => { !code ? resolve(code) : reject(code) })
+    } else {
+      resolve(0)
+    }
+  })
+}
+
+/**
+ * Get if husky is already installed
+ * @return {Boolean}
+ */
+function isHuskyInstalled () {
+  try {
+    require.resolve('husky')
+    return true
+  } catch (e) {
+    return false
+  }
+}

--- a/packages/sui-precommit/bin/sui-precommit-run.js
+++ b/packages/sui-precommit/bin/sui-precommit-run.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+const {spawn} = require('child_process')
+const BIN_PATH = require.resolve('@schibstedspain/sui-lint/bin/sui-lint')
+
+spawn(BIN_PATH, ['js'], { shell: true, stdio: 'inherit' })
+  .on('exit', code => { code && process.exit(code) })
+
+spawn(BIN_PATH, ['sass'], { shell: true, stdio: 'inherit' })
+  .on('exit', code => { code && process.exit(code) })
+
+spawn('npm', ['run', 'test'], { shell: true, stdio: 'inherit' })
+  .on('exit', code => { code && process.exit(code) })

--- a/packages/sui-precommit/bin/sui-precommit.js
+++ b/packages/sui-precommit/bin/sui-precommit.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+const program = require('commander')
+const pkg = require('../package.json')
+const version = pkg.version
+
+program
+  .version(version, '    --version')
+
+program
+  .command('run', 'run precommit rules')
+  .command('install', 'add precommit rules to git hook')
+
+program.parse(process.argv)

--- a/packages/sui-precommit/package.json
+++ b/packages/sui-precommit/package.json
@@ -1,17 +1,20 @@
 {
   "name": "@schibstedspain/sui-precommit",
   "version": "1.1.0",
-  "description": "Installs a git hook that executes sui commit rules",
+  "description": "Effortless SUI precommit rules integration in your project",
   "main": "index.js",
+  "bin": {
+    "sui-precommit": "./bin/sui-precommit.js"
+  },
   "scripts": {
-    "build": "echo \"building...\"",
-    "install": "node ./install.js"
+    "build": "echo \"building...\""
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@schibstedspain/sui-lint": "1",
+    "@schibstedspain/sui-lint": "2",
+    "commander": "2.9.0",
     "git-validate": "2.2.2"
   }
 }


### PR DESCRIPTION
## Description
Proposal for sui-precommit new deal

Changes:
* **precommit rules are run a as a whole**
  * Pros:
    *  If you add new rules, we don't have to change installation or worry about chantes made by user
  * Cons:
     * User can't choose what to executed.
* **Now hook install is not automatic**
  * Pros:
     * User controls how he wants to integrate with git. He can even set the precommit before executing commitizen (no frustration)
     * No magic. User won't find its package.json to have been changed...
* **Husky is used for git hooks integration**
  * Pros: 
     * It's npm scripts based, with adds value to the project.
     * It's already used by sui-mono


Please review @miduga && @carlosvillu 
