### PR TITLE
Migrate to s-ui npm org

### DIFF
--- a/.github/README_TEMPLATE.md
+++ b/.github/README_TEMPLATE.md
@@ -24,7 +24,7 @@ _For more examples and usage, please refer to the [Wiki][wiki]._
 ## Installation
 
 ```sh
-npm install @schibstedspain/my-package --save
+npm install @s-ui/my-package --save
 ```
 
 ## API Reference

--- a/.wiki/How-to-migrate-to-sui-studio-v4.md
+++ b/.wiki/How-to-migrate-to-sui-studio-v4.md
@@ -9,7 +9,7 @@ The only "global command" `suistudio init` was migrated to [sui-studio-create].
 
 ### 1.1 Install sui-studio
 ```sh
-$ npm install @schibstedspain/sui-studio@4 --save-exact --save-dev
+$ npm install @s-ui/studio@4 --save-exact --save-dev
 ```
 
 ### 1.2 Add sui-mono config
@@ -67,7 +67,7 @@ Now linting is reponsibility of [sui-lint] (through [sui-precommit]).
 ### 3.1 Install sui-precommit
 
 ```sh
-$ npm install @schibstedspain/sui-precommit@2 --save-dev --save-exact
+$ npm install @s-ui/precommit@2 --save-dev --save-exact
 ```
 
 ### 3.2 Install precommit hooks (linting)
@@ -115,7 +115,7 @@ And configure commit-msg hook to sui-mono cz-types.
   },
   "config": {
     "validate-commit-msg": {
-      "types": "@schibstedspain/sui-mono/src/types"
+      "types": "@s-ui/mono/src/types"
     }
   },
   "devDependencies": {
@@ -165,7 +165,7 @@ after:
 You need to replace one dep by the new one:
 ```sh
 $ sui-studio run-all npm uninstall @schibstedspain/suistudio-fatigue-deps --save
-$ npm install @schibstedspain/sui-component-dependencies@latest --save
+$ npm install @s-ui/component-dependencies@latest --save
 ```
 
 > :warning: **Caution!**
@@ -175,17 +175,17 @@ $ npm install @schibstedspain/sui-component-dependencies@latest --save
 ```js
 {
   "dependencies": {
-    "@schibstedspain/sui-component-dependencies": "latest"
+    "@s-ui/component-dependencies": "latest"
   }
 }
 ```
 
 
-[sui-studio-create]: https://www.npmjs.com/package/@schibstedspain/sui-studio-create
-[sui-component-peer-dependencies]: https://www.npmjs.com/package/@schibstedspain/sui-component-peer-dependencies
-[sui-mono]: https://www.npmjs.com/package/@schibstedspain/sui-mono
+[sui-studio-create]: https://www.npmjs.com/package/@s-ui/studio-create
+[sui-component-peer-dependencies]: https://www.npmjs.com/package/@s-ui/component-peer-dependencies
+[sui-mono]: https://www.npmjs.com/package/@s-ui/mono
 [suistudio-fatigue-deps]: https://www.npmjs.com/package/@schibstedspain/suistudio-fatigue-deps
 [linting-rules]: https://www.npmjs.com/package/@schibstedspain/linting-rules
-[sui-precommit]: https://www.npmjs.com/package/@schibstedspain/sui-precommit
-[sui-lint]: https://www.npmjs.com/package/@schibstedspain/sui-lint
-[sui-component-dependencies]: https://www.npmjs.com/package/@schibstedspain/sui-component-dependencies
+[sui-precommit]: https://www.npmjs.com/package/@s-ui/precommit
+[sui-lint]: https://www.npmjs.com/package/@s-ui/lint
+[sui-component-dependencies]: https://www.npmjs.com/package/@s-ui/component-dependencies

--- a/.wiki/How-to-setup-your-sui-repository.md
+++ b/.wiki/How-to-setup-your-sui-repository.md
@@ -11,7 +11,7 @@
 ### 1.1 Install `sui-precommit`
 
 ```sh
-$ npm install @schibstedspain/sui-precommit --save-dev --save-exact
+$ npm install @s-ui/precommit --save-dev --save-exact
 ```
 
 ### 1.2 Install `sui-precommit` scripts and hooks
@@ -34,7 +34,7 @@ Now your package.json to have the following changes
     "precommit": "sui-precommit run"
   },
   "devDependencies": {
-    "@schibstedspain/sui-precommit": "2",
+    "@s-ui/precommit": "2",
     "husky": "0.13.4"
   }
 }
@@ -50,7 +50,7 @@ Now, `sui-precommit run` will be executed prior every commit.
 ### 2.1 Install `sui-mono`
 
 ```sh
-$ npm install @schibstedspain/sui-mono --save-dev --save-exact
+$ npm install @s-ui/mono --save-dev --save-exact
 ```
 
 ### 2.2 Delegate your commits to `sui-mono`
@@ -64,7 +64,7 @@ Create a "co" script and now only use `npm run co` for your commits.
     "co": "sui-mono commit"
   },
   "devDependencies": {
-    "@schibstedspain/sui-mono": "1"
+    "@s-ui/mono": "1"
   }
 }
 ```
@@ -89,7 +89,7 @@ And configure commit-msg hook to sui-mono's commitizen types. Your package.json 
   },
   "config": {
     "validate-commit-msg": {
-      "types": "@schibstedspain/sui-mono/src/types"
+      "types": "@s-ui/mono/src/types"
     }
   },
   "devDependencies": {
@@ -98,5 +98,5 @@ And configure commit-msg hook to sui-mono's commitizen types. Your package.json 
 }
 ```
 
-[sui-mono]: https://www.npmjs.com/package/@schibstedspain/sui-mono
-[sui-precommit]: https://www.npmjs.com/package/@schibstedspain/sui-precommit
+[sui-mono]: https://www.npmjs.com/package/@s-ui/mono
+[sui-precommit]: https://www.npmjs.com/package/@s-ui/precommit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Packages must be properly named. 3 name are
 
 **Example for package `my-example-package`**
 * Folder: `./packages/sui-my-example-package`
-* NPM name: `@schibstedspain/sui-my-example-package`
+* NPM name: `@s-ui/my-example-package`
 
 ### Versionning
 
