### PR TITLE
feat(sui-widget-embedder): added remoteCdn option on build command to…

### DIFF
--- a/packages/sui-widget-embedder/README.md
+++ b/packages/sui-widget-embedder/README.md
@@ -35,7 +35,7 @@ Your project must follow the following folder structure:
 ```
 "config": {
   "sui-widget-embedder": {
-    "cdn": "http://cdn-widgets-vibbo.surge.sh",
+    "remoteCdn": "http://cdn-widgets-vibbo-pro.surge.sh",
     "devPort": "2017",
     "target": "https://vibbo.com"
   }
@@ -44,8 +44,8 @@ Your project must follow the following folder structure:
 
 Inside your project-level package.json, you must config the library,
 
-* cdn [REQUIRED]: the base path of the cdn where your assets will be located
-* devPor [OPTIONAL] (DEFAULT=3000): Port where your development server will be listening
+* remoteCdn [REQUIRED]: the base path of the cdn where your assets will be located
+* devPort [OPTIONAL] (DEFAULT=3000): Port where your development server will be listening
 * target [REQUIRED]: protocol and host from the site that you want to develop
 
 ### page config
@@ -102,8 +102,19 @@ $ sui-widget-embedder dev -p detail /vivienda/malaga-capital/aire-acondicionado-
 ```
 When you provide a path like last argument to the CLI you must go to `localhost:[port_setting]/static` to have a static version of the page
 
+# How to build
 
+If you want to get the remoteCdn from package config you just need to do that:
 
+```
+$ sui-widget-embedder build
+```
+
+If you want to define the remoteCdn by command option you can pass it using the param -R or --remoteCdn
+
+```
+$ sui-widget-embedder build -R http://mycdn.com
+```
 
 ## Contributing
 

--- a/packages/sui-widget-embedder/bin/sui-widget-embedder-build.js
+++ b/packages/sui-widget-embedder/bin/sui-widget-embedder-build.js
@@ -23,6 +23,7 @@ const config = pkg['config']['sui-widget-embedder']
 
 program
   .option('-C, --clean', 'Remove public folder before create a new one')
+  .option('-R --remoteCdn <url>', 'Remote url where the downloader will be placed')
   .on('--help', () => {
     console.log('  Description:')
     console.log('')
@@ -32,8 +33,13 @@ program
     console.log('')
     console.log('    $ sui-widget-embedder build')
     console.log('')
+    console.log(' You can even choose where should the downloader going to get the files:')
+    console.log('    $ sui-widget-embedder build -remoteCdn http://mysourcedomain.com')
+    console.log('')
   })
   .parse(process.argv)
+
+const remoteCdn = program.remoteCdn || config.remoteCdn
 
 if (program.clean) {
   console.log('Removing previous build...')
@@ -100,7 +106,7 @@ const createDownloader = () =>
         staticModule({
           'static-manifests': () => JSON.stringify(staticManifests),
           'static-pathnamesRegExp': () => JSON.stringify(staticPathnamesRegExp),
-          'static-cdn': () => JSON.stringify(config.cdn)
+          'static-cdn': () => JSON.stringify(remoteCdn)
         })
       )
       .pipe(minifyStream({ sourceMap: false }))
@@ -124,7 +130,7 @@ const createSW = () =>
       Object.keys(staticManifests).map(page => {
         const manifest = staticManifests[page]
         return Object.keys(manifest)
-          .map(entry => `${config.cdn}/${page}/${manifest[entry]}`)
+          .map(entry => `${remoteCdn}/${page}/${manifest[entry]}`)
           .filter(url => !url.endsWith('.map'))
       })
     )
@@ -136,7 +142,7 @@ const createSW = () =>
       .pipe(
         staticModule({
           'static-cache': () => JSON.stringify(staticCache),
-          'static-cdn': () => JSON.stringify(config.cdn)
+          'static-cdn': () => JSON.stringify(remoteCdn)
         })
       )
       .pipe(minifyStream({ sourceMap: false }))


### PR DESCRIPTION
# Remote CDN option
## Description
This pr adds the feature to implement the remoteCdn command that allows us build our sw.js pointing to the CDN URL that we desire.

## Example
```
sui-widget-embeder build -R http://mycdnurl.com
```
