### PR TITLE
fix(sui-studio): fix studio not working in IE browsers

### DIFF
--- a/packages/sui-studio/package.json
+++ b/packages/sui-studio/package.json
@@ -24,12 +24,13 @@
     "updtr": "0.2.0"
   },
   "dependencies": {
-    "@s-ui/deploy": "1",
-    "@schibstedspain/ddd-react-redux": "2",
     "@s-ui/bundler": "2",
     "@s-ui/component-peer-dependencies": "latest",
+    "@s-ui/deploy": "1",
     "@s-ui/helpers": "1",
     "@s-ui/mono": "1",
+    "@s-ui/polyfills": "1",
+    "@schibstedspain/ddd-react-redux": "2",
     "babel-standalone": "6.12.0",
     "bundle-loader": "0.5.4",
     "codemirror": "5.16.0",

--- a/packages/sui-studio/src/app.js
+++ b/packages/sui-studio/src/app.js
@@ -1,3 +1,4 @@
+import '@s-ui/polyfills'
 import React from 'react'
 import reactDOM from 'react-dom'
 import { AppContainer } from 'react-hot-loader'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Studio was broken in IE, because of the absence of Array.prototype.includes
Polyfills were added.

@carlosvillu @miduga please review