### PR TITLE
Feature/sui mono help commands

### DIFF
--- a/packages/sui-mono/bin/sui-mono-check.js
+++ b/packages/sui-mono/bin/sui-mono-check.js
@@ -1,5 +1,25 @@
 /* eslint no-console:0 */
+const program = require('commander')
 const checker = require('../src/check')
+
+program
+  .on('--help', () => {
+    console.log('  Description:')
+    console.log('')
+    console.log('    Reports if any package should be released based on ComVer')
+    console.log('')
+    console.log('    It will create a MAJOR only if there are BREAKING CHANGES in the commit description')
+    console.log('    The types fix, perf and feat will generate a MINOR')
+    console.log('    All other commit types will not generate a version change')
+    console.log('')
+    console.log('  Examples:')
+    console.log('')
+    console.log('    $ sui-mono check')
+    console.log('    $ sui-mono --help')
+    console.log('    $ sui-mono -h')
+    console.log('')
+  })
+  .parse(process.argv)
 
 const incrementName = (code) => {
   if (code === 1) {

--- a/packages/sui-mono/bin/sui-mono-link.js
+++ b/packages/sui-mono/bin/sui-mono-link.js
@@ -1,3 +1,7 @@
+#!/usr/bin/env node
+/* eslint no-console:0 */
+
+const program = require('commander')
 const path = require('path')
 const config = require('../src/config')
 const { serialSpawn } = require('@schibstedspain/sui-helpers/cli')
@@ -5,6 +9,23 @@ const {
   getPackagesPaths, getPackagesNames,
   getInternalDependencyMap, getUsedInternalDependencies
 } = require('@schibstedspain/sui-helpers/packages')
+
+program
+  .on('--help', () => {
+    console.log('  Description:')
+    console.log('')
+    console.log('    Links all the packages in the current project with all the dependencies that are also part of the project')
+    console.log('    For example sui-studio has a dependency on sui-mono')
+    console.log('    If you perform this command you will have your local sui-mono linked to your local sui-studio')
+    console.log('')
+    console.log('  Examples:')
+    console.log('')
+    console.log('    $ sui-mono link')
+    console.log('    $ sui-mono --help')
+    console.log('    $ sui-mono -h')
+    console.log('')
+  })
+  .parse(process.argv)
 
 const packages = config.getScopes()
 const cwd = path.join(process.cwd(), config.getPackagesFolder())

--- a/packages/sui-mono/bin/sui-mono-release.js
+++ b/packages/sui-mono/bin/sui-mono-release.js
@@ -1,9 +1,32 @@
 /* eslint no-console:0 */
 
+const program = require('commander')
 const path = require('path')
 const config = require('../src/config')
 const checker = require('../src/check')
 const { serialSpawn } = require('@schibstedspain/sui-helpers/cli')
+
+program
+  .on('--help', () => {
+    console.log('  Description:')
+    console.log('')
+    console.log('    Release your packages based on the version check output')
+    console.log('')
+    console.log('    Its adviced that you inspect the output on sui-mono check before releasing')
+    console.log('    Release is the process of:')
+    console.log('     - Build your projcet (with build or prepublish npm script')
+    console.log('     - Updating package.json version')
+    console.log('     - Creating a release commit type')
+    console.log('     - Pushing the package to npm (in case its not private)')
+    console.log('')
+    console.log('  Examples:')
+    console.log('')
+    console.log('    $ sui-mono release')
+    console.log('    $ sui-mono --help')
+    console.log('    $ sui-mono -h')
+    console.log('')
+  })
+  .parse(process.argv)
 
 const BASE_DIR = process.cwd()
 

--- a/packages/sui-mono/bin/sui-mono-run.js
+++ b/packages/sui-mono/bin/sui-mono-run.js
@@ -1,3 +1,6 @@
+#!/usr/bin/env node
+/* eslint no-console:0 */
+
 const path = require('path')
 const program = require('commander')
 const config = require('../src/config')
@@ -5,7 +8,20 @@ const { serialSpawn } = require('@schibstedspain/sui-helpers/cli')
 const PACKAGES_DIR = path.join(process.cwd(), config.getPackagesFolder())
 const cwds = config.getScopes().map(pkg => path.join(PACKAGES_DIR, pkg))
 
-program.parse(process.argv)
+program
+  .on('--help', () => {
+    console.log('  Description:')
+    console.log('')
+    console.log('    Runs the given command on all the packages')
+    console.log('')
+    console.log('  Examples:')
+    console.log('')
+    console.log('    $ sui-mono run npm i')
+    console.log('    $ sui-mono --help')
+    console.log('    $ sui-mono -h')
+    console.log('')
+  })
+  .parse(process.argv)
 
 serialSpawn(cwds.map(getTaskArray))
   .then(code => process.exit(code))


### PR DESCRIPTION
Provide help information for sui-mono commands

## Description
Now you can `sui-mono release --help` and not perform a release \o/

## Related Issue
This kind of fixes #53 but the help text provides examples of sui-mono I'll let julian decides to close the issue or create another PR for specific sui-studio help

## Example

```
sui-mono check --help
sui-mono release --help
sui-mono run --help
sui-mono link --help
```