### PR TITLE
fix(sui-mono): fix: release not detected with overlapped commits

### DIFF
--- a/packages/sui-mono/src/check.js
+++ b/packages/sui-mono/src/check.js
@@ -2,6 +2,7 @@
 
 const conventionalChangelog = require('conventional-changelog')
 const config = require('./config')
+const gitRawCommitsOpts = {reverse: true, topoOrder: true}
 
 const isCommitBreakingChange = (commit) => {
   return (typeof commit.footer === 'string' &&
@@ -64,7 +65,7 @@ const check = () =>
         }
         cb()
       }
-    }, {}, {reverse: true}).on('end', () => {
+    }, {}, gitRawCommitsOpts).on('end', () => {
       resolve(flattenForMonopackage(status))
     }).resume()
   })


### PR DESCRIPTION
## Description
Order was change: https://git-scm.com/docs/git-log#git-log---topo-order

## Related Issue
#100

@naxhh and @miduga please review