### PR TITLE
feat(sui-js): adding js-cookie top sui-js

### DIFF
--- a/packages/sui-js/README.md
+++ b/packages/sui-js/README.md
@@ -14,3 +14,25 @@ const {isMobile, osName} = stats(userAgent)
 domain.config('isMobile', isMobile) // bool
 domain.config('osName', osName) // string
 ```
+
+
+## cookie
+Parse, get and set cookies. Returns an object `cookie` with `parse`, `get` and `set` methods.
+
+**Note:** `set` method does not work on server side.
+
+```js
+import cookie from '@s-ui/js/lib/cookie'
+
+// Parse
+const {parse} = cookie
+domain.config('cookie', parse(cookies))
+
+// Get
+const {get: getCookie} = cookie
+const smartBannerCookie = getCookie('smartbanner')
+
+// Set
+const {set: setCookie} = cookie
+const setSmartBannerCookie = setCookie('smartbanner', 1)
+```

--- a/packages/sui-js/package.json
+++ b/packages/sui-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/js",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "Set of JS utilities",
   "scripts": {
     "lib": "rm -Rf ./lib && mkdir -p ./lib && babel --presets sui ./src --out-dir ./lib",

--- a/packages/sui-js/package.json
+++ b/packages/sui-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/js",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "description": "Set of JS utilities",
   "scripts": {
     "lib": "rm -Rf ./lib && mkdir -p ./lib && babel --presets sui ./src --out-dir ./lib",
@@ -9,7 +9,9 @@
   "keywords": [],
   "author": "Joan Claret <dpam23@gmail.com>",
   "dependencies": {
-    "bowser": "1.8.1"
+    "bowser": "1.8.1",
+    "js-cookie": "2.1.4",
+    "cookie": "0.3.1"
   },
   "license": "MIT",
   "repository": {

--- a/packages/sui-js/src/cookie/index.js
+++ b/packages/sui-js/src/cookie/index.js
@@ -1,0 +1,14 @@
+import {parse as parseCookie} from 'cookie'
+import jsCookie from 'js-cookie'
+
+const parse = (cookie) => parseCookie(cookie)
+const get = (key) => jsCookie.get(key)
+const set = (key, val) => jsCookie.set(key, val)
+
+const cookie = {
+  parse,
+  get,
+  set
+}
+
+export default cookie


### PR DESCRIPTION
## Description
Parse, get and set cookies. Returns an object `cookie` with `parse`, `get` and `set` methods.

**Note:** `set` method does not work on server side.

```js
import cookie from '@s-ui/js/lib/cookie'

// Parse
const {parse} = cookie
domain.config('cookie', parse(cookies))

// Get
const {get: getCookie} = cookie
const smartBannerCookie = getCookie('smartbanner')

// Set
const {set: setCookie} = cookie
const setSmartBannerCookie = setCookie('smartbanner', 1)
```