### PR TITLE
fix(sui-studio): update elements z-index

### DIFF
--- a/packages/sui-studio/src/components/demo/_style.scss
+++ b/packages/sui-studio/src/components/demo/_style.scss
@@ -20,7 +20,7 @@
     right: 0;
     top: 0;
     width: 100%;
-    z-index: 99998;
+    z-index: 9998;
 
     &--open {
       display: block;

--- a/packages/sui-studio/src/components/layout/_style.scss
+++ b/packages/sui-studio/src/components/layout/_style.scss
@@ -28,7 +28,7 @@
     transform: translate3d(-100%, 0, 0);
     transition: transform .5s ease-in-out;
     width: 100%;
-    z-index: 999998;
+    z-index: 9998;
 
     &Body {
       transition: width .25s ease-out;
@@ -66,5 +66,5 @@
   @include breakpoint-from(s) {
     display: none;
   }
-  z-index: 999999;
+  z-index: 9999;
 }

--- a/packages/sui-studio/src/styles/_settings.scss
+++ b/packages/sui-studio/src/styles/_settings.scss
@@ -100,7 +100,7 @@ $w-sidebar-collapsed: 48px;
   position: absolute;
   right: 16px;
   width: $size;
-  z-index: 99999;
+  z-index: 9999;
 
   svg {
     fill: $c-white;


### PR DESCRIPTION
ISSUES CLOSED: #25 
## Description

[The overlay z-index ](https://github.com/glenjamin/webpack-hot-middleware/blob/master/client-overlay.js#L13) was under the z-index we were setting in sui-studio, so I updated our z-index

## Related Issue
#25 
