### PR TITLE
feat(sui-studio): log demo errors on console too

### DIFF
--- a/packages/sui-studio/src/components/preview/index.js
+++ b/packages/sui-studio/src/components/preview/index.js
@@ -75,6 +75,7 @@ export default class Preview extends Component {
         this.setState({error: undefined})
       }
     } catch (err) {
+      console.error(err)
       this.setTimeout(() => {
         this.setState({error: err.toString()})
       }, ERROR_TIMEOUT)


### PR DESCRIPTION
## Description
Last version(s) changed the demo error reporting to a nice error message in the dom.
That's nice but you loose the stack and you generally don't know where the error comes from.

Example: "can't read type of undefined" instead of 'can't read type of undefined callback this._getStatus ....'