### PR TITLE
[sui-studio] Improve documentation with Shape props types

### DIFF
--- a/packages/sui-studio/package.json
+++ b/packages/sui-studio/package.json
@@ -47,8 +47,9 @@
     "pmx": "0.6.2",
     "react-codemirror": "0.2.6",
     "react-docgen": "2.9.1",
-    "react-markdown": "2.3.0",
-    "react-test-renderer": "15.3.2"
+    "react-render-html": "0.5.0",
+    "react-test-renderer": "15.3.2",
+    "showdown": "1.7.3"
   },
   "suistudio-webpack": {
     "vendor": [

--- a/packages/sui-studio/package.json
+++ b/packages/sui-studio/package.json
@@ -47,6 +47,7 @@
     "pmx": "0.6.2",
     "react-codemirror": "0.2.6",
     "react-docgen": "2.9.1",
+    "react-docs-markdown": "0.3.4",
     "react-render-html": "0.5.0",
     "react-test-renderer": "15.3.2",
     "showdown": "1.7.3"

--- a/packages/sui-studio/src/components/documentation/Markdown.js
+++ b/packages/sui-studio/src/components/documentation/Markdown.js
@@ -1,33 +1,24 @@
 import React, {Component, PropTypes} from 'react'
-import ReactMarkdown from 'react-markdown'
+import showdown from 'showdown'
+import renderHTML from 'react-render-html'
 
-import tryRequire from './try-require'
+const converter = new showdown.Converter()
+converter.setOption('tables', true)
+converter.setOption('simpleLineBreaks', true)
+converter.setOption('ghCompatibleHeaderId', true)
+converter.setFlavor('github')
 
 export default class Markdown extends Component {
   propTypes = {
-    params: PropTypes.object,
-    file: PropTypes.string
-  }
-
-  state = {
-    content: false
-  }
-
-  componentDidMount () {
-    const {file} = this.props
-    tryRequire(this.props.params).then(([_, readme, changelog]) => {
-      this.setState({content: file === 'CHANGELOG' ? changelog : readme})
-    })
+    content: PropTypes.string
   }
 
   render () {
-    const { content } = this.state
-    return (
-      content &&
-        <ReactMarkdown
-          className='sui-StudioMarkdown-body markdown-body'
-          source={content}
-        />
+    const {content} = this.props
+    return (content &&
+      <div className='markdown-body'>
+        {renderHTML(converter.makeHtml(content))}
+      </div>
     )
   }
 }

--- a/packages/sui-studio/src/components/documentation/MarkdownFile.js
+++ b/packages/sui-studio/src/components/documentation/MarkdownFile.js
@@ -1,0 +1,28 @@
+import React, {Component, PropTypes} from 'react'
+import Markdown from './Markdown'
+import tryRequire from './try-require'
+
+export default class MarkdownFile extends Component {
+  propTypes = {
+    params: PropTypes.object,
+    file: PropTypes.string
+  }
+
+  state = {
+    content: false
+  }
+
+  componentDidMount () {
+    const {file} = this.props
+    tryRequire(this.props.params).then(([_, readme, changelog]) => {
+      this.setState({content: file === 'CHANGELOG' ? changelog : readme})
+    })
+  }
+
+  render () {
+    const { content } = this.state
+    return (content && <Markdown content={content} />)
+  }
+}
+
+MarkdownFile.displayName = 'MarkdownFile'

--- a/packages/sui-studio/src/components/documentation/ReactDocGen.js
+++ b/packages/sui-studio/src/components/documentation/ReactDocGen.js
@@ -1,104 +1,8 @@
 import React, { Component, PropTypes } from 'react'
-
 import tryRequire from './try-require'
-
+import docsToMarkdown from 'react-docs-markdown'
 const reactDocs = require('react-docgen')
-const Params = ({params}) => {
-  return (
-    <div className='sui-StudioMethods-param'>
-      {
-        params.map(
-          (param, index) => {
-            const type = param.type ? `[${param.type ? param.type.name : ''}]` : ''
-            return (
-              <p
-                className='sui-StudioMethods-paramName'
-                key={index}>
-                {`${param.name} ${type}: ${param.description}`}
-              </p>
-            )
-          }
-        )
-      }
-    </div>
-  )
-}
-
-Params.propTypes = {params: PropTypes.array}
-
-const Methods = ({methods}) => {
-  if (methods.length === 0) return null
-
-  return (
-    <div className='sui-StudioMethods'>
-      <h3>Methods</h3>
-      {
-        methods.map((method, index) => (
-          <div key={index} className='sui-StudioMethods-method'>
-            <p className='sui-StudioMethods-methodName'>{`${method.name}: ${method.description || 'Missing description'}`}</p>
-            <p className='sui-StudioMethods-methodParams'>Params</p>
-            <Params params={method.params} />
-            {
-              method.description
-                ? <p className='sui-StudioMethods-methodReturns'>{`Return: ${method.description}`}</p>
-                : null
-            }
-          </div>
-        ))
-      }
-    </div>
-  )
-}
-
-Methods.displayName = 'Methods'
-Methods.propTypes = {methods: PropTypes.array}
-
-const Props = ({props = {}}) => {
-  return (
-    <div className='sui-StudioProps'>
-      <h3>Props</h3>
-      <table className='sui-StudioProps-table'>
-        <tbody>
-          <tr className='sui-StudioProps-head'>
-            <td>Name</td>
-            <td>Type</td>
-            <td>Default</td>
-            <td>Description</td>
-          </tr>
-          {
-            Object
-              .keys(props)
-              .sort()
-              .map((key, index) => {
-                const prop = props[key]
-                const required = prop.required
-                                  ? <span className='sui-StudioProps-required'>* required</span>
-                                  : undefined
-
-                const description = prop.description || ''
-                const type = prop.type ? prop.type.name : ''
-                const defaultValue = prop.defaultValue ? prop.defaultValue.value : ''
-
-                return (
-                  <tr
-                    className='sui-StudioProps-property'
-                    key={index}>
-                    <td>{key} {required}</td>
-                    <td className='sui-StudioProps-type'>{type}</td>
-                    <td>{defaultValue}</td>
-                    <td>{description}</td>
-                  </tr>
-                )
-              }
-            )
-          }
-        </tbody>
-      </table>
-    </div>
-  )
-}
-Props.displayName = 'Props'
-Props.propTypes = {props: PropTypes.object}
+import Markdown from './Markdown'
 
 class ReactDocGen extends Component {
   static propTypes = {
@@ -116,19 +20,13 @@ class ReactDocGen extends Component {
 
   render () {
     const {parsed} = this.state
-    return parsed && (
-      <div className='sui-StudioReactDocGen'>
-        <p className='sui-StudioReactDocGen-description'>
-          {parsed.description || ''}
-        </p>
-        <div className='sui-StudioReactDocGen-methodsContainer'>
-          <Methods methods={parsed.methods} />
-        </div>
-        <div className='sui-StudioReactDocGen-propsContainer'>
-          <Props props={parsed.props} />
-        </div>
-      </div>
-    )
+    let markdown = null
+    if (parsed) {
+      const {params: {category, component}} = this.props
+      const componentTitle = `${parsed.displayName} (${category}/${component})`
+      markdown = docsToMarkdown(parsed, componentTitle)
+    }
+    return (markdown && <Markdown content={markdown} />)
   }
 }
 

--- a/packages/sui-studio/src/components/layout/index.js
+++ b/packages/sui-studio/src/components/layout/index.js
@@ -1,6 +1,6 @@
 /* global __BASE_DIR__ */
 import React, {Component, PropTypes} from 'react'
-import ReactMarkdown from 'react-markdown'
+import Markdown from '../documentation/Markdown'
 import cx from 'classnames'
 
 import { iconClose, iconMenu } from '../icons'
@@ -26,7 +26,7 @@ export default class Layout extends Component {
   _renderReadme () {
     return (
       <div className='sui-Studio-readme'>
-        <ReactMarkdown source={readme} />
+        <Markdown content={readme} />
       </div>
     )
   }

--- a/packages/sui-studio/src/routes.js
+++ b/packages/sui-studio/src/routes.js
@@ -7,7 +7,7 @@ import Demo from './components/demo'
 import Tests from './components/tests'
 import Documentation from './components/documentation'
 import ReactDocGen from './components/documentation/ReactDocGen'
-import Markdown from './components/documentation/Markdown'
+import MarkdownFile from './components/documentation/MarkdownFile'
 
 export default (
   <Route>
@@ -17,8 +17,8 @@ export default (
         <Route path='demo' component={Demo} />
         <Route path='documentation' component={Documentation}>
           <Route path='api' component={ReactDocGen} />
-          <Route path='readme' component={(props) => <Markdown {...props} file='README' />} />
-          <Route path='changelog' component={(props) => <Markdown {...props} file='CHANGELOG' />} />
+          <Route path='readme' component={(props) => <MarkdownFile {...props} file='README' />} />
+          <Route path='changelog' component={(props) => <MarkdownFile {...props} file='CHANGELOG' />} />
         </Route>
         <Route path='tests' component={Tests} />
       </Route>


### PR DESCRIPTION
## Description
Shape props are now detailed, subprop by subprop.
Now react-docs output is not rendered by sui-studio itsefl but by react-docs-markdown
Thanks to react-docs-markdown, we also have other improvements like for oneOf props. 

## Related Issue
#29

@SUI-Components/developers please review
