### PR TITLE
Issue/27 [sui-studio] Add new Changelog tab for components

### DIFF
--- a/packages/babel-preset-sui/CHANGELOG.md
+++ b/packages/babel-preset-sui/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+<a name="1.3.0"></a>
+# 1.3.0 (2017-08-01)
+
+
+### Features
+
+* add babel-plugin-transform-export-extensions ([7dbc14b](https://github.com/SUI-Components/sui/commit/7dbc14b))
+
+
+
+<a name="1.2.0"></a>
+# 1.2.0 (2017-07-05)
+
+
+### Features
+
+* add legacy decorators plugin to make compatible some packages ([2b19af4](https://github.com/SUI-Components/sui/commit/2b19af4))
+
+
+
+<a name="1.1.0"></a>
+# 1.1.0 (2017-06-22)
+
+
+### Bug Fixes
+
+* fix first version to 1.0.0 ([4b4a9b3](https://github.com/SUI-Components/sui/commit/4b4a9b3))
+
+
+
+<a name="0.1.0"></a>
+# 0.1.0 (2017-06-22)
+
+
+### Bug Fixes
+
+* rename preset from schibsted-spain to sui ([e5a385f](https://github.com/SUI-Components/sui/commit/e5a385f))
+
+
+### Features
+
+* migration from babel-preset-schibsted-spain ([ef602e6](https://github.com/SUI-Components/sui/commit/ef602e6))
+
+
+

--- a/packages/sui-bundler/CHANGELOG.md
+++ b/packages/sui-bundler/CHANGELOG.md
@@ -1,0 +1,100 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+<a name="2.3.0"></a>
+# 2.3.0 (2017-08-09)
+
+
+### Bug Fixes
+
+* working inside the sui-studio ([c782bf0](https://github.com/SUI-Components/sui/commit/c782bf0))
+
+
+
+<a name="2.2.0"></a>
+# 2.2.0 (2017-07-27)
+
+
+### Bug Fixes
+
+* fix problems with postCss because API changed for the loader ([e60ed20](https://github.com/SUI-Components/sui/commit/e60ed20))
+
+
+
+<a name="2.1.0"></a>
+# 2.1.0 (2017-07-27)
+
+
+### Features
+
+* update to webpack 3.4.0 ([b28275b](https://github.com/SUI-Components/sui/commit/b28275b))
+
+
+
+<a name="1.5.0"></a>
+# 1.5.0 (2017-07-17)
+
+
+### Bug Fixes
+
+* fix wrong way to check hasErrors and hasWarnings, always was undefined ([b5b8421](https://github.com/SUI-Components/sui/commit/b5b8421))
+
+
+### Features
+
+* add Duplicated NPM Package checker on analyzing ([1809284](https://github.com/SUI-Components/sui/commit/1809284))
+
+
+
+<a name="1.4.0"></a>
+# 1.4.0 (2017-07-10)
+
+
+### Bug Fixes
+
+* use contenthash because chunkhash sometimes doesnt change ([ca03399](https://github.com/SUI-Components/sui/commit/ca03399))
+
+
+
+<a name="1.3.0"></a>
+# 1.3.0 (2017-07-05)
+
+
+### Features
+
+* use prefetch instead preload to avoid blocking requests ([582d59e](https://github.com/SUI-Components/sui/commit/582d59e))
+
+
+
+<a name="1.2.0"></a>
+# 1.2.0 (2017-07-04)
+
+
+### Bug Fixes
+
+* remove react alias as not need ([9db2e7a](https://github.com/SUI-Components/sui/commit/9db2e7a))
+
+
+### Features
+
+* rename package and its binary ([0f57470](https://github.com/SUI-Components/sui/commit/0f57470))
+* update sui-bundler from suistudio-webpack ([5bd67f4](https://github.com/SUI-Components/sui/commit/5bd67f4))
+
+
+### BREAKING CHANGES
+
+* CLI has changed name
+
+
+
+<a name="3.4.0"></a>
+# 3.4.0 (2017-06-27)
+
+
+### Features
+
+* migrate from sui-studio-webpack ([1b58081](https://github.com/SUI-Components/sui/commit/1b58081))
+
+
+

--- a/packages/sui-component-dependencies/CHANGELOG.md
+++ b/packages/sui-component-dependencies/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+<a name="1.2.0"></a>
+# 1.2.0 (2017-06-22)
+
+
+### Bug Fixes
+
+* make package public ([08b503b](https://github.com/SUI-Components/sui/commit/08b503b))
+
+
+
+<a name="1.1.0"></a>
+# 1.1.0 (2017-06-22)
+
+
+### Features
+
+* first release 1.0 ([54e5ff6](https://github.com/SUI-Components/sui/commit/54e5ff6))
+* migrate from [@schibstedspain](https://github.com/schibstedspain)/suistudio-fatigue-deps ([b0474f8](https://github.com/SUI-Components/sui/commit/b0474f8))
+
+
+

--- a/packages/sui-component-peer-dependencies/CHANGELOG.md
+++ b/packages/sui-component-peer-dependencies/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+<a name="1.1.0"></a>
+# 1.1.0 (2017-06-25)
+
+
+### Features
+
+* add dependencies to be used with all sui-components ([77fded5](https://github.com/SUI-Components/sui/commit/77fded5))
+
+
+

--- a/packages/sui-cz/CHANGELOG.md
+++ b/packages/sui-cz/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+<a name="1.3.0"></a>
+# 1.3.0 (2017-07-13)
+
+
+### Bug Fixes
+
+* fix: command fails when there is no package in monorepos ([0b603f8](https://github.com/SUI-Components/sui/commit/0b603f8))
+
+
+
+<a name="1.2.0"></a>
+# 1.2.0 (2017-06-21)
+
+
+### Bug Fixes
+
+* remove unused scripts ([2c77b71](https://github.com/SUI-Components/sui/commit/2c77b71))
+
+
+
+<a name="1.1.0"></a>
+# 1.1.0 (2017-06-16)
+
+
+### Bug Fixes
+
+* description have change since types implementation ([e490849](https://github.com/SUI-Components/sui/commit/e490849))
+
+
+### Features
+
+* add cz types to allow consitent integration with githooks ([296f8bb](https://github.com/SUI-Components/sui/commit/296f8bb))
+* set package name to [@schibstedspain](https://github.com/schibstedspain)/sui-cz ([b797042](https://github.com/SUI-Components/sui/commit/b797042))
+
+
+

--- a/packages/sui-decorators/CHANGELOG.md
+++ b/packages/sui-decorators/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+<a name="1.1.0"></a>
+# 1.1.0 (2017-08-02)
+
+
+### Features
+
+* add package.json ([63e3529](https://github.com/SUI-Components/sui/commit/63e3529))
+
+
+

--- a/packages/sui-helpers/CHANGELOG.md
+++ b/packages/sui-helpers/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+<a name="1.2.0"></a>
+# 1.2.0 (2017-07-04)
+
+
+### Features
+
+* add helpers to manage packages of file system ([b8ced10](https://github.com/SUI-Components/sui/commit/b8ced10))
+* new package with cli helpers ([e270fa0](https://github.com/SUI-Components/sui/commit/e270fa0))
+
+
+

--- a/packages/sui-helpers/cli.js
+++ b/packages/sui-helpers/cli.js
@@ -29,7 +29,7 @@ function getSpawnPromiseFactory (bin, args, options) {
 }
 
 /**
- * Spawn fiven command and return a promise of the exit code value
+ * Spawn given command and return a promise of the exit code value
  * @param  {String} bin     Binary path or alias
  * @param  {Array} args    Array of args, like ['npm', ['run', 'test']]
  * @param  {Object} [options={shell: true, stdio: 'inherit'}] Options to pass to child_process.spawn call

--- a/packages/sui-hoc/CHANGELOG.md
+++ b/packages/sui-hoc/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+<a name="1.3.0"></a>
+# 1.3.0 (2017-08-09)
+
+
+### Bug Fixes
+
+* avoid installing devDependencies ([0ab4d77](https://github.com/SUI-Components/sui/commit/0ab4d77))
+* wrong way to construct childContextTypes ([6e600c5](https://github.com/SUI-Components/sui/commit/6e600c5))
+
+
+
+<a name="1.2.0"></a>
+# 1.2.0 (2017-08-02)
+
+
+### Features
+
+* add Readme ([bff8988](https://github.com/SUI-Components/sui/commit/bff8988))
+
+
+
+<a name="1.1.0"></a>
+# 1.1.0 (2017-08-02)
+
+
+### Features
+
+* 🌈 First Commit ([b09a168](https://github.com/SUI-Components/sui/commit/b09a168))
+
+
+

--- a/packages/sui-i18n/CHANGELOG.md
+++ b/packages/sui-i18n/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+<a name="1.1.0"></a>
+# 1.1.0 (2017-08-02)
+
+
+### Features
+
+* add package.json ([b5b25a7](https://github.com/SUI-Components/sui/commit/b5b25a7))
+
+
+

--- a/packages/sui-lint/CHANGELOG.md
+++ b/packages/sui-lint/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+<a name="2.3.0"></a>
+# 2.3.0 (2017-07-04)
+
+
+### Bug Fixes
+
+* add public folder to eslint ignore path ([1a903bf](https://github.com/SUI-Components/sui/commit/1a903bf))
+* improve speed changing ignore patterns of sass-lint ([2dcb871](https://github.com/SUI-Components/sui/commit/2dcb871))
+
+
+
+<a name="2.1.0"></a>
+# 2.1.0 (2017-06-21)
+
+
+### Bug Fixes
+
+* remove unused scripts ([ecbbb62](https://github.com/SUI-Components/sui/commit/ecbbb62))
+
+
+
+<a name="2.0.0"></a>
+# 2.0.0 (2017-06-16)
+
+
+### Bug Fixes
+
+* add build script to be compatible with sui-mono releases ([020e211](https://github.com/SUI-Components/sui/commit/020e211))
+* fix implementation of build script ([9b00cd6](https://github.com/SUI-Components/sui/commit/9b00cd6))
+* improve resolution of eslint bin ([22f8073](https://github.com/SUI-Components/sui/commit/22f8073))
+
+
+### Features
+
+* first commit of linting-rules migration ([1829091](https://github.com/SUI-Components/sui/commit/1829091))
+* rename package so [@schibstedspain](https://github.com/schibstedspain)/sui-lint with consistent CLI ([650b16a](https://github.com/SUI-Components/sui/commit/650b16a))
+
+
+### BREAKING CHANGES
+
+* CLI has changed and not compatible to previous version
+
+
+

--- a/packages/sui-mono/CHANGELOG.md
+++ b/packages/sui-mono/CHANGELOG.md
@@ -1,0 +1,194 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+<a name="1.17.0"></a>
+# 1.17.0 (2017-08-09)
+
+
+### Bug Fixes
+
+* push tags to the repo ([92a1a7c](https://github.com/SUI-Components/sui/commit/92a1a7c))
+
+
+
+<a name="1.16.0"></a>
+# 1.16.0 (2017-08-09)
+
+
+### Bug Fixes
+
+* add help command for check ([866a1a3](https://github.com/SUI-Components/sui/commit/866a1a3))
+* add release command help ([ce61a89](https://github.com/SUI-Components/sui/commit/ce61a89))
+* remove console.log left there, bad boy! ([6037ea8](https://github.com/SUI-Components/sui/commit/6037ea8))
+* use git command instead the debugging one ([23030fe](https://github.com/SUI-Components/sui/commit/23030fe))
+
+
+### Features
+
+* add commands for link and run ([c774e23](https://github.com/SUI-Components/sui/commit/c774e23))
+* tag releases ([bb75071](https://github.com/SUI-Components/sui/commit/bb75071))
+* tag releases ([95d213b](https://github.com/SUI-Components/sui/commit/95d213b))
+
+
+
+<a name="1.14.0"></a>
+# 1.14.0 (2017-07-27)
+
+
+### Bug Fixes
+
+* fix condition for mono package ([2621031](https://github.com/SUI-Components/sui/commit/2621031))
+* fix how scope commits are flatten ([a180d3c](https://github.com/SUI-Components/sui/commit/a180d3c))
+
+
+### Features
+
+* check and release working for mono package mono repo projects ([493fcc9](https://github.com/SUI-Components/sui/commit/493fcc9))
+* if a package has no package.json the project is monopackage ([0f6276c](https://github.com/SUI-Components/sui/commit/0f6276c))
+
+
+
+<a name="1.14.0"></a>
+# 1.14.0 (2017-07-04)
+
+
+### Features
+
+* dont publish private packages ([55c35ce](https://github.com/SUI-Components/sui/commit/55c35ce))
+
+
+
+<a name="1.13.0"></a>
+# 1.13.0 (2017-07-04)
+
+
+### Features
+
+* sui-mono link command ([db9596a](https://github.com/SUI-Components/sui/commit/db9596a))
+
+
+
+<a name="1.12.0"></a>
+# 1.12.0 (2017-07-03)
+
+
+### Bug Fixes
+
+* fix to use default restrict access type instead private ([6a566a7](https://github.com/SUI-Components/sui/commit/6a566a7))
+
+
+
+<a name="1.12.0"></a>
+# 1.12.0 (2017-06-30)
+
+
+### Bug Fixes
+
+* version tag nos set properly ([fc740ff](https://github.com/SUI-Components/sui/commit/fc740ff)), closes [#3c00cec1d5e3138bf2095b70200b9e8d447f0de1](https://github.com/SUI-Components/sui/issues/3c00cec1d5e3138bf2095b70200b9e8d447f0de1)
+
+
+
+<a name="1.10.0"></a>
+# 1.10.0 (2017-06-29)
+
+
+### Bug Fixes
+
+* release version commit is empty ([3c00cec](https://github.com/SUI-Components/sui/commit/3c00cec))
+
+
+### Features
+
+* migrate commands executions to sui-helpers/cli ([e6341bf](https://github.com/SUI-Components/sui/commit/e6341bf))
+
+
+
+<a name="1.8.0"></a>
+# 1.8.0 (2017-06-25)
+
+
+### Bug Fixes
+
+* change release to avoid race conditions ([cb65029](https://github.com/SUI-Components/sui/commit/cb65029))
+
+
+
+<a name="1.7.0"></a>
+# 1.7.0 (2017-06-25)
+
+
+### Features
+
+* add "sui-mono run" for multiple executions ([c14b66c](https://github.com/SUI-Components/sui/commit/c14b66c))
+
+
+
+<a name="1.6.0"></a>
+# 1.6.0 (2017-06-22)
+
+
+### Features
+
+* add config by CLI options ([3bec4ef](https://github.com/SUI-Components/sui/commit/3bec4ef))
+
+
+
+<a name="1.5.0"></a>
+# 1.5.0 (2017-06-21)
+
+
+### Bug Fixes
+
+* remove unused scripts ([d7dd39b](https://github.com/SUI-Components/sui/commit/d7dd39b))
+
+
+
+<a name="1.4.0"></a>
+# 1.4.0 (2017-06-21)
+
+
+### Bug Fixes
+
+* remove unused script phoenix ([3b2b249](https://github.com/SUI-Components/sui/commit/3b2b249))
+
+
+
+<a name="1.3.0"></a>
+# 1.3.0 (2017-06-21)
+
+
+### Bug Fixes
+
+* not throw error on release if build script is absent ([f8d91dc](https://github.com/SUI-Components/sui/commit/f8d91dc))
+
+
+
+<a name="1.2.0"></a>
+# 1.2.0 (2017-06-21)
+
+
+### Bug Fixes
+
+* fix refactor error. packageConfig has no config prop ([d2312a3](https://github.com/SUI-Components/sui/commit/d2312a3))
+
+
+
+<a name="1.1.0"></a>
+# 1.1.0 (2017-06-16)
+
+
+### Bug Fixes
+
+* add build script which is mandatory ([8ce1de8](https://github.com/SUI-Components/sui/commit/8ce1de8))
+* move build script to scripts, instead of bin ([baa86d0](https://github.com/SUI-Components/sui/commit/baa86d0))
+* sui-mono/src/types does not work ([2f73f25](https://github.com/SUI-Components/sui/commit/2f73f25))
+* switch use of cz-crm to sui-cz ([9036614](https://github.com/SUI-Components/sui/commit/9036614))
+
+
+### Features
+
+* set package name to [@schibstedspain](https://github.com/schibstedspain)/sui-mono ([98255d4](https://github.com/SUI-Components/sui/commit/98255d4))
+
+
+

--- a/packages/sui-mono/CHANGELOG.md
+++ b/packages/sui-mono/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+<a name="1.18.0"></a>
+# 1.18.0 (2017-08-22)
+
+
+### Features
+
+* add command to generate changelog in markdown format ([bb62c38](https://github.com/SUI-Components/sui/commit/bb62c38))
+* update CHANGELOG.md as part of every release ([9a64254](https://github.com/SUI-Components/sui/commit/9a64254))
+
+
+
 <a name="1.17.0"></a>
 # 1.17.0 (2017-08-09)
 

--- a/packages/sui-mono/CHANGELOG.md
+++ b/packages/sui-mono/CHANGELOG.md
@@ -2,14 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+<a name="1.19.0"></a>
+# 1.19.0 (2017-08-23)
+
+
+### Bug Fixes
+
+* **sui-mono:** make changelog take into account monopackage repos ([4e6e1cb](https://github.com/SUI-Components/sui/commit/4e6e1cb))
+
+
+
 <a name="1.18.0"></a>
 # 1.18.0 (2017-08-22)
 
 
 ### Features
 
-* add command to generate changelog in markdown format ([bb62c38](https://github.com/SUI-Components/sui/commit/bb62c38))
-* update CHANGELOG.md as part of every release ([9a64254](https://github.com/SUI-Components/sui/commit/9a64254))
+* **sui-mono:** add command to generate changelog in markdown format ([bb62c38](https://github.com/SUI-Components/sui/commit/bb62c38))
+* **sui-mono:** update CHANGELOG.md as part of every release ([9a64254](https://github.com/SUI-Components/sui/commit/9a64254))
 
 
 
@@ -19,7 +29,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-* push tags to the repo ([92a1a7c](https://github.com/SUI-Components/sui/commit/92a1a7c))
+* **sui-mono:** push tags to the repo ([92a1a7c](https://github.com/SUI-Components/sui/commit/92a1a7c))
 
 
 
@@ -29,17 +39,17 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-* add help command for check ([866a1a3](https://github.com/SUI-Components/sui/commit/866a1a3))
-* add release command help ([ce61a89](https://github.com/SUI-Components/sui/commit/ce61a89))
-* remove console.log left there, bad boy! ([6037ea8](https://github.com/SUI-Components/sui/commit/6037ea8))
-* use git command instead the debugging one ([23030fe](https://github.com/SUI-Components/sui/commit/23030fe))
+* **sui-mono:** add help command for check ([866a1a3](https://github.com/SUI-Components/sui/commit/866a1a3))
+* **sui-mono:** add release command help ([ce61a89](https://github.com/SUI-Components/sui/commit/ce61a89))
+* **sui-mono:** remove console.log left there, bad boy! ([6037ea8](https://github.com/SUI-Components/sui/commit/6037ea8))
+* **sui-mono:** use git command instead the debugging one ([23030fe](https://github.com/SUI-Components/sui/commit/23030fe))
 
 
 ### Features
 
-* add commands for link and run ([c774e23](https://github.com/SUI-Components/sui/commit/c774e23))
-* tag releases ([bb75071](https://github.com/SUI-Components/sui/commit/bb75071))
-* tag releases ([95d213b](https://github.com/SUI-Components/sui/commit/95d213b))
+* **sui-mono:** add commands for link and run ([c774e23](https://github.com/SUI-Components/sui/commit/c774e23))
+* **sui-mono:** tag releases ([bb75071](https://github.com/SUI-Components/sui/commit/bb75071))
+* **sui-mono:** tag releases ([95d213b](https://github.com/SUI-Components/sui/commit/95d213b))
 
 
 
@@ -49,14 +59,14 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-* fix condition for mono package ([2621031](https://github.com/SUI-Components/sui/commit/2621031))
-* fix how scope commits are flatten ([a180d3c](https://github.com/SUI-Components/sui/commit/a180d3c))
+* **sui-mono:** fix condition for mono package ([2621031](https://github.com/SUI-Components/sui/commit/2621031))
+* **sui-mono:** fix how scope commits are flatten ([a180d3c](https://github.com/SUI-Components/sui/commit/a180d3c))
 
 
 ### Features
 
-* check and release working for mono package mono repo projects ([493fcc9](https://github.com/SUI-Components/sui/commit/493fcc9))
-* if a package has no package.json the project is monopackage ([0f6276c](https://github.com/SUI-Components/sui/commit/0f6276c))
+* **sui-mono:** check and release working for mono package mono repo projects ([493fcc9](https://github.com/SUI-Components/sui/commit/493fcc9))
+* **sui-mono:** if a package has no package.json the project is monopackage ([0f6276c](https://github.com/SUI-Components/sui/commit/0f6276c))
 
 
 
@@ -66,7 +76,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-* dont publish private packages ([55c35ce](https://github.com/SUI-Components/sui/commit/55c35ce))
+* **sui-mono:** dont publish private packages ([55c35ce](https://github.com/SUI-Components/sui/commit/55c35ce))
 
 
 
@@ -76,7 +86,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-* sui-mono link command ([db9596a](https://github.com/SUI-Components/sui/commit/db9596a))
+* **sui-mono:** sui-mono link command ([db9596a](https://github.com/SUI-Components/sui/commit/db9596a))
 
 
 
@@ -86,7 +96,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-* fix to use default restrict access type instead private ([6a566a7](https://github.com/SUI-Components/sui/commit/6a566a7))
+* **sui-mono:** fix to use default restrict access type instead private ([6a566a7](https://github.com/SUI-Components/sui/commit/6a566a7))
 
 
 
@@ -96,7 +106,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-* version tag nos set properly ([fc740ff](https://github.com/SUI-Components/sui/commit/fc740ff)), closes [#3c00cec1d5e3138bf2095b70200b9e8d447f0de1](https://github.com/SUI-Components/sui/issues/3c00cec1d5e3138bf2095b70200b9e8d447f0de1)
+* **sui-mono:** version tag nos set properly ([fc740ff](https://github.com/SUI-Components/sui/commit/fc740ff)), closes [#3c00cec1d5e3138bf2095b70200b9e8d447f0de1](https://github.com/SUI-Components/sui/issues/3c00cec1d5e3138bf2095b70200b9e8d447f0de1)
 
 
 
@@ -106,12 +116,12 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-* release version commit is empty ([3c00cec](https://github.com/SUI-Components/sui/commit/3c00cec))
+* **sui-mono:** release version commit is empty ([3c00cec](https://github.com/SUI-Components/sui/commit/3c00cec))
 
 
 ### Features
 
-* migrate commands executions to sui-helpers/cli ([e6341bf](https://github.com/SUI-Components/sui/commit/e6341bf))
+* **sui-mono:** migrate commands executions to sui-helpers/cli ([e6341bf](https://github.com/SUI-Components/sui/commit/e6341bf))
 
 
 
@@ -121,7 +131,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-* change release to avoid race conditions ([cb65029](https://github.com/SUI-Components/sui/commit/cb65029))
+* **sui-mono:** change release to avoid race conditions ([cb65029](https://github.com/SUI-Components/sui/commit/cb65029))
 
 
 
@@ -131,7 +141,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-* add "sui-mono run" for multiple executions ([c14b66c](https://github.com/SUI-Components/sui/commit/c14b66c))
+* **sui-mono:** add "sui-mono run" for multiple executions ([c14b66c](https://github.com/SUI-Components/sui/commit/c14b66c))
 
 
 
@@ -141,7 +151,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-* add config by CLI options ([3bec4ef](https://github.com/SUI-Components/sui/commit/3bec4ef))
+* **sui-mono:** add config by CLI options ([3bec4ef](https://github.com/SUI-Components/sui/commit/3bec4ef))
 
 
 
@@ -151,7 +161,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-* remove unused scripts ([d7dd39b](https://github.com/SUI-Components/sui/commit/d7dd39b))
+* **sui-mono:** remove unused scripts ([d7dd39b](https://github.com/SUI-Components/sui/commit/d7dd39b))
 
 
 
@@ -161,7 +171,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-* remove unused script phoenix ([3b2b249](https://github.com/SUI-Components/sui/commit/3b2b249))
+* **sui-mono:** remove unused script phoenix ([3b2b249](https://github.com/SUI-Components/sui/commit/3b2b249))
 
 
 
@@ -171,7 +181,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-* not throw error on release if build script is absent ([f8d91dc](https://github.com/SUI-Components/sui/commit/f8d91dc))
+* **sui-mono:** not throw error on release if build script is absent ([f8d91dc](https://github.com/SUI-Components/sui/commit/f8d91dc))
 
 
 
@@ -181,7 +191,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-* fix refactor error. packageConfig has no config prop ([d2312a3](https://github.com/SUI-Components/sui/commit/d2312a3))
+* **sui-mono:** fix refactor error. packageConfig has no config prop ([d2312a3](https://github.com/SUI-Components/sui/commit/d2312a3))
 
 
 
@@ -191,15 +201,15 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-* add build script which is mandatory ([8ce1de8](https://github.com/SUI-Components/sui/commit/8ce1de8))
-* move build script to scripts, instead of bin ([baa86d0](https://github.com/SUI-Components/sui/commit/baa86d0))
-* sui-mono/src/types does not work ([2f73f25](https://github.com/SUI-Components/sui/commit/2f73f25))
-* switch use of cz-crm to sui-cz ([9036614](https://github.com/SUI-Components/sui/commit/9036614))
+* **sui-mono:** add build script which is mandatory ([8ce1de8](https://github.com/SUI-Components/sui/commit/8ce1de8))
+* **sui-mono:** move build script to scripts, instead of bin ([baa86d0](https://github.com/SUI-Components/sui/commit/baa86d0))
+* **sui-mono:** sui-mono/src/types does not work ([2f73f25](https://github.com/SUI-Components/sui/commit/2f73f25))
+* **sui-mono:** switch use of cz-crm to sui-cz ([9036614](https://github.com/SUI-Components/sui/commit/9036614))
 
 
 ### Features
 
-* set package name to [@schibstedspain](https://github.com/schibstedspain)/sui-mono ([98255d4](https://github.com/SUI-Components/sui/commit/98255d4))
+* **sui-mono:** set package name to [@schibstedspain](https://github.com/schibstedspain)/sui-mono ([98255d4](https://github.com/SUI-Components/sui/commit/98255d4))
 
 
 

--- a/packages/sui-mono/bin/sui-mono-changelog.js
+++ b/packages/sui-mono/bin/sui-mono-changelog.js
@@ -1,0 +1,72 @@
+/* eslint no-console:0 */
+const program = require('commander')
+const fs = require('fs')
+const path = require('path')
+const conventionalChangelog = require('conventional-changelog')
+const {getScopes, getPackagesFolder, isMonoPackage} = require('../src/config')
+const { getPackagesPaths } = require('@schibstedspain/sui-helpers/packages')
+
+program
+  .usage('<folder1> <folder2> <etc>')
+  .on('--help', () => {
+    console.log('  Description:')
+    console.log('')
+    console.log('    Generates a CHANGELOG.md of the given folders.')
+    console.log('    If no folder is specified, CHANGELOG.md will be generated for all packages.')
+    console.log('')
+    console.log('  Examples:')
+    console.log('')
+    console.log('    $ sui-mono changelog ./packages/sui-bundler')
+    console.log('    $ sui-mono changelog')
+    console.log('')
+  })
+  .parse(process.argv)
+
+const CHANGELOG_NAME = 'CHANGELOG.md'
+const cwd = path.join(process.cwd(), getPackagesFolder())
+const isMulpiPackage = !isMonoPackage()
+const folders = program.args.length ? program.args : getPackagesPaths(cwd)(getScopes())
+const changelogOptions = {
+  preset: 'angular',
+  append: false,
+  transform: function (commit, cb) {
+    if (commit.type === 'release') { // Identifies commits that set a version as tags are not set
+      commit.version = commit.subject.replace('v', '')
+    }
+    if (isMulpiPackage) { // Remove repeated scope for multipackage
+      commit.scope = ''
+    }
+    commit.committerDate = commit.committerDate.substring(0, 10) // simple date format
+    cb(null, commit)
+  }
+}
+
+/**
+ * Generate CHANGELOG.md file for all commits of given folder
+ * @param  {String} folder Path of the folder
+ * @return {Promise<String>} Promise resolve with path of generated file
+ */
+function generateChangelog (folder) {
+  return new Promise((resolve, reject) => {
+    let gitRawCommitsOpts = { path: folder }
+    let outputFile = path.join(folder, CHANGELOG_NAME)
+    let output = fs.createWriteStream(path.join(outputFile))
+    let chunkCount = 0
+    return conventionalChangelog(changelogOptions, {}, gitRawCommitsOpts)
+      .on('data', (chunk) => {
+        if (!chunkCount++) { // First chunk is always an empty release
+          output.write('# Change Log\n\n' +
+            'All notable changes to this project will be documented in this file.\n\n'
+          )
+        } else {
+          output.write(chunk)
+        }
+      })
+      .on('end', () => resolve(outputFile))
+      .on('error', reject)
+  })
+}
+
+Promise.all(folders.map(path => generateChangelog(path)))
+  .then(code => process.exit(0))
+  .catch(code => process.exit(1))

--- a/packages/sui-mono/bin/sui-mono-release.js
+++ b/packages/sui-mono/bin/sui-mono-release.js
@@ -72,6 +72,9 @@ const releaseEachPkg = ({pkg, code} = {}) => {
       ['npm', ['--no-git-tag-version', 'version', `${RELEASE_CODES[code]}`]],
       ['git', ['add', cwd]],
       ['git', ['commit -m "release(' + packageScope + '): v$(node -p -e "require(\'./package.json\')".version)"']],
+      ['sui-mono', ['changelog', cwd]],
+      ['git', ['add', cwd]],
+      ['git', ['commit --amend --no-verify --no-edit']],
       ['git', ['tag -a ' + tagPrefix + '$(node -p -e "require(\'./package.json\')".version) -m \"v$(node -p -e "require(\'./package.json\')".version)\"']], // eslint-disable-line no-useless-escape
       !pkgInfo.private && ['npm', ['publish', `--access=${publishAccess}`]],
       ['git', ['push', '--tags', 'origin', 'HEAD']]

--- a/packages/sui-mono/bin/sui-mono.js
+++ b/packages/sui-mono/bin/sui-mono.js
@@ -18,6 +18,9 @@ program
   .command('check', 'Gives information if something should be updated')
 
 program
+  .command('changelog', 'Generate CHANGELOG.md files')
+
+program
   .command('release', 'Release whatever need to be release')
 
 program

--- a/packages/sui-mono/package.json
+++ b/packages/sui-mono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schibstedspain/sui-mono",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "Commit and release manager",
   "main": "index.js",
   "bin": {

--- a/packages/sui-mono/package.json
+++ b/packages/sui-mono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schibstedspain/sui-mono",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Commit and release manager",
   "main": "index.js",
   "bin": {

--- a/packages/sui-mono/src/config.js
+++ b/packages/sui-mono/src/config.js
@@ -42,9 +42,8 @@ module.exports = {
   },
   isMonoPackage: function () {
     const folders = cwds(path.join(basePath, packagesFolder), deepLevel)
-    const foldersWithPackageConfig = folders.filter(getPackageConfig)
-
-    return folders.length > foldersWithPackageConfig.length
+    const pkgFolders = folders.filter(getPackageConfig)
+    return !pkgFolders.length
   }
 }
 

--- a/packages/sui-perf/CHANGELOG.md
+++ b/packages/sui-perf/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+<a name="1.2.0"></a>
+# 1.2.0 (2017-07-25)
+
+
+### Features
+
+* add minPercent option on charts to filter minor data ([4a258bb](https://github.com/SUI-Components/sui/commit/4a258bb))
+* add React components mount measurement ([2b93cd7](https://github.com/SUI-Components/sui/commit/2b93cd7))
+
+
+
+<a name="1.1.0"></a>
+# 1.1.0 (2017-07-13)
+
+
+### Features
+
+* new service for performance logging ([2df910c](https://github.com/SUI-Components/sui/commit/2df910c))
+
+
+

--- a/packages/sui-polyfills/CHANGELOG.md
+++ b/packages/sui-polyfills/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+<a name="1.2.0"></a>
+# 1.2.0 (2017-07-26)
+
+
+### Bug Fixes
+
+* add module.exports ([944e204](https://github.com/SUI-Components/sui/commit/944e204))
+
+
+
+<a name="1.1.0"></a>
+# 1.1.0 (2017-07-19)
+
+
+### Features
+
+* create sui-polyfills to be reused on all our projects ([df2086e](https://github.com/SUI-Components/sui/commit/df2086e))
+
+
+

--- a/packages/sui-precommit/CHANGELOG.md
+++ b/packages/sui-precommit/CHANGELOG.md
@@ -1,0 +1,60 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+<a name="2.2.0"></a>
+# 2.2.0 (2017-06-27)
+
+
+### Features
+
+* commit to force release ([efee2b1](https://github.com/SUI-Components/sui/commit/efee2b1))
+
+
+
+<a name="2.1.0"></a>
+# 2.1.0 (2017-06-21)
+
+
+### Bug Fixes
+
+* remove unused scripts ([e8e1d39](https://github.com/SUI-Components/sui/commit/e8e1d39))
+
+
+
+<a name="2.0.0"></a>
+# 2.0.0 (2017-06-21)
+
+
+### Bug Fixes
+
+* fix install execution for windows ([8a38405](https://github.com/SUI-Components/sui/commit/8a38405))
+
+
+### Features
+
+* transform sui-precommit to a simple CLI service ([65be335](https://github.com/SUI-Components/sui/commit/65be335))
+
+
+### BREAKING CHANGES
+
+* API has changed... now it's sui-lint instead of linting-rules
+
+
+
+<a name="1.1.0"></a>
+# 1.1.0 (2017-06-16)
+
+
+### Bug Fixes
+
+* add build script to be compatible with sui-mono releases ([0cd7d4b](https://github.com/SUI-Components/sui/commit/0cd7d4b))
+
+
+### Features
+
+* first commit of frontend-commit-rules migration to sui-precommit ([6f77134](https://github.com/SUI-Components/sui/commit/6f77134))
+* rename package to [@schibstedspain](https://github.com/schibstedspain)/sui-precommit ([b9a0a1d](https://github.com/SUI-Components/sui/commit/b9a0a1d))
+
+
+

--- a/packages/sui-react-domain-connector/CHANGELOG.md
+++ b/packages/sui-react-domain-connector/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+<a name="1.1.0"></a>
+# 1.1.0 (2017-08-02)
+
+
+### Features
+
+* 🌈 Migrate package ([a02f295](https://github.com/SUI-Components/sui/commit/a02f295))
+
+
+
+<a name="1.1.0"></a>
+# 1.1.0 (2017-08-02)
+
+
+### Features
+
+* add package.json ([541f16d](https://github.com/SUI-Components/sui/commit/541f16d))
+
+
+

--- a/packages/sui-react-initial-props/CHANGELOG.md
+++ b/packages/sui-react-initial-props/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+<a name="1.2.0"></a>
+# 1.2.0 (2017-08-09)
+
+
+### Bug Fixes
+
+* add missing main on package.json ([d5abe46](https://github.com/SUI-Components/sui/commit/d5abe46))
+
+
+
+<a name="1.1.0"></a>
+# 1.1.0 (2017-08-09)
+
+
+### Bug Fixes
+
+* use new syntax as a HoC and add README ([1754b78](https://github.com/SUI-Components/sui/commit/1754b78))
+
+
+### Features
+
+* add some useful params and improve readability ([1e0d658](https://github.com/SUI-Components/sui/commit/1e0d658))
+* create sui-react-initial-props first version ([1201321](https://github.com/SUI-Components/sui/commit/1201321))
+* redefine the HoC and add missing dependency ([8ec10d7](https://github.com/SUI-Components/sui/commit/8ec10d7))
+
+
+

--- a/packages/sui-ssr/CHANGELOG.md
+++ b/packages/sui-ssr/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+<a name="1.1.0"></a>
+# 1.1.0 (2017-08-02)
+
+
+### Features
+
+* add package.json ([d1495ce](https://github.com/SUI-Components/sui/commit/d1495ce))
+
+
+

--- a/packages/sui-studio-create/CHANGELOG.md
+++ b/packages/sui-studio-create/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+<a name="4.5.0"></a>
+# 4.5.0 (2017-08-17)
+
+
+### Features
+
+* perform npm install after creating studio ([11024bd](https://github.com/SUI-Components/sui/commit/11024bd))
+
+
+
+<a name="4.4.0"></a>
+# 4.4.0 (2017-07-20)
+
+
+### Bug Fixes
+
+* wrong package.json generation ([5bebaff](https://github.com/SUI-Components/sui/commit/5bebaff))
+
+
+
+<a name="4.3.0"></a>
+# 4.3.0 (2017-07-13)
+
+
+### Bug Fixes
+
+* improve phoenix scripts for generated pacakge.json ([dfd35e6](https://github.com/SUI-Components/sui/commit/dfd35e6))
+* wrong package.json generation ([16b7269](https://github.com/SUI-Components/sui/commit/16b7269))
+
+
+
+<a name="4.1.0"></a>
+# 4.1.0 (2017-06-25)
+
+
+### Features
+
+* add updated sui-studio-create behavior ([ec6677f](https://github.com/SUI-Components/sui/commit/ec6677f))
+
+
+

--- a/packages/sui-studio/CHANGELOG.md
+++ b/packages/sui-studio/CHANGELOG.md
@@ -1,0 +1,148 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+<a name="4.15.0"></a>
+# 4.15.0 (2017-08-09)
+
+
+### Features
+
+* using V2 of the sui-bundler ([c18bb16](https://github.com/SUI-Components/sui/commit/c18bb16))
+
+
+
+<a name="4.14.0"></a>
+# 4.14.0 (2017-08-04)
+
+
+### Bug Fixes
+
+* disabling on the fly loaded style ([acf766a](https://github.com/SUI-Components/sui/commit/acf766a))
+* easier disabling, link update ([ada8bc6](https://github.com/SUI-Components/sui/commit/ada8bc6))
+* search for component.js just in case ([8b2b78e](https://github.com/SUI-Components/sui/commit/8b2b78e))
+
+
+### Features
+
+* pass domain to playground ([3844647](https://github.com/SUI-Components/sui/commit/3844647))
+
+
+
+<a name="4.12.0"></a>
+# 4.12.0 (2017-07-24)
+
+
+### Bug Fixes
+
+* update elements z-index ([6a2b16e](https://github.com/SUI-Components/sui/commit/6a2b16e))
+
+
+### Features
+
+* perform a npm install after generating a component and check it doesn't already ex ([1dce5ae](https://github.com/SUI-Components/sui/commit/1dce5ae))
+* update fse-extra dependency with Promise support ([d38a4ef](https://github.com/SUI-Components/sui/commit/d38a4ef))
+
+
+
+<a name="4.11.0"></a>
+# 4.11.0 (2017-07-17)
+
+
+### Bug Fixes
+
+* fix linter error unnecesary escape character ([ae6e1af](https://github.com/SUI-Components/sui/commit/ae6e1af))
+
+
+
+<a name="4.10.0"></a>
+# 4.10.0 (2017-07-13)
+
+
+### Features
+
+* less noise on the console by correctly collapsing messages for styles ([7455dfd](https://github.com/SUI-Components/sui/commit/7455dfd))
+* show a warning when developer is not adding a context.js but using context in a co ([490c6de](https://github.com/SUI-Components/sui/commit/490c6de))
+
+
+
+<a name="4.8.0"></a>
+# 4.8.0 (2017-07-13)
+
+
+### Features
+
+* log demo errors on console too ([f1e1d3d](https://github.com/SUI-Components/sui/commit/f1e1d3d))
+
+
+
+<a name="4.8.0"></a>
+# 4.8.0 (2017-07-04)
+
+
+### Bug Fixes
+
+* don't deprecate link command, only mention link-all ([13840f9](https://github.com/SUI-Components/sui/commit/13840f9))
+
+
+### Features
+
+* command: sui-studio run-all ([cbff577](https://github.com/SUI-Components/sui/commit/cbff577))
+
+
+
+<a name="4.6.0"></a>
+# 4.6.0 (2017-06-29)
+
+
+### Features
+
+* update from origin repo ([62f5ff1](https://github.com/SUI-Components/sui/commit/62f5ff1))
+
+
+
+<a name="4.5.0"></a>
+# 4.5.0 (2017-06-29)
+
+
+### Bug Fixes
+
+* take config from config:sui-studio instead of config:suistudio ([26476d9](https://github.com/SUI-Components/sui/commit/26476d9))
+* update generate ([1041659](https://github.com/SUI-Components/sui/commit/1041659))
+
+
+### Features
+
+* migrate to sui-bundler ([1abc9a3](https://github.com/SUI-Components/sui/commit/1abc9a3))
+* update from origin repo ([5b5f1be](https://github.com/SUI-Components/sui/commit/5b5f1be))
+
+
+
+<a name="4.2.0"></a>
+# 4.2.0 (2017-06-27)
+
+
+### Features
+
+* add peer dependencies to sui-studio ([907f846](https://github.com/SUI-Components/sui/commit/907f846))
+
+
+
+<a name="4.1.0"></a>
+# 4.1.0 (2017-06-25)
+
+
+### Bug Fixes
+
+* fix run-all for complex commands ([848da14](https://github.com/SUI-Components/sui/commit/848da14))
+* fix sui-mono levels to 2 for category/component pattern ([751d4b2](https://github.com/SUI-Components/sui/commit/751d4b2))
+* make sui-studio local package ([7af7c90](https://github.com/SUI-Components/sui/commit/7af7c90))
+* remove unsued npm co script ([e63ab7e](https://github.com/SUI-Components/sui/commit/e63ab7e))
+
+
+### Features
+
+* add commit command to sui-studio ([d5839b8](https://github.com/SUI-Components/sui/commit/d5839b8))
+
+
+

--- a/packages/sui-studio/package.json
+++ b/packages/sui-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schibstedspain/sui-studio",
-  "version": "4.15.0",
+  "version": "4.16.0",
   "description": "Develop, maintain and publish your SUI components.",
   "main": "index.js",
   "bin": {

--- a/packages/sui-studio/src/components/documentation/Markdown.js
+++ b/packages/sui-studio/src/components/documentation/Markdown.js
@@ -5,24 +5,28 @@ import tryRequire from './try-require'
 
 export default class Markdown extends Component {
   propTypes = {
-    params: PropTypes.object
+    params: PropTypes.object,
+    file: PropTypes.string
   }
 
   state = {
-    readme: false
+    content: false
   }
 
   componentDidMount () {
-    tryRequire(this.props.params).then(([_, readme]) => this.setState({readme}))
+    const {file} = this.props
+    tryRequire(this.props.params).then(([_, readme, changelog]) => {
+      this.setState({content: file === 'CHANGELOG' ? changelog : readme})
+    })
   }
 
   render () {
-    const { readme } = this.state
+    const { content } = this.state
     return (
-      readme &&
+      content &&
         <ReactMarkdown
           className='sui-StudioMarkdown-body markdown-body'
-          source={readme}
+          source={content}
         />
     )
   }

--- a/packages/sui-studio/src/components/workbench/index.js
+++ b/packages/sui-studio/src/components/workbench/index.js
@@ -22,6 +22,7 @@ export default class Workbench extends Component {
             <Tab name='Demo' path='demo' />
             <Tab name='Api' path='documentation/api' />
             <Tab name='Readme' path='documentation/readme' />
+            <Tab name='Changelog' path='documentation/changelog' />
             { /* TODO: https://github.com/SUI-Components/SUIStudio/issues/51 <Tab name='Tests' path='tests' /> */ }
           </ul>
         </nav>

--- a/packages/sui-studio/src/routes.js
+++ b/packages/sui-studio/src/routes.js
@@ -17,7 +17,8 @@ export default (
         <Route path='demo' component={Demo} />
         <Route path='documentation' component={Documentation}>
           <Route path='api' component={ReactDocGen} />
-          <Route path='readme' component={Markdown} />
+          <Route path='readme' component={(props) => <Markdown {...props} file='README' />} />
+          <Route path='changelog' component={(props) => <Markdown {...props} file='CHANGELOG' />} />
         </Route>
         <Route path='tests' component={Tests} />
       </Route>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
New command to generate CHANGELOG for monorepos (mono and multipackages)

- [x] Add command to generate changelog
- [x] Make the changelog to autoamtically update on every release
- [x] Add the tab on sui-studio, as required by #27 

## Related Issue
#27 

## More info


@SUI-Components/developers please review !