@@ -52,7 +52,7 @@ Some fields are mandatory in every `package.json`:
 
 {
   /* ... */
-  "name": "@schibstedspain/sui-my-example-package",
+  "name": "@s-ui/my-example-package",
   "version": "1.0.0",
   /* ... */
   "repository": {
@@ -100,7 +100,7 @@ This way, you warranty that the original owner can review the changes you've mad
 Use [npm deprecate](https://docs.npmjs.com/cli/deprecate) to warn developers that the component was migrated when they install it.
 
 ```
-npm deprecate @scope/origin-package "@scope/origin-package is deprecated. Use @schibstedspain/sui-my-example-package instead."
+npm deprecate @scope/origin-package "@scope/origin-package is deprecated. Use @s-ui/my-example-package instead."
 ```
 
 ##### 2. Update README with deprecation warning
@@ -109,7 +109,7 @@ Add this (modified) snippet on top of your package README.md file.
 ```markdown
 ![deprecated](https://img.shields.io/badge/stability-deprecated-red.svg) THIS PACKAGE IS **DEPRECATED!**
 
-**Use [@schibstedspain/sui-my-example-package](https://www.npmjs.com/package/@schibstedspain/sui-my-example-package) instead.**
+**Use [@s-ui/my-example-package](https://www.npmjs.com/package/@s-ui/my-example-package) instead.**
 
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Packages must be properly named. 3 name are
 
 2 simple rules:
 * `sui` prefix for all packages
-* `@schibstedspain` scope for publish
+* `@s-ui` scope for publish
 
 **Example for package `my-example-package`**
 * Folder: `./packages/sui-my-example-package`

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "precommit": "sui-precommit run"
   },
   "devDependencies": {
-    "@schibstedspain/sui-lint": "2",
-    "@schibstedspain/sui-mono": "1",
-    "@schibstedspain/sui-precommit": "2",
+    "@s-ui/lint": "2",
+    "@s-ui/mono": "1",
+    "@s-ui/precommit": "2",
     "husky": "0.13.4",
     "validate-commit-msg": "2.12.2"
   },
@@ -31,15 +31,15 @@
       "packagesFolder": "./packages"
     },
     "validate-commit-msg": {
-      "types": "@schibstedspain/sui-mono/src/types"
+      "types": "@s-ui/mono/src/types"
     }
   },
   "eslintConfig": {
     "extends": [
-      "./node_modules/@schibstedspain/sui-lint/eslintrc.js"
+      "./node_modules/@s-ui/lint/eslintrc.js"
     ]
   },
-  "sasslintConfig": "./node_modules/@schibstedspain/sui-lint/sass-lint.yml",
+  "sasslintConfig": "./node_modules/@s-ui/lint/sass-lint.yml",
   "author": "David Almeida <davidbarna@gmail.com>",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schibstedspain/sui",
+  "name": "@s-ui/sui",
   "version": "0.0.0",
   "description": "Monorepo for SUI (Schibsted User Interface) packages.",
   "keywords": [
@@ -8,7 +8,7 @@
     "sui"
   ],
   "scripts": {
-    "phoenix": "rm -Rf node_modules && npm i && sui-mono run rm -Rf node_modules && sui-mono run npm i",
+    "phoenix": "rm -Rf node_modules && npm i && sui-mono run-parallel rm -Rf node_modules && sui-mono run-parallel npm i",
     "co": "sui-mono commit",
     "release": "sui-mono release",
     "release:check": "sui-mono check",

--- a/packages/sui-bundler/CHANGELOG.md
+++ b/packages/sui-bundler/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+<a name="2.8.0"></a>
+# 2.8.0 (2017-09-19)
+
+
+### Bug Fixes
+
+* replace references to schibstedspain ([2c6b633](https://github.com/SUI-Components/sui/commit/2c6b633))
+
+
+
 <a name="2.7.0"></a>
 # 2.7.0 (2017-09-15)
 
@@ -125,6 +135,16 @@ All notable changes to this project will be documented in this file.
 ### BREAKING CHANGES
 
 * CLI has changed name
+
+
+
+<a name="3.4.0"></a>
+# 3.4.0 (2017-06-27)
+
+
+### Features
+
+* migrate from sui-studio-webpack ([1b58081](https://github.com/SUI-Components/sui/commit/1b58081))
 
 
 

--- a/packages/sui-bundler/CHANGELOG.md
+++ b/packages/sui-bundler/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+<a name="2.9.0"></a>
+# 2.9.0 (2017-09-20)
+
+
+### Bug Fixes
+
+* replace references to sui-studio by s-ui/studio ([86bae2d](https://github.com/SUI-Components/sui/commit/86bae2d))
+
+
+
 <a name="2.8.0"></a>
 # 2.8.0 (2017-09-19)
 

--- a/packages/sui-bundler/CHANGELOG.md
+++ b/packages/sui-bundler/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+<a name="2.7.0"></a>
+# 2.7.0 (2017-09-15)
+
+
+### Features
+
+* move package from [@schibstedspain](https://github.com/schibstedspain) scope to [@s-ui](https://github.com/s-ui) org ([4ade47e](https://github.com/SUI-Components/sui/commit/4ade47e))
+
+
+
 <a name="2.6.0"></a>
 # 2.6.0 (2017-09-13)
 

--- a/packages/sui-bundler/README.md
+++ b/packages/sui-bundler/README.md
@@ -10,7 +10,7 @@ xw
 ## Installation
 
 ```sh
-$ npm install @schibstedspain/sui-bundler --save-dev
+$ npm install @s-ui/bundler --save-dev
 ```
 
 ## Usage
@@ -95,7 +95,7 @@ Esta desactivado por defecto. Para activarlo, tienes que poner `offline: true` e
 En el punto de entrada de tu apliación debes registrar el serviceWorker con el siguiente snippet:
 
 ```js
-import {register, unregister} from '@schibstedspain/sui-bundler/registerServiceWorker'
+import {register, unregister} from '@s-ui/bundler/registerServiceWorker'
 register({
   first: () => window.alert('Content is cached for offline use.'),
   renovate: () => window.alert('New content is available; please refresh.')

--- a/packages/sui-bundler/example/package.json
+++ b/packages/sui-bundler/example/package.json
@@ -13,7 +13,7 @@
     "react-dom": "15.4.2"
   },
   "devDependencies": {
-    "@schibstedspain/sui-bundler": "2"
+    "@s-ui/bundler": "2"
   },
   "keywords": [],
   "author": "",

--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/bundler",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "Config-free bundler for ES6 React apps.",
   "bin": {
     "sui-bundler": "./bin/sui-bundler.js"

--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/bundler",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "Config-free bundler for ES6 React apps.",
   "bin": {
     "sui-bundler": "./bin/sui-bundler.js"

--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schibstedspain/sui-bundler",
+  "name": "@s-ui/bundler",
   "version": "2.6.0",
   "description": "Config-free bundler for ES6 React apps.",
   "bin": {

--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/bundler",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Config-free bundler for ES6 React apps.",
   "bin": {
     "sui-bundler": "./bin/sui-bundler.js"

--- a/packages/sui-bundler/webpack.config.dev.js
+++ b/packages/sui-bundler/webpack.config.dev.js
@@ -51,7 +51,7 @@ let webpackConfig = {
     rules: [
       {
         test: /\.jsx?$/,
-        exclude: /node_modules(?!\/@s-ui\/sui-studio\/src)/,
+        exclude: /node_modules(?!\/@s-ui\/studio\/src)/,
         loader: 'babel-loader',
         query: {
           presets: ['sui']

--- a/packages/sui-bundler/webpack.config.dev.js
+++ b/packages/sui-bundler/webpack.config.dev.js
@@ -51,7 +51,7 @@ let webpackConfig = {
     rules: [
       {
         test: /\.jsx?$/,
-        exclude: /node_modules(?!\/@schibstedspain\/sui-studio\/src)/,
+        exclude: /node_modules(?!\/@s-ui\/sui-studio\/src)/,
         loader: 'babel-loader',
         query: {
           presets: ['sui']

--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -133,7 +133,7 @@ module.exports = {
     rules: [
       {
         test: /\.jsx?$/,
-        exclude: /node_modules(?!\/@s-ui\/sui-studio\/src)/,
+        exclude: /node_modules(?!\/@s-ui\/studio\/src)/,
         loader: 'babel-loader',
         query: {
           presets: ['sui']

--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -133,7 +133,7 @@ module.exports = {
     rules: [
       {
         test: /\.jsx?$/,
-        exclude: /node_modules(?!\/@schibstedspain\/sui-studio\/src)/,
+        exclude: /node_modules(?!\/@s-ui\/sui-studio\/src)/,
         loader: 'babel-loader',
         query: {
           presets: ['sui']

--- a/packages/sui-component-dependencies/CHANGELOG.md
+++ b/packages/sui-component-dependencies/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+<a name="1.3.0"></a>
+# 1.3.0 (2017-09-15)
+
+
+### Features
+
+* move package from [@schibstedspain](https://github.com/schibstedspain) scope to [@s-ui](https://github.com/s-ui) org ([cf48bd2](https://github.com/SUI-Components/sui/commit/cf48bd2))
+
+
+
 <a name="1.2.0"></a>
 # 1.2.0 (2017-06-22)
 
@@ -9,17 +19,6 @@ All notable changes to this project will be documented in this file.
 ### Bug Fixes
 
 * make package public ([08b503b](https://github.com/SUI-Components/sui/commit/08b503b))
-
-
-
-<a name="1.1.0"></a>
-# 1.1.0 (2017-06-22)
-
-
-### Features
-
-* first release 1.0 ([54e5ff6](https://github.com/SUI-Components/sui/commit/54e5ff6))
-* migrate from [@schibstedspain](https://github.com/schibstedspain)/suistudio-fatigue-deps ([b0474f8](https://github.com/SUI-Components/sui/commit/b0474f8))
 
 
 

--- a/packages/sui-component-dependencies/README.md
+++ b/packages/sui-component-dependencies/README.md
@@ -8,5 +8,5 @@ It provides:
 ## Installation
 
 ```sh
-$ npm install @schibstedspain/sui-component-dependencies --save-dev
+$ npm install @s-ui/component-dependencies --save-dev
 ```

--- a/packages/sui-component-dependencies/package.json
+++ b/packages/sui-component-dependencies/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schibstedspain/sui-component-dependencies",
+  "name": "@s-ui/component-dependencies",
   "version": "1.2.0",
   "description": "A set of dependencies of all SUI components.",
   "keywords": [

--- a/packages/sui-component-dependencies/package.json
+++ b/packages/sui-component-dependencies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/component-dependencies",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A set of dependencies of all SUI components.",
   "keywords": [
     "fatigue",

--- a/packages/sui-component-peer-dependencies/CHANGELOG.md
+++ b/packages/sui-component-peer-dependencies/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-<a name="1.1.0"></a>
-# 1.1.0 (2017-06-25)
+<a name="1.2.0"></a>
+# 1.2.0 (2017-09-15)
 
 
 ### Features
 
-* add dependencies to be used with all sui-components ([77fded5](https://github.com/SUI-Components/sui/commit/77fded5))
+* move package from [@schibstedspain](https://github.com/schibstedspain) scope to [@s-ui](https://github.com/s-ui) org ([152f969](https://github.com/SUI-Components/sui/commit/152f969))
 
 
 

--- a/packages/sui-component-peer-dependencies/README.md
+++ b/packages/sui-component-peer-dependencies/README.md
@@ -7,5 +7,5 @@ When hosting components, this package is its single source of truth.
 ## Installation
 
 ```sh
-$ npm install @schibstedspain/sui-component-peer-dependencies --save-dev
+$ npm install @s-ui/component-peer-dependencies --save-dev
 ```

--- a/packages/sui-component-peer-dependencies/package.json
+++ b/packages/sui-component-peer-dependencies/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schibstedspain/sui-component-peer-dependencies",
+  "name": "@s-ui/component-peer-dependencies",
   "version": "1.1.0",
   "description": "A set of dependencies for hosts of sui components.",
   "keywords": [

--- a/packages/sui-component-peer-dependencies/package.json
+++ b/packages/sui-component-peer-dependencies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/component-peer-dependencies",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A set of dependencies for hosts of sui components.",
   "keywords": [
     "bundle",

--- a/packages/sui-cz/CHANGELOG.md
+++ b/packages/sui-cz/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+<a name="1.4.0"></a>
+# 1.4.0 (2017-09-15)
+
+
+### Features
+
+* move package from [@schibstedspain](https://github.com/schibstedspain) scope to [@s-ui](https://github.com/s-ui) org ([12a4baf](https://github.com/SUI-Components/sui/commit/12a4baf))
+
+
+
 <a name="1.3.0"></a>
 # 1.3.0 (2017-07-13)
 
@@ -19,22 +29,6 @@ All notable changes to this project will be documented in this file.
 ### Bug Fixes
 
 * remove unused scripts ([2c77b71](https://github.com/SUI-Components/sui/commit/2c77b71))
-
-
-
-<a name="1.1.0"></a>
-# 1.1.0 (2017-06-16)
-
-
-### Bug Fixes
-
-* description have change since types implementation ([e490849](https://github.com/SUI-Components/sui/commit/e490849))
-
-
-### Features
-
-* add cz types to allow consitent integration with githooks ([296f8bb](https://github.com/SUI-Components/sui/commit/296f8bb))
-* set package name to [@schibstedspain](https://github.com/schibstedspain)/sui-cz ([b797042](https://github.com/SUI-Components/sui/commit/b797042))
 
 
 

--- a/packages/sui-cz/README.md
+++ b/packages/sui-cz/README.md
@@ -18,7 +18,7 @@ It's highly inspired in `cz-customizable` adapter.
 
 ```shell
 npm install --save-dev validate-commit-msg
-npm install --save-dev @schibstedspain/sui-cz
+npm install --save-dev @s-ui/cz
 ```
 
 in `package.json`
@@ -27,7 +27,7 @@ in `package.json`
 {
   "config": {
     "validate-commit-msg": {
-      "types": "@schibstedspain/sui-cz/types"
+      "types": "@s-ui/cz/types"
       /* rest of your config here */
     }
   }
@@ -45,7 +45,7 @@ npm install husky --save-dev
 
 ```shell
 npm install --save-dev validate-commit-msg
-npm install --save-dev @schibstedspain/sui-cz
+npm install --save-dev @s-ui/cz
 ```
 
 in `package.json`

--- a/packages/sui-cz/package.json
+++ b/packages/sui-cz/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schibstedspain/sui-cz",
+  "name": "@s-ui/cz",
   "version": "1.3.0",
   "description": "Commitizen adapter for sui packages",
   "main": "index.js",

--- a/packages/sui-cz/package.json
+++ b/packages/sui-cz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/cz",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Commitizen adapter for sui packages",
   "main": "index.js",
   "keywords": [

--- a/packages/sui-decorators/CHANGELOG.md
+++ b/packages/sui-decorators/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-<a name="1.1.0"></a>
-# 1.1.0 (2017-08-02)
+<a name="1.2.0"></a>
+# 1.2.0 (2017-09-15)
 
 
 ### Features
 
-* add package.json ([63e3529](https://github.com/SUI-Components/sui/commit/63e3529))
+* move package from [@schibstedspain](https://github.com/schibstedspain) scope to [@s-ui](https://github.com/s-ui) org ([88db84c](https://github.com/SUI-Components/sui/commit/88db84c))
 
 
 

--- a/packages/sui-decorators/package.json
+++ b/packages/sui-decorators/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schibstedspain/sui-decorators",
+  "name": "@s-ui/decorators",
   "private": true,
   "version": "1.1.0",
   "description": "> Set of ES6 decorators to improve your apps",

--- a/packages/sui-decorators/package.json
+++ b/packages/sui-decorators/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@s-ui/decorators",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "> Set of ES6 decorators to improve your apps",
   "main": "index.js",
   "scripts": {

--- a/packages/sui-deploy/CHANGELOG.md
+++ b/packages/sui-deploy/CHANGELOG.md
@@ -2,43 +2,53 @@
 
 All notable changes to this project will be documented in this file.
 
+<a name="1.6.0"></a>
+# 1.6.0 (2017-09-15)
+
+
+### Features
+
+* move package from [@schibstedspain](https://github.com/schibstedspain) scope to [@s-ui](https://github.com/s-ui) org ([945321c](https://github.com/SUI-Components/sui/commit/945321c))
+
+
+
 <a name="1.5.0"></a>
-# 1.5.0 (2017-09-07)
+# 1.5.0 (2017-09-13)
 
 
 ### Bug Fixes
 
-* avoid race conditions for deployments aliases ([7485dce](https://github.com/SUI-Components/sui/commit/7485dce))
+* avoid race conditions for deployments aliases ([a1fd9fd](https://github.com/SUI-Components/sui/commit/a1fd9fd))
 
 
 
 <a name="1.4.0"></a>
-# 1.4.0 (2017-09-07)
+# 1.4.0 (2017-09-13)
 
 
 ### Features
 
-* rename to [@s-ui](https://github.com/s-ui)/deploy ([668a999](https://github.com/SUI-Components/sui/commit/668a999))
+* rename to [@s-ui](https://github.com/s-ui)/deploy ([d0cfab4](https://github.com/SUI-Components/sui/commit/d0cfab4))
 
 
 
 <a name="1.3.0"></a>
-# 1.3.0 (2017-09-07)
+# 1.3.0 (2017-09-13)
 
 
 ### Bug Fixes
 
-* fix: version of sui-helpers too old ([93be1a4](https://github.com/SUI-Components/sui/commit/93be1a4))
+* fix: version of sui-helpers too old ([408c623](https://github.com/SUI-Components/sui/commit/408c623))
 
 
 
 <a name="1.2.0"></a>
-# 1.2.0 (2017-09-07)
+# 1.2.0 (2017-09-13)
 
 
 ### Features
 
-* prepare CLI api tu future targets ([2a152d3](https://github.com/SUI-Components/sui/commit/2a152d3))
+* prepare CLI api tu future targets ([96311ed](https://github.com/SUI-Components/sui/commit/96311ed))
 
 
 

--- a/packages/sui-deploy/bin/sui-deploy-spa.js
+++ b/packages/sui-deploy/bin/sui-deploy-spa.js
@@ -3,8 +3,8 @@
 
 const program = require('commander')
 const NowClient = require('now-client')
-const { getSpawnPromise } = require('@schibstedspain/sui-helpers/cli')
-const {writeFile, removeFile} = require('@schibstedspain/sui-helpers/file')
+const { getSpawnPromise } = require('@s-ui/helpers/cli')
+const {writeFile, removeFile} = require('@s-ui/helpers/file')
 const DEFAULT_FOLDER = './public'
 const writePackageJson = (name) => writeFile(pkgFilePath, `{
   "name": "@sui-deploy/${name}",

--- a/packages/sui-deploy/package.json
+++ b/packages/sui-deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/deploy",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": " CLI to deploy of sui-based projects",
   "main": "./bin/sui-deploy.js",
   "bin": {

--- a/packages/sui-deploy/package.json
+++ b/packages/sui-deploy/package.json
@@ -10,7 +10,7 @@
   "author": "David Almeida <davidbarna@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@schibstedspain/sui-helpers": "1",
+    "@s-ui/helpers": "1",
     "commander": "2.9.0",
     "now-client": "1.1.1"
   },

--- a/packages/sui-helpers/CHANGELOG.md
+++ b/packages/sui-helpers/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+<a name="1.5.0"></a>
+# 1.5.0 (2017-09-15)
+
+
+### Bug Fixes
+
+* fix to work on node v6 enironments ([9b7cfc3](https://github.com/SUI-Components/sui/commit/9b7cfc3))
+
+
+
 <a name="1.4.0"></a>
 # 1.4.0 (2017-09-15)
 
@@ -21,6 +31,17 @@ All notable changes to this project will be documented in this file.
 * add helper to display errors when command fails ([23b7d9d](https://github.com/SUI-Components/sui/commit/23b7d9d))
 * add helpers for file management ([1e69854](https://github.com/SUI-Components/sui/commit/1e69854))
 * add method to run commands in parallel ([02ea05e](https://github.com/SUI-Components/sui/commit/02ea05e))
+
+
+
+<a name="1.2.0"></a>
+# 1.2.0 (2017-07-04)
+
+
+### Features
+
+* add helpers to manage packages of file system ([b8ced10](https://github.com/SUI-Components/sui/commit/b8ced10))
+* new package with cli helpers ([e270fa0](https://github.com/SUI-Components/sui/commit/e270fa0))
 
 
 

--- a/packages/sui-helpers/CHANGELOG.md
+++ b/packages/sui-helpers/CHANGELOG.md
@@ -2,14 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
-<a name="1.3.0"></a>
-# 1.3.0 (2017-09-06)
+<a name="1.4.0"></a>
+# 1.4.0 (2017-09-15)
 
 
 ### Features
 
-* add helper to display errors when command fails ([d2bc8cf](https://github.com/SUI-Components/sui/commit/d2bc8cf))
-* add helpers for file management ([dd77a98](https://github.com/SUI-Components/sui/commit/dd77a98))
+* Move package from [@schibstedspain](https://github.com/schibstedspain) scope to [@s-ui](https://github.com/s-ui) org ([dbd8e0f](https://github.com/SUI-Components/sui/commit/dbd8e0f))
+
+
+
+<a name="1.3.0"></a>
+# 1.3.0 (2017-09-13)
+
+
+### Features
+
+* add helper to display errors when command fails ([23b7d9d](https://github.com/SUI-Components/sui/commit/23b7d9d))
+* add helpers for file management ([1e69854](https://github.com/SUI-Components/sui/commit/1e69854))
+* add method to run commands in parallel ([02ea05e](https://github.com/SUI-Components/sui/commit/02ea05e))
 
 
 

--- a/packages/sui-helpers/README.md
+++ b/packages/sui-helpers/README.md
@@ -6,7 +6,7 @@
 ## Usage
 
 ```js
-import {serialSpawn} from '@schibstedspain/sui-helpers/cli'
+import {serialSpawn} from '@s-ui/helpers/cli'
 
 serialSpawn([
     ['sui-lint', ['js']],

--- a/packages/sui-helpers/cli.js
+++ b/packages/sui-helpers/cli.js
@@ -30,7 +30,7 @@ function parallelSpawn (commands, options = {}) {
     let [bin, args, opts] = command
     let stdout = ''
     let stderr = ''
-    opts = {...opts, ...options}
+    opts = Object.assign({}, opts, options)
 
     let child = getSpawnProcess(bin, args, opts)
     child.stdout.on('data', (data) => { stdout += data.toString() })

--- a/packages/sui-helpers/package.json
+++ b/packages/sui-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/helpers",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "A set of internal helpers used by sui-related packages.",
   "keywords": [],
   "author": "David Almeida <davidbarna@gmail.com>",

--- a/packages/sui-helpers/package.json
+++ b/packages/sui-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/helpers",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A set of internal helpers used by sui-related packages.",
   "keywords": [],
   "author": "David Almeida <davidbarna@gmail.com>",

--- a/packages/sui-helpers/package.json
+++ b/packages/sui-helpers/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schibstedspain/sui-helpers",
+  "name": "@s-ui/helpers",
   "version": "1.3.0",
   "description": "A set of internal helpers used by sui-related packages.",
   "keywords": [],

--- a/packages/sui-hoc/CHANGELOG.md
+++ b/packages/sui-hoc/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+<a name="1.4.0"></a>
+# 1.4.0 (2017-09-15)
+
+
+### Features
+
+* Move package from [@schibstedspain](https://github.com/schibstedspain) scope to [@s-ui](https://github.com/s-ui) org ([05d1fe3](https://github.com/SUI-Components/sui/commit/05d1fe3))
+
+
+
 <a name="1.3.0"></a>
 # 1.3.0 (2017-08-09)
 
@@ -20,16 +30,6 @@ All notable changes to this project will be documented in this file.
 ### Features
 
 * add Readme ([bff8988](https://github.com/SUI-Components/sui/commit/bff8988))
-
-
-
-<a name="1.1.0"></a>
-# 1.1.0 (2017-08-02)
-
-
-### Features
-
-* 🌈 First Commit ([b09a168](https://github.com/SUI-Components/sui/commit/b09a168))
 
 
 

--- a/packages/sui-hoc/package.json
+++ b/packages/sui-hoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/hoc",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Set of HoC useful for react",
   "scripts": {
     "lib": "rm -Rf ./lib && mkdir -p ./lib && babel --presets sui ./src --out-dir ./lib",

--- a/packages/sui-hoc/package.json
+++ b/packages/sui-hoc/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schibstedspain/sui-hoc",
+  "name": "@s-ui/hoc",
   "version": "1.3.0",
   "description": "Set of HoC useful for react",
   "scripts": {
@@ -13,7 +13,7 @@
     "react": "15"
   },
   "devDependencies": {
-    "@schibstedspain/sui-component-peer-dependencies": "1",
+    "@s-ui/component-peer-dependencies": "1",
     "babel-cli": "6.24.1",
     "babel-preset-sui": "1"
   }

--- a/packages/sui-i18n/CHANGELOG.md
+++ b/packages/sui-i18n/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-<a name="1.1.0"></a>
-# 1.1.0 (2017-08-02)
+<a name="1.2.0"></a>
+# 1.2.0 (2017-09-15)
 
 
 ### Features
 
-* add package.json ([b5b25a7](https://github.com/SUI-Components/sui/commit/b5b25a7))
+* Move package from [@schibstedspain](https://github.com/schibstedspain) scope to [@s-ui](https://github.com/s-ui) org ([ec355e7](https://github.com/SUI-Components/sui/commit/ec355e7))
 
 
 

--- a/packages/sui-i18n/package.json
+++ b/packages/sui-i18n/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@s-ui/i18n",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "> Isomorphic i18n service for browser and node.",
   "main": "index.js",
   "scripts": {

--- a/packages/sui-i18n/package.json
+++ b/packages/sui-i18n/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schibstedspain/sui-i18n",
+  "name": "@s-ui/i18n",
   "private": true,
   "version": "1.1.0",
   "description": "> Isomorphic i18n service for browser and node.",

--- a/packages/sui-lint/CHANGELOG.md
+++ b/packages/sui-lint/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+<a name="2.4.0"></a>
+# 2.4.0 (2017-09-15)
+
+
+### Features
+
+* Move package from [@schibstedspain](https://github.com/schibstedspain) scope to [@s-ui](https://github.com/s-ui) org ([1aa4bcc](https://github.com/SUI-Components/sui/commit/1aa4bcc))
+
+
+
 <a name="2.3.0"></a>
 # 2.3.0 (2017-07-04)
 
@@ -20,29 +30,6 @@ All notable changes to this project will be documented in this file.
 ### Bug Fixes
 
 * remove unused scripts ([ecbbb62](https://github.com/SUI-Components/sui/commit/ecbbb62))
-
-
-
-<a name="2.0.0"></a>
-# 2.0.0 (2017-06-16)
-
-
-### Bug Fixes
-
-* add build script to be compatible with sui-mono releases ([020e211](https://github.com/SUI-Components/sui/commit/020e211))
-* fix implementation of build script ([9b00cd6](https://github.com/SUI-Components/sui/commit/9b00cd6))
-* improve resolution of eslint bin ([22f8073](https://github.com/SUI-Components/sui/commit/22f8073))
-
-
-### Features
-
-* first commit of linting-rules migration ([1829091](https://github.com/SUI-Components/sui/commit/1829091))
-* rename package so [@schibstedspain](https://github.com/schibstedspain)/sui-lint with consistent CLI ([650b16a](https://github.com/SUI-Components/sui/commit/650b16a))
-
-
-### BREAKING CHANGES
-
-* CLI has changed and not compatible to previous version
 
 
 

--- a/packages/sui-lint/Readme.md
+++ b/packages/sui-lint/Readme.md
@@ -12,7 +12,7 @@ It provides:
 ## Installation
 
 ```sh
-$ npm install @schibstedspain/sui-lint --save-dev
+$ npm install @s-ui/lint --save-dev
 ```
 
 ## CLI
@@ -45,8 +45,8 @@ Al igual que en el caso anterior no puedes pasar una nueva configuración, y las
 ```json
 {
   "eslintConfig": {
-     "extends": ["./node_modules/@schibstedspain/sui-lint/eslintrc.js"]},
-  "sasslintConfig": "./node_modules/@schibstedspain/sui-lint/sass-lint.yml"
+     "extends": ["./node_modules/@s-ui/lint/eslintrc.js"]},
+  "sasslintConfig": "./node_modules/@s-ui/lint/sass-lint.yml"
 }
 ```
 
@@ -62,9 +62,9 @@ Al igual que en el caso anterior no puedes pasar una nueva configuración, y las
     "lint:sass": "sui-lint sass"
   },
   "devDependencies": {
-    "@schibstedspain/sui-lint": "1.0.0-beta.1"
+    "@s-ui/lint": "1.0.0-beta.1"
   },
-  "eslintConfig": { "extends": ["./node_modules/@schibstedspain/sui-lint/eslintrc.js"]},
-  "sasslintConfig": "./node_modules/@schibstedspain/sui-lint/sass-lint.yml"
+  "eslintConfig": { "extends": ["./node_modules/@s-ui/lint/eslintrc.js"]},
+  "sasslintConfig": "./node_modules/@s-ui/lint/sass-lint.yml"
 }
 ```

--- a/packages/sui-lint/package.json
+++ b/packages/sui-lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/lint",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Linting CLI for sui packages",
   "main": "./bin/sui-lint.js",
   "bin": {

--- a/packages/sui-lint/package.json
+++ b/packages/sui-lint/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schibstedspain/sui-lint",
+  "name": "@s-ui/lint",
   "version": "2.3.0",
   "description": "Linting CLI for sui packages",
   "main": "./bin/sui-lint.js",

--- a/packages/sui-mono/CHANGELOG.md
+++ b/packages/sui-mono/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+<a name="1.24.0"></a>
+# 1.24.0 (2017-09-18)
+
+
+### Bug Fixes
+
+* point to correct version of [@s-ui](https://github.com/s-ui)/cz ([718e943](https://github.com/SUI-Components/sui/commit/718e943))
+
+
+
 <a name="1.23.0"></a>
 # 1.23.0 (2017-09-15)
 

--- a/packages/sui-mono/CHANGELOG.md
+++ b/packages/sui-mono/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+<a name="1.23.0"></a>
+# 1.23.0 (2017-09-15)
+
+
+### Features
+
+* Move package from [@schibstedspain](https://github.com/schibstedspain) scope to [@s-ui](https://github.com/s-ui) org ([0d70fc3](https://github.com/SUI-Components/sui/commit/0d70fc3))
+
+
+
 <a name="1.22.0"></a>
 # 1.22.0 (2017-09-13)
 

--- a/packages/sui-mono/README.md
+++ b/packages/sui-mono/README.md
@@ -80,10 +80,10 @@ To release all the packages
 
 ## How to configure your project
 
-First you need to install the `@schibstedspain/sui-mono` package in your project
+First you need to install the `@s-ui/mono` package in your project
 
 ```
-npm i --save-dev @schibstedspain/sui-mono
+npm i --save-dev @s-ui/mono
 ```
 
 Then, configure your package.json
@@ -108,7 +108,7 @@ Here's a full example of the options
     ]
   },
   "validate-commit-msg": {
-    "types": "@schibstedspain/sui-mono/src/types"
+    "types": "@s-ui/mono/src/types"
   },
 }
 ```

--- a/packages/sui-mono/bin/sui-mono-changelog.js
+++ b/packages/sui-mono/bin/sui-mono-changelog.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 const path = require('path')
 const conventionalChangelog = require('conventional-changelog')
 const {getScopes, getPackagesFolder, isMonoPackage} = require('../src/config')
-const { getPackagesPaths } = require('@schibstedspain/sui-helpers/packages')
+const { getPackagesPaths } = require('@s-ui/helpers/packages')
 
 program
   .usage('<folder1> <folder2> <etc>')

--- a/packages/sui-mono/bin/sui-mono-commit.js
+++ b/packages/sui-mono/bin/sui-mono-commit.js
@@ -6,6 +6,6 @@ bootstrap({
   debug: false,
   cliPath: path.join(process.cwd(), 'node_modules/commitizen'),
   config: {
-    path: './node_modules/@schibstedspain/sui-cz'
+    path: './node_modules/@s-ui/cz'
   }
 })

--- a/packages/sui-mono/bin/sui-mono-link.js
+++ b/packages/sui-mono/bin/sui-mono-link.js
@@ -4,11 +4,11 @@
 const program = require('commander')
 const path = require('path')
 const config = require('../src/config')
-const { serialSpawn } = require('@schibstedspain/sui-helpers/cli')
+const { serialSpawn } = require('@s-ui/helpers/cli')
 const {
   getPackagesPaths, getPackagesNames,
   getInternalDependencyMap, getUsedInternalDependencies
-} = require('@schibstedspain/sui-helpers/packages')
+} = require('@s-ui/helpers/packages')
 
 program
   .on('--help', () => {

--- a/packages/sui-mono/bin/sui-mono-release.js
+++ b/packages/sui-mono/bin/sui-mono-release.js
@@ -4,7 +4,7 @@ const program = require('commander')
 const path = require('path')
 const config = require('../src/config')
 const checker = require('../src/check')
-const { serialSpawn } = require('@schibstedspain/sui-helpers/cli')
+const { serialSpawn } = require('@s-ui/helpers/cli')
 
 program
   .on('--help', () => {
@@ -32,7 +32,7 @@ const BASE_DIR = process.cwd()
 
 const packagesFolder = config.getPackagesFolder()
 const publishAccess = config.getPublishAccess()
-const suiMonoBinPath = require.resolve('@schibstedspain/sui-mono/bin/sui-mono')
+const suiMonoBinPath = require.resolve('@s-ui/mono/bin/sui-mono')
 
 const RELEASE_CODES = {
   0: 'clean',

--- a/packages/sui-mono/bin/sui-mono-run-parallel.js
+++ b/packages/sui-mono/bin/sui-mono-run-parallel.js
@@ -2,7 +2,7 @@
 /* eslint no-console:0 */
 const program = require('commander')
 const {getAllTaskArrays} = require('../src/run')
-const {parallelSpawn} = require('@schibstedspain/sui-helpers/cli')
+const {parallelSpawn} = require('@s-ui/helpers/cli')
 
 program
   .on('--help', () => {

--- a/packages/sui-mono/bin/sui-mono-run.js
+++ b/packages/sui-mono/bin/sui-mono-run.js
@@ -2,7 +2,7 @@
 /* eslint no-console:0 */
 const program = require('commander')
 const {getAllTaskArrays} = require('../src/run')
-const {serialSpawn} = require('@schibstedspain/sui-helpers/cli')
+const {serialSpawn} = require('@s-ui/helpers/cli')
 
 program
   .on('--help', () => {

--- a/packages/sui-mono/package.json
+++ b/packages/sui-mono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/mono",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "Commit and release manager",
   "main": "index.js",
   "bin": {

--- a/packages/sui-mono/package.json
+++ b/packages/sui-mono/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "devDependencies": {},
   "dependencies": {
-    "@s-ui/cz": "1.1",
+    "@s-ui/cz": "1.4",
     "@s-ui/helpers": "1",
     "commander": "2.9.0",
     "commitizen": "2.8.6",

--- a/packages/sui-mono/package.json
+++ b/packages/sui-mono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/mono",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "description": "Commit and release manager",
   "main": "index.js",
   "bin": {

--- a/packages/sui-mono/package.json
+++ b/packages/sui-mono/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schibstedspain/sui-mono",
+  "name": "@s-ui/mono",
   "version": "1.22.0",
   "description": "Commit and release manager",
   "main": "index.js",
@@ -15,8 +15,8 @@
   "license": "MIT",
   "devDependencies": {},
   "dependencies": {
-    "@schibstedspain/sui-cz": "1.1",
-    "@schibstedspain/sui-helpers": "1",
+    "@s-ui/cz": "1.1",
+    "@s-ui/helpers": "1",
     "commander": "2.9.0",
     "commitizen": "2.8.6",
     "conventional-changelog": "1.1.0"

--- a/packages/sui-mono/src/types.js
+++ b/packages/sui-mono/src/types.js
@@ -1,1 +1,1 @@
-module.exports = require('@schibstedspain/sui-cz/types')
+module.exports = require('@s-ui/cz/types')

--- a/packages/sui-perf/CHANGELOG.md
+++ b/packages/sui-perf/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+<a name="1.4.0"></a>
+# 1.4.0 (2017-09-15)
+
+
+### Features
+
+* Move package from [@schibstedspain](https://github.com/schibstedspain) scope to [@s-ui](https://github.com/s-ui) org ([572d4b8](https://github.com/SUI-Components/sui/commit/572d4b8))
+
+
+
 <a name="1.3.0"></a>
 # 1.3.0 (2017-09-13)
 

--- a/packages/sui-perf/README.md
+++ b/packages/sui-perf/README.md
@@ -34,7 +34,7 @@ Charts can get as complex as needed to find out the blockers of your code. Check
 ## Installation
 
 ```sh
-npm install @schibstedspain/sui-perf --save
+npm install @s-ui/perf --save
 ```
 
 ## API Reference
@@ -47,7 +47,7 @@ npm install @schibstedspain/sui-perf --save
 Get an instance of `perf` which measurements are scoped to this instance.
 
 ```js
-import getPerf from '@schibstedspain/sui-perf'
+import getPerf from '@s-ui/perf'
 
 const perf = getPerf('my-request-unique-id')
 perf.mark('Request')
@@ -99,7 +99,7 @@ perf.measure('Fetch user')
 
 ### Charts
 
-`@schibstedspain/sui-perf/lib/chart` has no dependency of and can be imported separately.
+`@s-ui/perf/lib/chart` has no dependency of and can be imported separately.
 
 
 
@@ -108,7 +108,7 @@ Get a text-based timeline chart from given entries.
 Check [timelineOptions](#timelineOptions).
 
 ```js
-import {getTimelineChart} from '@schibstedspain/sui-perf/lib/charts'
+import {getTimelineChart} from '@s-ui/perf/lib/charts'
 
 const options = {/* your custom options */}
 const timeline = getTimelineChart(options)(perf.getEntries())
@@ -127,7 +127,7 @@ A shorthand to directly print the chart with `console.log`.
 Check [timelineOptions](#timelineOptions).
 
 ```js
-import {printTimelineChart} from '@schibstedspain/sui-perf/lib/charts'
+import {printTimelineChart} from '@s-ui/perf/lib/charts'
 const options = {/* your custom options */}
 printTimelineChart(options)(perf.getEntries())
 /*
@@ -157,8 +157,8 @@ Measure all requests made with the given instance of [superagent](https://www.np
 
 ```js
 import superagent from 'superagent'
-import getPerf from '@schibstedspain/sui-perf'
-import measureSuperagent from '@schibstedspain/sui-perf/lib/measure-superagent'
+import getPerf from '@s-ui/perf'
+import measureSuperagent from '@s-ui/perf/lib/measure-superagent'
 
 const perf = getPerf('my-request-unique-id')
 const clearMeasureSuperAgent =  measureSuperagent(superagent, perf)
@@ -172,8 +172,8 @@ clearMeasureSuperAgent()
 Measure mounting of all React components, either on client or server.
 
 ```js
-import getPerf from '@schibstedspain/sui-perf'
-import measureReact from '@schibstedspain/sui-perf/lib/measure-react'
+import getPerf from '@s-ui/perf'
+import measureReact from '@s-ui/perf/lib/measure-react'
 
 const perf = getPerf('my-request-unique-id')
 const clearMeasureReact =  measureReact(perf)
@@ -188,8 +188,8 @@ Measure all axios requests.
 
 ```js
 import axios from 'axios'
-import getPerf from '@schibstedspain/sui-perf'
-import measureAxios from '@schibstedspain/sui-perf/lib/measure-axios'
+import getPerf from '@s-ui/perf'
+import measureAxios from '@s-ui/perf/lib/measure-axios'
 
 /* ... */
 

--- a/packages/sui-perf/package.json
+++ b/packages/sui-perf/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schibstedspain/sui-perf",
+  "name": "@s-ui/perf",
   "version": "1.3.0",
   "description": "Utilities to measure and monitor perf of your isomorphic apps.",
   "main": "lib/index.js",

--- a/packages/sui-perf/package.json
+++ b/packages/sui-perf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/perf",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Utilities to measure and monitor perf of your isomorphic apps.",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/sui-polyfills/CHANGELOG.md
+++ b/packages/sui-polyfills/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+<a name="1.4.0"></a>
+# 1.4.0 (2017-09-15)
+
+
+### Features
+
+* Move package from [@schibstedspain](https://github.com/schibstedspain) scope to [@s-ui](https://github.com/s-ui) org ([db8a9a8](https://github.com/SUI-Components/sui/commit/db8a9a8))
+
+
+
+<a name="1.3.0"></a>
+# 1.3.0 (2017-08-28)
+
+
+### Features
+
+* bump core-js version to be in sync with the one used by babel ([22b49e0](https://github.com/SUI-Components/sui/commit/22b49e0))
+
+
+
 <a name="1.2.0"></a>
 # 1.2.0 (2017-07-26)
 
@@ -9,16 +29,6 @@ All notable changes to this project will be documented in this file.
 ### Bug Fixes
 
 * add module.exports ([944e204](https://github.com/SUI-Components/sui/commit/944e204))
-
-
-
-<a name="1.1.0"></a>
-# 1.1.0 (2017-07-19)
-
-
-### Features
-
-* create sui-polyfills to be reused on all our projects ([df2086e](https://github.com/SUI-Components/sui/commit/df2086e))
 
 
 

--- a/packages/sui-polyfills/README.md
+++ b/packages/sui-polyfills/README.md
@@ -11,5 +11,5 @@
 ## Installation
 
 ```sh
-npm install @schibstedspain/sui-polyfills --save
+npm install @s-ui/polyfills --save
 ```

--- a/packages/sui-polyfills/package.json
+++ b/packages/sui-polyfills/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schibstedspain/sui-polyfills",
+  "name": "@s-ui/polyfills",
   "version": "1.4.0",
   "description": "Polyfills for your project",
   "main": "src/index.js",

--- a/packages/sui-polyfills/package.json
+++ b/packages/sui-polyfills/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@s-ui/polyfills",
   "version": "1.4.0",
-  "description": "Polyfills for your project",
+  "description": "Common polyfills for your project",
   "main": "src/index.js",
   "scripts": {},
   "keywords": [],

--- a/packages/sui-precommit/CHANGELOG.md
+++ b/packages/sui-precommit/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+<a name="2.4.0"></a>
+# 2.4.0 (2017-09-15)
+
+
+### Bug Fixes
+
+* make installation to add exact version of husky ([193ec1c](https://github.com/SUI-Components/sui/commit/193ec1c))
+* remove git-validate dependency ([b47bd21](https://github.com/SUI-Components/sui/commit/b47bd21))
+
+
+### Features
+
+* Move package from [@schibstedspain](https://github.com/schibstedspain) scope to [@s-ui](https://github.com/s-ui) org ([11bf0c1](https://github.com/SUI-Components/sui/commit/11bf0c1))
+
+
+
 <a name="2.2.0"></a>
 # 2.2.0 (2017-06-27)
 
@@ -39,22 +55,6 @@ All notable changes to this project will be documented in this file.
 ### BREAKING CHANGES
 
 * API has changed... now it's sui-lint instead of linting-rules
-
-
-
-<a name="1.1.0"></a>
-# 1.1.0 (2017-06-16)
-
-
-### Bug Fixes
-
-* add build script to be compatible with sui-mono releases ([0cd7d4b](https://github.com/SUI-Components/sui/commit/0cd7d4b))
-
-
-### Features
-
-* first commit of frontend-commit-rules migration to sui-precommit ([6f77134](https://github.com/SUI-Components/sui/commit/6f77134))
-* rename package to [@schibstedspain](https://github.com/schibstedspain)/sui-precommit ([b9a0a1d](https://github.com/SUI-Components/sui/commit/b9a0a1d))
 
 
 

--- a/packages/sui-precommit/Readme.md
+++ b/packages/sui-precommit/Readme.md
@@ -13,7 +13,7 @@ It provides:
 
 
 ```sh
-$ npm install @schibstedspain/sui-precommit --save-dev
+$ npm install @s-ui/precommit --save-dev
 ```
 
 ## CLI

--- a/packages/sui-precommit/bin/sui-precommit-install.js
+++ b/packages/sui-precommit/bin/sui-precommit-install.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const { getSpawnPromise } = require('@schibstedspain/sui-helpers/cli')
+const { getSpawnPromise } = require('@s-ui/helpers/cli')
 const path = require('path')
 const fs = require('fs')
 const pkgPath = path.join(process.cwd(), 'package.json')

--- a/packages/sui-precommit/bin/sui-precommit-run.js
+++ b/packages/sui-precommit/bin/sui-precommit-run.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-const { serialSpawn } = require('@schibstedspain/sui-helpers/cli')
-const BIN_PATH = require.resolve('@schibstedspain/sui-lint/bin/sui-lint')
+const { serialSpawn } = require('@s-ui/helpers/cli')
+const BIN_PATH = require.resolve('@s-ui/lint/bin/sui-lint')
 
 serialSpawn([
   [BIN_PATH, ['js']],

--- a/packages/sui-precommit/package.json
+++ b/packages/sui-precommit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/precommit",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Effortless SUI precommit rules integration in your project",
   "main": "index.js",
   "bin": {

--- a/packages/sui-precommit/package.json
+++ b/packages/sui-precommit/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schibstedspain/sui-precommit",
+  "name": "@s-ui/precommit",
   "version": "2.3.0",
   "description": "Effortless SUI precommit rules integration in your project",
   "main": "index.js",
@@ -9,8 +9,8 @@
   "keywords": [],
   "author": "",
   "dependencies": {
-    "@schibstedspain/sui-lint": "2",
-    "@schibstedspain/sui-helpers": "1",
+    "@s-ui/lint": "2",
+    "@s-ui/helpers": "1",
     "commander": "2.9.0"
   },
   "license": "MIT",

--- a/packages/sui-react-domain-connector/CHANGELOG.md
+++ b/packages/sui-react-domain-connector/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+<a name="1.2.0"></a>
+# 1.2.0 (2017-09-15)
+
+
+### Features
+
+* Move package from [@schibstedspain](https://github.com/schibstedspain) scope to [@s-ui](https://github.com/s-ui) org ([0370d1f](https://github.com/SUI-Components/sui/commit/0370d1f))
+
+
+
 <a name="1.1.0"></a>
 # 1.1.0 (2017-08-02)
 
@@ -9,16 +19,6 @@ All notable changes to this project will be documented in this file.
 ### Features
 
 * 🌈 Migrate package ([a02f295](https://github.com/SUI-Components/sui/commit/a02f295))
-
-
-
-<a name="1.1.0"></a>
-# 1.1.0 (2017-08-02)
-
-
-### Features
-
-* add package.json ([541f16d](https://github.com/SUI-Components/sui/commit/541f16d))
 
 
 

--- a/packages/sui-react-domain-connector/README.md
+++ b/packages/sui-react-domain-connector/README.md
@@ -2,7 +2,7 @@
 
 ## Install
 
-`$ npm install @schibstedspain/sui-react-domain-connector`
+`$ npm install @s-ui/react-domain-connector`
 
 ## Usage
 
@@ -11,7 +11,7 @@
 
 import React from 'react'
 import {render} from 'react-dom'
-import {Provider} from '@schibstedspain/sui-react-domain-connector'
+import {Provider} from '@s-ui/react-domain-connector'
 
 import Domain from '@schibstedspain/domain'
 import Rosetta from '@schibstedspain/rosetta'
@@ -42,7 +42,7 @@ Or passing directly the store, if you need it outside
 
 import React from 'react'
 import {render} from 'react-dom'
-import {Provider, createStore} from '@schibstedspain/sui-react-domain-connector'
+import {Provider, createStore} from '@s-ui/react-domain-connector'
 
 import Domain from '@schibstedspain/domain'
 import Rosetta from '@schibstedspain/rosetta'
@@ -76,7 +76,7 @@ Passing Config to your components
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 
-import {compose, mapConfigToProps} from '@schibstedspain/sui-react-domain-connector'
+import {compose, mapConfigToProps} from '@s-ui/react-domain-connector'
 
 class Search extends Component {
   const {gradesConfig} = this.props
@@ -107,7 +107,7 @@ export default compose(
 Or Using locals HoC to avoid use the global state when you dont need it
 
 ```js
-import {withLocalService, mapServiceToProps, mapResponseToProps, compose} from '@schibstedspain/sui-react-domain-connector'
+import {withLocalService, mapServiceToProps, mapResponseToProps, compose} from '@s-ui/react-domain-connector'
 
 const Home = ({
   history,
@@ -156,7 +156,7 @@ Using UI HoC to manage not relative Domain updates
 
 ```js
 
-import {mapUIServiceToProps, mapUIResponseToProps, compose} from '@schibstedspain/sui-react-domain-connector'
+import {mapUIServiceToProps, mapUIResponseToProps, compose} from '@s-ui/react-domain-connector'
 
 const Home = ({
   history,
@@ -200,7 +200,7 @@ export default compose(
 Comonication between components:
 
 ```
-import { withLocalService, withStreamService, compose } from '@schibstedspain/sui-react-domain-connector'
+import { withLocalService, withStreamService, compose } from '@s-ui/react-domain-connector'
 
 class Home extends PureComponent {
   static displayName = 'Home'

--- a/packages/sui-react-domain-connector/package.json
+++ b/packages/sui-react-domain-connector/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schibstedspain/sui-react-domain-connector",
+  "name": "@s-ui/react-domain-connector",
   "version": "1.1.0",
   "description": "Connect any React component to your domain use cases",
   "main": "lib/index.js",
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@schibstedspain/sui-lint": "2",
+    "@s-ui/lint": "2",
     "babel-cli": "6.24.1",
     "babel-preset-sui": "1",
     "react": "15"
@@ -30,8 +30,8 @@
   },
   "eslintConfig": {
     "extends": [
-      "./node_modules/@schibstedspain/sui-lint/eslintrc.js"
+      "./node_modules/@s-ui/lint/eslintrc.js"
     ]
   },
-  "sasslintConfig": "./node_modules/@schibstedspain/sui-lint/sass-lint.yml"
+  "sasslintConfig": "./node_modules/@s-ui/lint/sass-lint.yml"
 }

--- a/packages/sui-react-domain-connector/package.json
+++ b/packages/sui-react-domain-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/react-domain-connector",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Connect any React component to your domain use cases",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/sui-react-initial-props/CHANGELOG.md
+++ b/packages/sui-react-initial-props/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+<a name="1.3.0"></a>
+# 1.3.0 (2017-09-15)
+
+
+### Features
+
+* Move package from [@schibstedspain](https://github.com/schibstedspain) scope to [@s-ui](https://github.com/s-ui) org ([ef07b38](https://github.com/SUI-Components/sui/commit/ef07b38))
+
+
+
 <a name="1.2.0"></a>
 # 1.2.0 (2017-08-09)
 
@@ -9,23 +19,6 @@ All notable changes to this project will be documented in this file.
 ### Bug Fixes
 
 * add missing main on package.json ([d5abe46](https://github.com/SUI-Components/sui/commit/d5abe46))
-
-
-
-<a name="1.1.0"></a>
-# 1.1.0 (2017-08-09)
-
-
-### Bug Fixes
-
-* use new syntax as a HoC and add README ([1754b78](https://github.com/SUI-Components/sui/commit/1754b78))
-
-
-### Features
-
-* add some useful params and improve readability ([1e0d658](https://github.com/SUI-Components/sui/commit/1e0d658))
-* create sui-react-initial-props first version ([1201321](https://github.com/SUI-Components/sui/commit/1201321))
-* redefine the HoC and add missing dependency ([8ec10d7](https://github.com/SUI-Components/sui/commit/8ec10d7))
 
 
 

--- a/packages/sui-react-initial-props/README.md
+++ b/packages/sui-react-initial-props/README.md
@@ -14,7 +14,7 @@
 
 ```js
 // React Router routes
-import loadPage from '@schibstedspain/sui-react-initial-props/lib/loadPage'
+import loadPage from '@s-ui/react-initial-props/lib/loadPage'
 
 // context factory has to return a promise and it will be passed to the context of your components
 // as well as a param to the getInitialProps
@@ -40,7 +40,7 @@ export default (
 
 ```js
 // universal - React Router routes
-import loadPage from '@schibstedspain/sui-react-initial-props/lib/loadPage'
+import loadPage from '@s-ui/react-initial-props/lib/loadPage'
 
 // context factory has to return a promise and it will be passed to the context of your components
 // as well as a param to the getInitialProps
@@ -70,7 +70,7 @@ export default (
 import {
   createServerContextFactoryParams,
   ssrComponentWithInitialProps
-} from '@schibstedspain/sui-react-initial-props'
+} from '@s-ui/react-initial-props'
 
 function isomorphic (req, res, next) {
 contextFactory(

--- a/packages/sui-react-initial-props/package.json
+++ b/packages/sui-react-initial-props/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schibstedspain/sui-react-initial-props",
+  "name": "@s-ui/react-initial-props",
   "version": "1.2.0",
   "main": "lib/index.js",
   "description": "Provide a way to get initial props for async pages",
@@ -14,11 +14,11 @@
     "react": "15"
   },
   "devDependencies": {
-    "@schibstedspain/sui-component-peer-dependencies": "1",
+    "@s-ui/component-peer-dependencies": "1",
     "babel-cli": "6.24.1",
     "babel-preset-sui": "1"
   },
   "dependencies": {
-    "@schibstedspain/sui-hoc": "1"
+    "@s-ui/hoc": "1"
   }
 }

--- a/packages/sui-react-initial-props/package.json
+++ b/packages/sui-react-initial-props/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/react-initial-props",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "lib/index.js",
   "description": "Provide a way to get initial props for async pages",
   "scripts": {

--- a/packages/sui-react-initial-props/src/ssrComponentWithInitialProps.js
+++ b/packages/sui-react-initial-props/src/ssrComponentWithInitialProps.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOMServer from 'react-dom/server'
-import withContext from '@schibstedspain/sui-hoc/lib/withContext'
+import withContext from '@s-ui/hoc/lib/withContext'
 
 export default function ssrComponentWithInitialProps ({ Target, context, renderProps }) {
   // get the page with the initialProps

--- a/packages/sui-ssr/CHANGELOG.md
+++ b/packages/sui-ssr/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-<a name="1.1.0"></a>
-# 1.1.0 (2017-08-02)
+<a name="1.2.0"></a>
+# 1.2.0 (2017-09-15)
 
 
 ### Features
 
-* add package.json ([d1495ce](https://github.com/SUI-Components/sui/commit/d1495ce))
+* Move package from [@schibstedspain](https://github.com/schibstedspain) scope to [@s-ui](https://github.com/s-ui) org ([cef060f](https://github.com/SUI-Components/sui/commit/cef060f))
 
 
 

--- a/packages/sui-ssr/README.md
+++ b/packages/sui-ssr/README.md
@@ -11,5 +11,5 @@ SSR can be tought to configure and maintain. SSR handles that for you providing:
 ## Installation
 
 ```sh
-npm install @schibstedspain/sui-ssr --save
+npm install @s-ui/ssr --save
 ```

--- a/packages/sui-ssr/package.json
+++ b/packages/sui-ssr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@s-ui/ssr",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "> Plug SSR to you SUI SPA.",
   "main": "index.js",
   "scripts": {

--- a/packages/sui-ssr/package.json
+++ b/packages/sui-ssr/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schibstedspain/sui-ssr",
+  "name": "@s-ui/ssr",
   "private": true,
   "version": "1.1.0",
   "description": "> Plug SSR to you SUI SPA.",

--- a/packages/sui-studio-create/CHANGELOG.md
+++ b/packages/sui-studio-create/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+<a name="4.6.0"></a>
+# 4.6.0 (2017-09-15)
+
+
+### Features
+
+* Move package from [@schibstedspain](https://github.com/schibstedspain) scope to [@s-ui](https://github.com/s-ui) org ([95eb003](https://github.com/SUI-Components/sui/commit/95eb003))
+
+
+
 <a name="4.5.0"></a>
 # 4.5.0 (2017-08-17)
 
@@ -30,16 +40,6 @@ All notable changes to this project will be documented in this file.
 
 * improve phoenix scripts for generated pacakge.json ([dfd35e6](https://github.com/SUI-Components/sui/commit/dfd35e6))
 * wrong package.json generation ([16b7269](https://github.com/SUI-Components/sui/commit/16b7269))
-
-
-
-<a name="4.1.0"></a>
-# 4.1.0 (2017-06-25)
-
-
-### Features
-
-* add updated sui-studio-create behavior ([ec6677f](https://github.com/SUI-Components/sui/commit/ec6677f))
 
 
 

--- a/packages/sui-studio-create/README.md
+++ b/packages/sui-studio-create/README.md
@@ -6,7 +6,7 @@
 ## Installation
 
 ```sh
-$ npm install -g @schibstedspain/sui-studio-create
+$ npm install -g @s-ui/studio-create
 ```
 
 ## Usage

--- a/packages/sui-studio-create/package.json
+++ b/packages/sui-studio-create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/studio-create",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "description": " CLI to create studios for sui components development.",
   "main": "src/index.js",
   "bin": {

--- a/packages/sui-studio-create/package.json
+++ b/packages/sui-studio-create/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schibstedspain/sui-studio-create",
+  "name": "@s-ui/studio-create",
   "version": "4.5.0",
   "description": " CLI to create studios for sui components development.",
   "main": "src/index.js",

--- a/packages/sui-studio-create/src/index.js
+++ b/packages/sui-studio-create/src/index.js
@@ -5,7 +5,7 @@ const colors = require('colors')
 const program = require('commander')
 const BASE_DIR = process.cwd()
 const fse = require('fs-extra')
-const { getSpawnPromise } = require('@schibstedspain/sui-helpers/cli')
+const { getSpawnPromise } = require('@s-ui/helpers/cli')
 
 program
   .on('--help', () => {
@@ -94,8 +94,8 @@ Promise.all([
       "author": "",
       "license": "MIT",
       "devDependencies": {
-        "@schibstedspain/sui-precommit": "2",
-        "@schibstedspain/sui-studio": "4",
+        "@s-ui/precommit": "2",
+        "@s-ui/studio": "4",
         "husky": "0.13.4",
         "validate-commit-msg": "2.12.2"
       },
@@ -106,7 +106,7 @@ Promise.all([
           "deepLevel": 2
         },
         "validate-commit-msg": {
-          "types": "@schibstedspain/sui-mono/src/types"
+          "types": "@s-ui/mono/src/types"
         }
       }
     }

--- a/packages/sui-studio/CHANGELOG.md
+++ b/packages/sui-studio/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file.
 * fix: grouped logs break when an error happens ([a8adfb8](https://github.com/SUI-Components/sui/commit/a8adfb8))
 * log errors in fetching of styles ([029dd8f](https://github.com/SUI-Components/sui/commit/029dd8f))
 
+### Features
+
+* Move package from [@schibstedspain](https://github.com/schibstedspain) scope to [@s-ui](https://github.com/s-ui) org ([46fef87](https://github.com/SUI-Components/sui/commit/46fef87))
 
 
 <a name="4.26.0"></a>
@@ -275,6 +278,3 @@ All notable changes to this project will be documented in this file.
 ### BREAKING CHANGES
 
 * API is now named sui-studio instead of suistudio
-
-
-

--- a/packages/sui-studio/README.md
+++ b/packages/sui-studio/README.md
@@ -23,7 +23,7 @@ npm install sui-studio -g
 First install sui-studio:
 
 ```sh
-npm i -g @schibstedspain/sui-studio
+npm i -g @s-ui/studio
 sui-studio init <project_name>
 cd <project_name>
 ```

--- a/packages/sui-studio/bin/helpers/cli.js
+++ b/packages/sui-studio/bin/helpers/cli.js
@@ -4,7 +4,7 @@
  * @return {ChildProcess}
  */
 function callSuiMonoCommand (command) {
-  const BIN_PATH = require.resolve('@schibstedspain/sui-mono/bin/sui-mono')
+  const BIN_PATH = require.resolve('@s-ui/mono/bin/sui-mono')
   const [,, ...args] = process.argv
 
   callCommand(BIN_PATH, [command, ...args])

--- a/packages/sui-studio/bin/sui-studio-build.js
+++ b/packages/sui-studio/bin/sui-studio-build.js
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 /* eslint no-console:0 */
 
-const { serialSpawn } = require('@schibstedspain/sui-helpers/cli')
+const { serialSpawn } = require('@s-ui/helpers/cli')
 const {join} = require('path')
 
 console.log('\n', process.env.NODE_ENV, '\n')
 process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 
-const devServerExec = require.resolve('@schibstedspain/sui-bundler/bin/sui-bundler-build')
+const devServerExec = require.resolve('@s-ui/bundler/bin/sui-bundler-build')
 
 serialSpawn([
   [devServerExec, ['-C'], {shell: false, cwd: join(__dirname, '..')}],

--- a/packages/sui-studio/bin/sui-studio-deploy.js
+++ b/packages/sui-studio/bin/sui-studio-deploy.js
@@ -4,7 +4,7 @@
 const program = require('commander')
 const { getSpawnPromise, showError } = require('@s-ui/helpers/cli')
 const BUILD_FOLDER = './public'
-const DEPLOY_PATH = require.resolve('@s-ui/sui-deploy/bin/sui-deploy')
+const DEPLOY_PATH = require.resolve('@s-ui/deploy/bin/sui-deploy')
 
 program
   .usage('-n my-components')

--- a/packages/sui-studio/bin/sui-studio-deploy.js
+++ b/packages/sui-studio/bin/sui-studio-deploy.js
@@ -2,7 +2,7 @@
 /* eslint no-console:0 no-template-curly-in-string:0 */
 
 const program = require('commander')
-const { getSpawnPromise, showError } = require('@schibstedspain/sui-helpers/cli')
+const { getSpawnPromise, showError } = require('@s-ui/helpers/cli')
 const BUILD_FOLDER = './public'
 const DEPLOY_PATH = require.resolve('@s-ui/sui-deploy/bin/sui-deploy')
 

--- a/packages/sui-studio/bin/sui-studio-generate.js
+++ b/packages/sui-studio/bin/sui-studio-generate.js
@@ -5,8 +5,8 @@ const colors = require('colors')
 const fs = require('fs')
 const pascalCase = require('pascal-case')
 const spawn = require('child_process').spawn
-const {showError} = require('@schibstedspain/sui-helpers/cli')
-const {writeFile} = require('@schibstedspain/sui-helpers/file')
+const {showError} = require('@s-ui/helpers/cli')
+const {writeFile} = require('@s-ui/helpers/file')
 
 program
   .option('-R, --router', 'add routering for this component')
@@ -90,7 +90,7 @@ Promise.all([
       "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
     },
     "dependencies": {
-      "@schibstedspain/sui-component-dependencies": "latest"
+      "@s-ui/component-dependencies": "latest"
     },
     "keywords": [],
     "author": "",

--- a/packages/sui-studio/bin/sui-studio-init.js
+++ b/packages/sui-studio/bin/sui-studio-init.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-throw new Error('sui-studio init is not available anymore. Use @schibstedspain/sui-studio-create instead.')
+throw new Error('sui-studio init is not available anymore. Use @s-ui/studio-create instead.')

--- a/packages/sui-studio/bin/sui-studio.js
+++ b/packages/sui-studio/bin/sui-studio.js
@@ -4,7 +4,7 @@
 require('fs.realpath').monkeypatch()
 
 const program = require('commander')
-const { getSpawnPromise } = require('@schibstedspain/sui-helpers/cli')
+const { getSpawnPromise } = require('@s-ui/helpers/cli')
 const {join} = require('path')
 const pkg = require('../package.json')
 
@@ -17,7 +17,7 @@ program
   .command('start').alias('s')
   .option('-d, --dir-base [dir]', 'Setup base dir where live src and demo folders', '.')
   .action(({dirBase}) => {
-    const devServerExec = require.resolve('@schibstedspain/sui-bundler/bin/sui-bundler-dev')
+    const devServerExec = require.resolve('@s-ui/bundler/bin/sui-bundler-dev')
     getSpawnPromise(devServerExec, [], {shell: false, cwd: join(__dirname, '..'), env: process.env})
       .then(process.exit, process.exit)
   })

--- a/packages/sui-studio/package.json
+++ b/packages/sui-studio/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schibstedspain/sui-studio",
+  "name": "@s-ui/studio",
   "version": "4.27.0",
   "description": "Develop, maintain and publish your SUI components.",
   "main": "index.js",
@@ -26,10 +26,10 @@
   "dependencies": {
     "@s-ui/sui-deploy": "1",
     "@schibstedspain/ddd-react-redux": "2",
-    "@schibstedspain/sui-bundler": "2",
-    "@schibstedspain/sui-component-peer-dependencies": "latest",
-    "@schibstedspain/sui-helpers": "1",
-    "@schibstedspain/sui-mono": "1",
+    "@s-ui/bundler": "2",
+    "@s-ui/component-peer-dependencies": "latest",
+    "@s-ui/helpers": "1",
+    "@s-ui/mono": "1",
     "babel-standalone": "6.12.0",
     "bundle-loader": "0.5.4",
     "codemirror": "5.16.0",

--- a/packages/sui-studio/package.json
+++ b/packages/sui-studio/package.json
@@ -24,7 +24,7 @@
     "updtr": "0.2.0"
   },
   "dependencies": {
-    "@s-ui/sui-deploy": "1",
+    "@s-ui/deploy": "1",
     "@schibstedspain/ddd-react-redux": "2",
     "@s-ui/bundler": "2",
     "@s-ui/component-peer-dependencies": "latest",

--- a/packages/sui-studio/package.json
+++ b/packages/sui-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/studio",
-  "version": "4.27.0",
+  "version": "4.27.1",
   "description": "Develop, maintain and publish your SUI components.",
   "main": "index.js",
   "bin": {

--- a/packages/sui-studio/src/components/demo/index.js
+++ b/packages/sui-studio/src/components/demo/index.js
@@ -21,7 +21,7 @@ import {createStore} from '@schibstedspain/ddd-react-redux'
 const DEFAULT_CONTEXT = 'default'
 const EVIL_HACK_TO_RERENDER_AFTER_CHANGE = ' '
 const DDD_REACT_REDUX = '@schibstedspain/ddd-react-redux'
-const REACT_DOMAIN_CONNECTOR = '@schibstedspain/sui-react-domain-connector'
+const REACT_DOMAIN_CONNECTOR = '@s-ui/react-domain-connector'
 
 const createContextByType = (ctxt, type) => {
   // check if the user has created a context.js with the needed contextTypes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is step 1 of the following tasks:
* [x] Move all sui packages to npm @s-ui scope
* [ ] Release all packages to mew scope
* [ ] Redirect all sui packages @schisbtedspain to it @s-ui equivalence
* [ ] Deprecate all sui packages @schisbtedspain
* [x] Modify sui-studio generate to include @s-ui dependencies
* [x] Modify sui-studio-create to include @s-ui dependencies