### PR TITLE
Fix version tag

### DIFF
--- a/packages/sui-mono/bin/sui-mono-release.js
+++ b/packages/sui-mono/bin/sui-mono-release.js
@@ -37,7 +37,7 @@ const releaseEachPkg = ({pkg, code} = {}) => {
     let commands = [
       ['npm', ['--no-git-tag-version', 'version', `${RELEASE_CODES[code]}`]],
       ['git', ['add', cwd]],
-      ['git', [`commit -m "release(${pkg}): v${pkgInfo.version}"`]],
+      ['git', ['commit -m "release(' + pkg + '): v$(node -p -e "require(\'./package.json\')".version)"']],
       ['npm', ['publish', `--access=${publishAccess}`]],
       ['git', ['push', 'origin', 'HEAD']]
     ]

--- a/packages/sui-mono/package.json
+++ b/packages/sui-mono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schibstedspain/sui-mono",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Commit and release manager",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Description
Release commit had empty version number

## Notes
A wrong version was published as 1.12.0 and then unpublished. But, i could'nt publish 1.12.0 so I did it as 1.12.1...

As we use comver it shouldn't be a concern...
But, I can publish 1.13 if you think it's more apropriate.

Please review @naxhh @carlosvillu @miduga 

