### PR TITLE
feat(sui-js): add string utilities

### DIFF
--- a/packages/sui-js/README.md
+++ b/packages/sui-js/README.md
@@ -41,8 +41,8 @@ const setSmartBannerCookie = setCookie('smartbanner', 1)
 A bunch of string utilities: remove accents, ...
 
 ```js
-import { removeAccents } from '@s-ui/js/lib/string'
+import { removeAccents, hasAccents } from '@s-ui/js/lib/string'
 
-console.log(removeAccents('París')) // Paris
-console.log(removeAccents('Árbol')) // Arbol
+console.log(removeAccents('París')) // "Paris"
+console.log(hasAccents('Árbol')) // true
 ```

--- a/packages/sui-js/README.md
+++ b/packages/sui-js/README.md
@@ -36,3 +36,13 @@ const smartBannerCookie = getCookie('smartbanner')
 const {set: setCookie} = cookie
 const setSmartBannerCookie = setCookie('smartbanner', 1)
 ```
+
+## string
+A bunch of string utilities: remove accents, ...
+
+```js
+import { removeAccents } from '@s-ui/js/lib/string'
+
+console.log(removeAccents('París')) // Paris
+console.log(removeAccents('Árbol')) // Arbol
+```

--- a/packages/sui-js/package.json
+++ b/packages/sui-js/package.json
@@ -10,8 +10,9 @@
   "author": "Joan Claret <dpam23@gmail.com>",
   "dependencies": {
     "bowser": "1.8.1",
+    "cookie": "0.3.1",
     "js-cookie": "2.1.4",
-    "cookie": "0.3.1"
+    "remove-accents": "0.4.2"
   },
   "license": "MIT",
   "repository": {

--- a/packages/sui-js/src/string/index.js
+++ b/packages/sui-js/src/string/index.js
@@ -1,0 +1,4 @@
+import accents from 'remove-accents'
+
+export const hasAccents = accents.has
+export const removeAccents = accents.remove


### PR DESCRIPTION
## Description
Add a bunch of string utilities (`sui-js`). For now: `removeAccents` and `hasAccents` methods. Use npm `remove-accents` third-party package.

## Example
```js
import { removeAccents, hasAccents } from '@s-ui/js/lib/string'

console.log(removeAccents('París')) // "Paris"
console.log(hasAccents('Árbol')) // true
```

Please review @SUI-Components/developers !