### PR TITLE
feat(sui-hoc): fix proptypes and prepare for react 16 using external proptypes library

### DIFF
--- a/packages/sui-hoc/package.json
+++ b/packages/sui-hoc/package.json
@@ -10,7 +10,8 @@
   "author": "",
   "license": "ISC",
   "peerDependencies": {
-    "react": "15"
+    "prop-types": "15",
+    "react": "15 || 16"
   },
   "devDependencies": {
     "@s-ui/component-peer-dependencies": "1",

--- a/packages/sui-hoc/src/withContext.js
+++ b/packages/sui-hoc/src/withContext.js
@@ -1,9 +1,10 @@
-import React, {Component, PropTypes} from 'react'
+import React, {Component} from 'react'
+import PropTypes from 'prop-types'
 
 export default context => Target => class extends Component {
   static displayName = `withContext(${Target.displayName})`
   static childContextTypes = Object.keys(context).reduce((acc, key) => {
-    acc[key] = PropTypes.object
+    acc[key] = PropTypes.any
     return acc
   }, {})
 


### PR DESCRIPTION
This fixes the problem with the warnings about the contextTypes when using the hoc to add context to a component. It also uses the external prop-types library to be prepared when using React 16 library version.