### PR TITLE
Feature/sui mono tag releases

### DIFF
--- a/packages/sui-mono/bin/sui-mono-release.js
+++ b/packages/sui-mono/bin/sui-mono-release.js
@@ -29,7 +29,13 @@ const releaseEachPkg = ({pkg, code} = {}) => {
   return new Promise((resolve, reject) => {
     if (code === 0) { return resolve() }
 
+    console.log(pkg)
     const isMonoPackage = config.isMonoPackage()
+
+    const tagPrefix = isMonoPackage
+      ? ''
+      : `${pkg}-`
+
     const packageScope = isMonoPackage
       ? 'META'
       : pkg
@@ -44,7 +50,7 @@ const releaseEachPkg = ({pkg, code} = {}) => {
       ['npm', ['--no-git-tag-version', 'version', `${RELEASE_CODES[code]}`]],
       ['git', ['add', cwd]],
       ['git', ['commit -m "release(' + packageScope + '): v$(node -p -e "require(\'./package.json\')".version)"']],
-      ['git', ['tag -a $(node -p -e "require(\'./package.json\')".version)" -m "v$(node -p -e \"require(\'./package.json\')".version)\""']], // eslint-disable-line no-useless-escape
+      ['echo', ['tag -a ' + tagPrefix + '$(node -p -e "require(\'./package.json\')".version)" -m "v$(node -p -e \"require(\'./package.json\')".version)\""']], // eslint-disable-line no-useless-escape
       !pkgInfo.private && ['npm', ['publish', `--access=${publishAccess}`]],
       ['git', ['push', 'origin', 'HEAD']]
     ].filter(Boolean)

--- a/packages/sui-mono/bin/sui-mono-release.js
+++ b/packages/sui-mono/bin/sui-mono-release.js
@@ -29,7 +29,6 @@ const releaseEachPkg = ({pkg, code} = {}) => {
   return new Promise((resolve, reject) => {
     if (code === 0) { return resolve() }
 
-    console.log(pkg)
     const isMonoPackage = config.isMonoPackage()
 
     const tagPrefix = isMonoPackage

--- a/packages/sui-mono/bin/sui-mono-release.js
+++ b/packages/sui-mono/bin/sui-mono-release.js
@@ -49,7 +49,7 @@ const releaseEachPkg = ({pkg, code} = {}) => {
       ['npm', ['--no-git-tag-version', 'version', `${RELEASE_CODES[code]}`]],
       ['git', ['add', cwd]],
       ['git', ['commit -m "release(' + packageScope + '): v$(node -p -e "require(\'./package.json\')".version)"']],
-      ['echo', ['tag -a ' + tagPrefix + '$(node -p -e "require(\'./package.json\')".version)" -m "v$(node -p -e \"require(\'./package.json\')".version)\""']], // eslint-disable-line no-useless-escape
+      ['git', ['tag -a ' + tagPrefix + '$(node -p -e "require(\'./package.json\')".version)" -m "v$(node -p -e \"require(\'./package.json\')".version)\""']], // eslint-disable-line no-useless-escape
       !pkgInfo.private && ['npm', ['publish', `--access=${publishAccess}`]],
       ['git', ['push', 'origin', 'HEAD']]
     ].filter(Boolean)

--- a/packages/sui-mono/bin/sui-mono-release.js
+++ b/packages/sui-mono/bin/sui-mono-release.js
@@ -30,21 +30,21 @@ const releaseEachPkg = ({pkg, code} = {}) => {
     if (code === 0) { return resolve() }
 
     const isMonoPackage = config.isMonoPackage()
-
-    const packageName = isMonoPackage
+    const packageScope = isMonoPackage
       ? 'META'
       : pkg
 
     const cwd = isMonoPackage
       ? BASE_DIR
-      : path.join(BASE_DIR, packagesFolder, packageName)
+      : path.join(BASE_DIR, packagesFolder, pkg)
     const pkgInfo = require(path.join(cwd, 'package.json'))
     const scripts = pkgInfo.scripts || {}
 
     let commands = [
       ['npm', ['--no-git-tag-version', 'version', `${RELEASE_CODES[code]}`]],
       ['git', ['add', cwd]],
-      ['git', ['commit -m "release(' + packageName + '): v$(node -p -e "require(\'./package.json\')".version)"']],
+      ['git', ['commit -m "release(' + packageScope + '): v$(node -p -e "require(\'./package.json\')".version)"']],
+      ['git', ['tag -a $(node -p -e "require(\'./package.json\')".version)" -m "v$(node -p -e \"require(\'./package.json\')".version)\""']], // eslint-disable-line no-useless-escape
       !pkgInfo.private && ['npm', ['publish', `--access=${publishAccess}`]],
       ['git', ['push', 'origin', 'HEAD']]
     ].filter(Boolean)


### PR DESCRIPTION
Tag releases on sui-mono

## Description
monorepo monopackages had been being tagged manually. Sui mono added support for monopackages but didn't add the ability to auto tag them.

This pr solve that issue, and also provides auto tagging for multipackage

## Related Issue
Fixes #68

## Example

Mono package will execute this command:
```
git tag -a 8.13.0 -m v8.13.0
```

Multi package will execute:
```
git tag -a sui-mono-1.21.0 -m v1.21.0
```