### PR TITLE
fix(sui-studio): enforce displayName for all components

### DIFF
--- a/packages/sui-studio/src/components/demo/index.js
+++ b/packages/sui-studio/src/components/demo/index.js
@@ -119,6 +119,8 @@ export default class Demo extends Component {
       withProvider(hasProvider, store)
     )(Base)
 
+    !Enhance.displayName && console.error(new Error('Component.displayName must be defined.'))
+    
     return (
       <div className='sui-StudioDemo'>
         <Style>{style}</Style>
@@ -146,7 +148,7 @@ export default class Demo extends Component {
 
         <Preview
           code={playground}
-          scope={{React, [`${cleanDisplayName(Enhance.displayName || Enhance.name)}`]: Enhance, domain}}
+          scope={{React, [`${cleanDisplayName(Enhance.displayName)}`]: Enhance, domain}}
         />
       </div>
     )


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
If displayName is not set, the demo doesn't work in prod, like happened here: https://github.com/SUI-Components/sui-components/pull/152

@SUI-Components/developers please review