### PR TITLE
feat(sui-widget-embedder): Changed innerHTML by appendChild to avoid …

### DIFF
--- a/packages/sui-widget-embedder/src-react/render.js
+++ b/packages/sui-widget-embedder/src-react/render.js
@@ -1,7 +1,10 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 
-document.body.innerHTML += '<div id="root"></div>'
+const rootElement = document.createElement('div')
+rootElement.setAttribute('id', 'root')
+document.body.appendChild(rootElement)
+
 export default function render (root) {
   ReactDOM.render(<div>{root}</div>, document.querySelector('#root'))
 }


### PR DESCRIPTION
# Usage of InnerHTML on body resets event listeners on all it's childs (whole web)
## Description
A bug was detected due the usage on vibbo. After bundle.js load, some events stopped to work. Doing a research using slow conection trothing I have founded that the problem was focused with the bundle.js file. Checking line by line of the widget and disabling comment by comment I've founded that the problem was exactly on the import of the widget render. After do some try and failure and analyse the code I realise about the usage of InnerHTML. 

Doing the change and testing it on vibbo all started to work again. After do a research and learn more about InnerHTML I've founded multiple articles talking about not to use it but this one is the most relevant for our case:

https://stackoverflow.com/questions/595808/is-it-possible-to-append-to-innerhtml-without-destroying-descendants-event-list

