### PR TITLE
Feature/add duplicate package checker on analyze

### DIFF
--- a/packages/sui-bundler/bin/sui-bundler-analyzer.js
+++ b/packages/sui-bundler/bin/sui-bundler-analyzer.js
@@ -1,15 +1,40 @@
 #!/usr/bin/env node
+/* eslint-disable no-console */
 
 const webpack = require('webpack')
+const ora = require('ora')
 const {BundleAnalyzerPlugin} = require('webpack-bundle-analyzer')
+const DuplicatePackageCheckerPlugin = require('duplicate-package-checker-webpack-plugin')
+
 const config = require('../webpack.config.prod')
 
-config.plugins.push(new BundleAnalyzerPlugin())
+console.log('🔎  Bundler Analyzer')
 
+// Don't show ugly deprecation warnings that mess with the logging
+process.noDeprecation = true
+
+config.plugins.push(new BundleAnalyzerPlugin())
+config.plugins.push(new DuplicatePackageCheckerPlugin({
+  // Also show module that is requiring each duplicate package
+  verbose: true,
+  // Emit errors instead of warnings
+  emitError: false
+}))
+
+const spinner = ora(`Building and analyzing...`).start()
 webpack(config).run((error, stats) => {
   if (error) {
+    spinner.fail('Error analyzing the build')
     throw new Error(error)
   }
 
-  console.log(stats) // eslint-disable-line no-console
+  spinner.succeed('Bundle analyzed successfully')
+  const jsonStats = stats.toJson()
+  if (stats.hasErrors()) {
+    return jsonStats.errors.map(error => console.error(error))
+  }
+
+  if (stats.hasWarnings()) {
+    jsonStats.warnings.map(warning => console.warn(warning))
+  }
 })

--- a/packages/sui-bundler/bin/sui-bundler-build.js
+++ b/packages/sui-bundler/bin/sui-bundler-build.js
@@ -49,11 +49,11 @@ webpack(config).run((error, stats) => {
 
   const jsonStats = stats.toJson()
 
-  if (jsonStats.hasErrors) {
+  if (stats.hasErrors()) {
     return jsonStats.errors.map(error => console.log(chalkError(error)))
   }
 
-  if (jsonStats.hasWarnings) {
+  if (stats.hasWarnings()) {
     console.log(chalkWarning('Webpack generated the following warnings: '))
     jsonStats.warnings.map(warning => console.log(chalkWarning(warning)))
   }

--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -35,6 +35,7 @@
     "css-content-loader": "1.0.0",
     "css-loader": "0.26.1",
     "detect-port": "1.2.1",
+    "duplicate-package-checker-webpack-plugin": "1.2.5",
     "extract-text-webpack-plugin": "2.0.0-beta.4",
     "file-loader": "0.9.0",
     "fs-extra": "3.0.1",

--- a/packages/sui-studio/bin/sui-studio-generate.js
+++ b/packages/sui-studio/bin/sui-studio-generate.js
@@ -96,7 +96,7 @@ COMPONENT_PACKAGE_JSON_FILE,
   "scripts": {
     "build": "rm -Rf ./lib && mkdir -p ./lib && npm run build:js && npm run build:styles",
     "build:js": "../../../node_modules/.bin/babel --presets sui ./src --out-dir ./lib",
-    "build:styles": "../../../node_modules/.bin/cpx \"./src/**/*.scss\" ./lib"
+    "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
     "@schibstedspain/sui-component-dependencies": "latest"


### PR DESCRIPTION
Review @carlosvillu @davidbarna 

- [x] Add duplicate package checker on analyzing.
- [x] Fix error linter that prevented to commit.
- [x] Fix way to check errors and warnings of the stats.

Checker on analyzing for dupe packages dependencies:
![image](https://user-images.githubusercontent.com/1561955/28237747-d6aea21c-6946-11e7-9544-6d558c2694fc.png)
