### PR TITLE
feat(sui-perf): add support to measure axios' requests

### DIFF
--- a/packages/sui-perf/README.md
+++ b/packages/sui-perf/README.md
@@ -183,6 +183,25 @@ console.log(perf.getEntries())
 clearMeasureReact()
 ```
 
+#### measureAxios(perf)(axios)
+Measure all axios requests.
+
+```js
+import axios from 'axios'
+import getPerf from '@schibstedspain/sui-perf'
+import measureAxios from '@schibstedspain/sui-perf/lib/measure-axios'
+
+/* ... */
+
+const axiosInstance = axios.create()
+const perf = getPerf('my-request-unique-id')
+const clearMeasureAxios = measureAxios(perf)(axiosInstance)
+
+/* ... */
+console.log(perf.getEntries())
+clearMeasureAxios()
+```
+
 ## Contributing
 
 Please refer to the [main repo contributing info](https://github.com/SUI-Components/sui/blob/master/CONTRIBUTING.md).

--- a/packages/sui-perf/src/measure-axios.js
+++ b/packages/sui-perf/src/measure-axios.js
@@ -1,0 +1,36 @@
+let requestCount = 0
+
+/**
+ * Return a unique label for given axios request
+ * @param  {Object} config Axios request config
+ * @param  {Object} config.method
+ * @param  {Object} config.url
+ * @return {String}
+ */
+const getRequestLabel = ({ method, url }) => {
+  return `🌎  ${method.toUpperCase()} /${url} #${++requestCount}`
+}
+
+/**
+ *
+ * Params are curried
+ * @param  {Object} perf Instance of performance marker
+ * @param  {Function} perf.mark
+ * @param  {Function} perf.stop
+ * @param  {Object} axios Instance of axios
+ * @return {Function} Function to unregister performance hooks
+ */
+const measureAxios = (perf) => (axios) => {
+  const interceptor = axios.interceptors.request.use((config) => {
+    const axiosRequestId = getRequestLabel(config)
+    perf.mark(axiosRequestId)
+    config.transformResponse.axiosPerformanceTransform = (data, headers) => {
+      perf.stop(axiosRequestId)
+      return data
+    }
+    return config
+  })
+  return () => axios.interceptors.request.eject(interceptor)
+}
+
+export default measureAxios


### PR DESCRIPTION
## Description
This is one part of a 3 PRs that solves [this issue](https://github.com/SUI-Components/sui/issues/79) :
* Add support to measure axios' requests ([sui](https://github.com/SUI-Components/sui/pull/111))
* Add request id to the domain on SSR ([mt--web-app](https://github.schibsted.io/scmspain/frontend-mt--web-app/pull/126))
* Add (commented) support for axios measurement ([mt--lib-motor](https://github.schibsted.io/scmspain/frontend-mt--lib-motor/pull/150))

## Additional notes
Testing this feature on mt--web-app with 3 simultaneous request and cache deactivated for news, we get the following:

```
timeline        start  time   %    label
███████████████ 0ms    4811ms 100% Request
 █              399ms  272ms  6%   CreateContext
  ████          672ms  1363ms 28%  UseCases
   ███          1101ms 934ms  19%  🌎  GET /https://ms-mt--api-web.spain.schibsted.io/advertisement-configuration #1
          ███   3236ms 979ms  20%  🌎  GET /https://ms-mt--api-web.spain.schibsted.io/news/home #2
          ███   3236ms 897ms  19%  🌎  GET /https://ms-mt--api-web.spain.schibsted.io/ads/home/ #5
          ████  3245ms 1345ms 28%  🌎  GET /https://ms-mt--api-web.spain.schibsted.io/tagcloud-groups #6
timeline        start  time   %    label
███████████████ 0ms    3203ms 100% Request
⸠               1ms    1ms    0%   CreateContext
████████        2ms    1613ms 50%  UseCases
        ████    1623ms 869ms  27%  🌎  GET /https://ms-mt--api-web.spain.schibsted.io/news/home #3
timeline        start  time   %    label
███████████████ 0ms    3317ms 100% Request
⸠               1ms    1ms    0%   CreateContext
███████         2ms    1611ms 49%  UseCases
       ███████  1619ms 1588ms 48%  🌎  GET /https://ms-mt--api-web.spain.schibsted.io/news/home #4
```

ISSUES CLOSED: #79

Please review @carlosvillu @miduga