### PR TITLE
feat(sui-bundler): use new uglifyJSPlugin version

### DIFF
--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -59,9 +59,10 @@
     "script-ext-html-webpack-plugin": "1.8.5",
     "style-loader": "0.18.2",
     "sw-precache-webpack-plugin": "0.11.4",
+    "uglifyjs-webpack-plugin": "1.0.1",
     "url-loader": "0.5.9",
     "webpack": "3.4.0",
-    "webpack-bundle-analyzer": "2.8.3",
+    "webpack-bundle-analyzer": "2.9.0",
     "webpack-dev-middleware": "1.11.0",
     "webpack-hot-middleware": "2.18.2",
     "webpack-manifest-plugin": "1.2.1"

--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -9,6 +9,7 @@ const ManifestPlugin = require('webpack-manifest-plugin')
 const SWPrecacheWebpackPlugin = require('sw-precache-webpack-plugin')
 const Externals = require('./plugins/externals')
 const path = require('path')
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
 
 const {when, cleanList, envVars, MAIN_ENTRY_POINT, config} = require('./shared')
 const {navigateFallbackWhitelist, navigateFallback, runtimeCaching, directoryIndex} = require('./shared/precache')
@@ -104,19 +105,10 @@ module.exports = {
       ),
       staticFileGlobsIgnorePatterns: [/\.map$/, /asset-manifest\.json$/]
     })),
-    new webpack.optimize.UglifyJsPlugin({
-      compress: {
-        warnings: false,
-        // Disabled because of an issue with Uglify breaking seemingly valid code:
-        // https://github.com/facebookincubator/create-react-app/issues/2376
-        // Pending further investigation:
-        // https://github.com/mishoo/UglifyJS2/issues/2011
-        comparisons: false
-      },
-      output: {
-        comments: false
-      },
-      sourceMap: true
+    new UglifyJsPlugin({
+      cache: true,
+      parallel: true,
+      sourceMap: false
     }),
     when(config.externals, () => new Externals({files: config.externals})),
     new webpack.LoaderOptionsPlugin({


### PR DESCRIPTION
It has a new parallelisation flag in order to do in parallel the uglification of the files.

A quick test of before and after building same application:
```
before
CDN=/ NODE_ENV=production npm run build  43.83s user 2.99s system 102% cpu 45.744 total

after
CDN=/ NODE_ENV=production npm run build 28.49s user 3.02s system 95% cpu 33.110 total
```