### PR TITLE
[sui-mono] new command sui-mono run-parallel

### DIFF
--- a/packages/sui-mono/README.md
+++ b/packages/sui-mono/README.md
@@ -18,7 +18,7 @@ It provides:
 
 ### Run command on all packages
 
-You can run a single command on each package of the monorepo
+You can run a single command on each package of the monorepo, **in series**
 
 ```
 $ sui-mono run <command>
@@ -26,6 +26,13 @@ $ sui-mono run rm -Rf node_modules
 $ sui-mono run npm install
 ```
 
+You can also run them **in parallel**
+
+```
+$ sui-mono run-parallel <command>
+$ sui-mono run-parallel rm -Rf node_modules
+$ sui-mono run-parallel npm install
+```
 
 ### Link
 

--- a/packages/sui-mono/bin/sui-mono-run-parallel.js
+++ b/packages/sui-mono/bin/sui-mono-run-parallel.js
@@ -2,23 +2,23 @@
 /* eslint no-console:0 */
 const program = require('commander')
 const {getAllTaskArrays} = require('../src/run')
-const {serialSpawn} = require('@schibstedspain/sui-helpers/cli')
+const {parallelSpawn} = require('@schibstedspain/sui-helpers/cli')
 
 program
   .on('--help', () => {
     console.log('  Description:')
     console.log('')
     console.log('    Runs the given command on all the packages')
-    console.log('    Commands are run in series, preserving output stream')
+    console.log('    Commands are run in parallel, with colorless output')
     console.log('')
     console.log('  Examples:')
     console.log('')
-    console.log('    $ sui-mono run npm i')
-    console.log('    $ sui-mono run --help')
+    console.log('    $ sui-mono run-parallel npm i')
+    console.log('    $ sui-mono run-parallel --help')
     console.log('')
   })
   .parse(process.argv)
 
-serialSpawn(getAllTaskArrays())
+parallelSpawn(getAllTaskArrays())
   .then(code => process.exit(code))
   .catch(code => process.exit(code))

--- a/packages/sui-mono/bin/sui-mono.js
+++ b/packages/sui-mono/bin/sui-mono.js
@@ -24,6 +24,9 @@ program
   .command('release', 'Release whatever need to be release')
 
 program
-  .command('run', 'Run a command on each package')
+  .command('run', 'Run a command on each package, in series')
+
+program
+  .command('run-parallel', 'Run a command on each package, in parallel')
 
 program.parse(process.argv)

--- a/packages/sui-mono/src/run.js
+++ b/packages/sui-mono/src/run.js
@@ -1,0 +1,26 @@
+const path = require('path')
+const program = require('commander')
+const config = require('../src/config')
+const PACKAGES_DIR = path.join(process.cwd(), config.getPackagesFolder())
+
+/**
+ * Get array of commands to execute on all folders
+ * @return {Array<Array>}
+ */
+function getAllTaskArrays () {
+  const cwds = config.getScopes().map(pkg => path.join(PACKAGES_DIR, pkg))
+  return cwds.map(getTaskArray)
+}
+
+/**
+ * Get array of command for given folder
+ * @param  {String} folder
+ * @return {Array<Array>}
+ */
+function getTaskArray (folder) {
+  const [command] = program.args
+  const args = process.argv.slice(process.argv.indexOf(command) + 1)
+  return [command, args, {cwd: folder}]
+}
+
+module.exports = { getAllTaskArrays }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
New command to improve productivity, mainly when resetting a projects with "run phoenix"

The command was tested  on sui-components
`sui-mono run npm i`: 171s
`sui-mono run-parallel npm i`:  52s


## Additional info
A new command was created as it was difficult to do something like `npm run --parallel npm i`. In this case, `process.argv` was changing the order of the arguments like this : npm, run, i, npm.

Let me know if you know a better way.

Please review @carlosvillu @miduga