### PR TITLE
fix(sui-studio): don't deprecate link command, only mention link-all

### DIFF
--- a/packages/sui-studio/bin/sui-studio-link.js
+++ b/packages/sui-studio/bin/sui-studio-link.js
@@ -6,7 +6,7 @@ const fs = require('fs-extra')
 const program = require('commander')
 const BASE_DIR = process.cwd()
 
-console.log(colors.yellow('sui-studio link is deprecated. Use "sui-studio link-all" instead.'))
+console.log(colors.cyan('If you\'re linking internal components, "sui-studio link-all" might be a better option.'))
 
 program
   .parse(process.argv)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As @naxhh pointed out, `sui-studio link` can link a component outside of the studio. `sui-studio link-all` can't...
