### PR TITLE
feat(sui-studio): mark and search by compliant

### DIFF
--- a/packages/sui-studio/src/components/icons/index.js
+++ b/packages/sui-studio/src/components/icons/index.js
@@ -20,3 +20,10 @@ export const iconClose = (
     <path d='M0 0h24v24H0z' fill='none' />
   </svg>
 )
+
+export const iconStart = (
+  <svg xmlns="http://www.w3.org/2000/svg" fill="burlywood" height="18" viewBox="0 0 18 18" width="18">
+    <path d="M9 11.3l3.71 2.7-1.42-4.36L15 7h-4.55L9 2.5 7.55 7H3l3.71 2.64L5.29 14z"/>
+    <path d="M0 0h18v18H0z" fill="none"/>
+  </svg>
+)

--- a/packages/sui-studio/src/components/icons/index.js
+++ b/packages/sui-studio/src/components/icons/index.js
@@ -22,8 +22,8 @@ export const iconClose = (
 )
 
 export const iconStart = (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="burlywood" height="18" viewBox="0 0 18 18" width="18">
-    <path d="M9 11.3l3.71 2.7-1.42-4.36L15 7h-4.55L9 2.5 7.55 7H3l3.71 2.64L5.29 14z"/>
-    <path d="M0 0h18v18H0z" fill="none"/>
+  <svg xmlns='http://www.w3.org/2000/svg' fill='burlywood' height='18' viewBox='0 0 18 18' width='18'>
+    <path d='M9 11.3l3.71 2.7-1.42-4.36L15 7h-4.55L9 2.5 7.55 7H3l3.71 2.64L5.29 14z' />
+    <path d='M0 0h18v18H0z' fill='none' />
   </svg>
 )

--- a/packages/sui-studio/src/components/navigation/_style.scss
+++ b/packages/sui-studio/src/components/navigation/_style.scss
@@ -64,6 +64,10 @@
         color: darken($c-primary, 10%);
         pointer-events: none;
       }
+
+      &Item {
+        display: flex;
+      }
     }
 
     &Title {

--- a/packages/sui-studio/src/components/navigation/index.js
+++ b/packages/sui-studio/src/components/navigation/index.js
@@ -1,11 +1,15 @@
 import React, {Component, PropTypes} from 'react'
 import {Link} from 'react-router'
 import Logo from './Logo'
+import {iconStart} from '../icons'
 
-import { getComponentsList, getStudioName } from '../utils'
+import { getComponentsList, getStudioName, getStudioCompliant } from '../utils'
 
 const componentsList = getComponentsList()
 const studioName = getStudioName()
+const compliant = getStudioCompliant()
+
+const SEARCH_BY_COMPLIANT = '*'
 
 export default class Navigation extends Component {
   state = { search: '' }
@@ -19,11 +23,20 @@ export default class Navigation extends Component {
   }
 
   _filterComponentsFromSearch ({ search }) {
+    if (search === SEARCH_BY_COMPLIANT) {
+      return componentsList
+               .filter(({category, component}) => this._isCompliant({category, component}))
+    }
+
     return componentsList
             .filter(
               ({category, component}) =>
                 category.includes(search) || component.includes(search)
             )
+  }
+
+  _isCompliant ({category, component}) {
+    return compliant.includes(`${category}/${component}`)
   }
 
   _renderListFilteredBySearch ({ handleClick, search }) {
@@ -53,7 +66,13 @@ export default class Navigation extends Component {
                     onClick={handleClick}
                     to={`/workbench/${category}/${component}`}
                   >
-                    {component}
+                    <div className='sui-StudioNav-menuLinkItem'>
+                      <span>{component}</span>
+                      {
+                        this._isCompliant({category, component}) &&
+                        <i className='sui-StudioNav-menuLinkItemStart'>{iconStart}</i>
+                      }
+                    </div>
                   </Link>
                 </li>
               )

--- a/packages/sui-studio/src/components/utils.js
+++ b/packages/sui-studio/src/components/utils.js
@@ -1,6 +1,8 @@
 /* global __BASE_DIR__ */
 const DEFAULT_LOGO = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 470 340.6'> <path fill='#e30613' d='M129.6 170.3c0-58.6 29.6-110.2 74.6-140.8L155.5 1.8c-4.2-2.4-9.3-2.3-13.5.1L6.7 81.2C2.5 83.6 0 88.1 0 92.9v156.9c0 4.8 2.6 9.2 6.8 11.6l137.4 77.5c4.2 2.3 9.4 2.3 13.6-.2l46.7-27.4c-45.2-30.6-74.9-82.3-74.9-141z' /> <path fill='#009fe3' d='M299.8.1c-35.4 0-68.3 10.8-95.6 29.4l87.7 49.8c4.2 2.4 6.8 6.8 6.8 11.6l1.1 156.8c0 4.8-2.5 9.3-6.7 11.7l-88.6 51.9c27.2 18.4 60 29.2 95.3 29.2 94 0 170.2-76.2 170.2-170.2S393.8.1 299.8.1z' /> <path fill='#000411' d='M299.8 247.7l-1.1-156.8c0-4.8-2.6-9.2-6.8-11.6l-87.7-49.8c-45 30.6-74.6 82.3-74.6 140.8 0 58.7 29.7 110.4 74.9 141l88.6-51.9c4.2-2.4 6.7-6.9 6.7-11.7z' /></svg>"
 
+const DEFAULT_COMPLIANT = []
+
 export const getComponentsList = () => {
   const reqPackages = require.context(`${__BASE_DIR__}/components`, true, /^\.\/\w+\/\w+\/package\.json/)
   return reqPackages
@@ -26,6 +28,11 @@ export const getStudioName = () => {
 export const getStudioLogo = () => {
   const config = getSuiStudioConfig()
   return config.logo || DEFAULT_LOGO
+}
+
+export const getStudioCompliant = () => {
+  const config = getSuiStudioConfig()
+  return config.compliant || DEFAULT_COMPLIANT
 }
 
 export const isEmptyObject = obj => {


### PR DESCRIPTION
Now you can mark a component like a compliant component using the stadio´s package.json

<img width="688" alt="captura de pantalla 2017-09-19 a las 17 13 15" src="https://user-images.githubusercontent.com/179462/30599790-dee91110-9d5d-11e7-97bb-221ba5003628.png">

And if you want search by all compliant component in the studio, you can search by "*"

![search_by_compliant](https://user-images.githubusercontent.com/179462/30599823-faaea310-9d5d-11e7-872d-fb73f66a9ed3.gif)

