### PR TITLE
fix(sui-bundler): fix json files not loading in sass imports

### DIFF
--- a/packages/sui-bundler/plugins/loader-options.js
+++ b/packages/sui-bundler/plugins/loader-options.js
@@ -1,0 +1,30 @@
+/**
+ * Simple plugin that guarantees loaders to be loaded with the given options
+ * in any context.
+ * This fixes a bug of webpack that was loading files outside of context with
+ * the given loaders, but not their options.
+ *
+ * @param {Object} [options={}] key = loader name, value = loader options
+ */
+function LoaderUniversalOptionsPlugin (options = {}) {
+  this.loaderOptions = options
+}
+
+LoaderUniversalOptionsPlugin.prototype.apply = function (compiler, compilation) {
+  var options = this.loaderOptions
+  compiler.plugin('compilation', (compilation) => {
+    compilation.plugin('normal-module-loader', (loaderContext, module) => {
+      for (let idx in module.loaders) {
+        let obj = module.loaders[idx]
+        for (let pkg in options) {
+          if (obj.loader.includes(`/${pkg}/`)) {
+            obj.options = options[pkg]
+            break
+          }
+        }
+      }
+    })
+  })
+}
+
+module.exports = LoaderUniversalOptionsPlugin

--- a/packages/sui-bundler/shared/loader-options.js
+++ b/packages/sui-bundler/shared/loader-options.js
@@ -1,0 +1,13 @@
+// Contains loaders options to avoid duplication between
+// webpack prod and dev configs
+
+const jsonImporter = require('node-sass-json-importer')
+
+module.exports = {
+  'sass-loader': {
+    importer: jsonImporter
+  },
+  'postcss-loader': {
+    plugins: (loader) => [require('autoprefixer')()]
+  }
+}

--- a/packages/sui-bundler/webpack.config.dev.js
+++ b/packages/sui-bundler/webpack.config.dev.js
@@ -1,12 +1,13 @@
 const webpack = require('webpack')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
-const jsonImporter = require('node-sass-json-importer')
+const LoaderUniversalOptionsPlugin = require('./plugins/loader-options')
 const path = require('path')
 
 require('./shared/shims')
+
 const {envVars, MAIN_ENTRY_POINT, config, whenInstalled, cleanList} = require('./shared')
 
-module.exports = {
+let webpackConfig = {
   context: path.resolve(process.cwd(), 'src'),
   resolve: {
     extensions: ['*', '.js', '.jsx', '.json']
@@ -41,12 +42,10 @@ module.exports = {
       debug: true,
       noInfo: true,
       options: {
-        sassLoader: {
-          importer: jsonImporter
-        },
         context: '/'
       }
-    })
+    }),
+    new LoaderUniversalOptionsPlugin(require('./shared/loader-options'))
   ],
   module: {
     rules: [
@@ -86,14 +85,12 @@ module.exports = {
         use: [
           'style-loader',
           'css-loader',
-          {
-            loader: 'postcss-loader',
-            options: {
-              plugins: (loader) => [require('autoprefixer')()]
-            }
-          },
+          'postcss-loader',
           'sass-loader'
-        ]}
+        ]
+      }
     ]
   }
 }
+
+module.exports = webpackConfig

--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -2,11 +2,11 @@
 const webpack = require('webpack')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
+const LoaderUniversalOptionsPlugin = require('./plugins/loader-options')
 const PreloadWebpackPlugin = require('preload-webpack-plugin')
 const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin')
 const ManifestPlugin = require('webpack-manifest-plugin')
 const SWPrecacheWebpackPlugin = require('sw-precache-webpack-plugin')
-const jsonImporter = require('node-sass-json-importer')
 const Externals = require('./plugins/externals')
 const path = require('path')
 
@@ -124,12 +124,10 @@ module.exports = {
       debug: false,
       noInfo: true,
       options: {
-        sassLoader: {
-          importer: jsonImporter
-        },
         context: '/'
       }
-    })
+    }),
+    new LoaderUniversalOptionsPlugin(require('./shared/loader-options'))
   ]),
   module: {
     rules: [
@@ -169,12 +167,7 @@ module.exports = {
         test: /(\.css|\.scss)$/,
         use: ExtractTextPlugin.extract([
           'css-loader',
-          {
-            loader: 'postcss-loader',
-            options: {
-              plugins: (loader) => [require('autoprefixer')()]
-            }
-          },
+          'postcss-loader',
           'sass-loader'
         ])
       }


### PR DESCRIPTION
## Description
Webpack was loading sass-loader without its options (jsonImporter) for files outside of the context: sui-studio/src.
Created a plugin that ensure loader are instantiated with the same options in all

@naxhh @kikoruiz @miduga please review