### PR TITLE
feat(babel-preset-sui): replace es2015 preset by env

### DIFF
--- a/packages/babel-preset-sui/lib/index.js
+++ b/packages/babel-preset-sui/lib/index.js
@@ -3,14 +3,25 @@ const cleanList = require('./clean-list')
 
 module.exports = {
   'presets': cleanList([
-    require('babel-preset-es2015'),
+    ["env", {
+      "debug": false,
+      "targets": {
+        "node": "6.0.0",
+        "browsers": [
+          "> 1%",
+          "last 4 versions",
+          "Firefox ESR",
+          "Safari >= 6",
+          "iOS >= 7",
+          "not ie < 11"
+        ]
+      }
+    }],
     isInstalled(['preact', 'react'], 'babel-preset-react'),
     isInstalled('flow-bin', 'babel-preset-flow')
   ]),
   'plugins': [
-    require('babel-plugin-syntax-trailing-function-commas'),
     require('babel-plugin-transform-async-generator-functions'),
-    require('babel-plugin-transform-async-to-generator'),
     require('babel-plugin-transform-decorators-legacy').default,
     require('babel-plugin-transform-class-properties'),
     require('babel-plugin-transform-object-rest-spread'),

--- a/packages/babel-preset-sui/package.json
+++ b/packages/babel-preset-sui/package.json
@@ -8,16 +8,14 @@
   "license": "MIT",
   "dependencies": {
     "babel-plugin-syntax-dynamic-import": "6.18.0",
-    "babel-plugin-syntax-trailing-function-commas": "6.22.0",
     "babel-plugin-transform-async-generator-functions": "6.24.1",
-    "babel-plugin-transform-async-to-generator": "6.24.1",
     "babel-plugin-transform-class-properties": "6.24.1",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "babel-plugin-transform-export-extensions": "6.22.0",
     "babel-plugin-transform-object-rest-spread": "6.26.0",
     "babel-plugin-transform-react-remove-prop-types": "0.4.8",
     "babel-plugin-transform-runtime": "6.23.0",
-    "babel-preset-es2015": "6.24.1",
+    "babel-preset-env": "1.6.0",
     "babel-preset-flow": "6.23.0",
     "babel-preset-react": "6.24.1",
     "react-hot-loader": "3.0.0-beta.6"


### PR DESCRIPTION
ISSUES CLOSED: #122

No improvement of final build... Even trying to build only for Chrome it doesn't seem to be worth having separated bundles by env.