### PR TITLE
Pass domain to playground

### DIFF
--- a/packages/sui-studio/src/components/demo/index.js
+++ b/packages/sui-studio/src/components/demo/index.js
@@ -143,7 +143,7 @@ export default class Demo extends Component {
 
         <Preview
           code={playground}
-          scope={{React, [`${cleanDisplayName(Enhance.displayName || Enhance.name)}`]: Enhance}}
+          scope={{React, [`${cleanDisplayName(Enhance.displayName || Enhance.name)}`]: Enhance, domain}}
         />
       </div>
     )


### PR DESCRIPTION
## Description
In order to pass initialProps to the component without a "tramsmit" like solution in the studio. We will go to use directly the domain in the playground
