### PR TITLE
feat(sui-react-initial-props): use prop-types library

### DIFF
--- a/packages/sui-react-initial-props/package.json
+++ b/packages/sui-react-initial-props/package.json
@@ -11,7 +11,8 @@
   "author": "",
   "license": "ISC",
   "peerDependencies": {
-    "react": "15"
+    "prop-types": "15",
+    "react": "15 || 16"
   },
   "devDependencies": {
     "@s-ui/component-peer-dependencies": "1",

--- a/packages/sui-react-initial-props/src/loadPage.js
+++ b/packages/sui-react-initial-props/src/loadPage.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 
 import withInitialProps from './withInitialProps'
 import createClientContextFactoryParams from './createClientContextFactoryParams'


### PR DESCRIPTION
Move to prop-types library in order to be able to use React 16.