### PR TITLE
fix(sui-studio): fix linting error with new import when generating a component

### DIFF
--- a/packages/sui-studio/bin/sui-studio-generate.js
+++ b/packages/sui-studio/bin/sui-studio-generate.js
@@ -117,7 +117,7 @@ node_modules`),
   writeFile(
   COMPONENT_ENTRY_JS_POINT_FILE,
   `import React, {Component} from 'react'
-   import PropTypes from 'prop-types'
+import PropTypes from 'prop-types'
 
 class ${componentInPascal} extends Component {
   render () {


### PR DESCRIPTION
Fix linting warning when creating a new component because not needed spaces before the line.