### PR TITLE
feat(sui-react-domain-connector): add static method getInitialProps w…

### DIFF
--- a/packages/sui-react-domain-connector/src/mapConfigToProps.js
+++ b/packages/sui-react-domain-connector/src/mapConfigToProps.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 const mapConfigToProps = (...configs) => Target => {
   class DDDConfigInjector extends Component {
     static displayName = `mapConfigToProps(${Target.displayName})`
+    static getInitialProps = Target.getInitialProps
     static contextTypes = {
       domain: PropTypes.object.isRequired
     }

--- a/packages/sui-react-domain-connector/src/mapUIResponseToProps.js
+++ b/packages/sui-react-domain-connector/src/mapUIResponseToProps.js
@@ -10,6 +10,7 @@ const mapUIResponseToProps = (...paths) => Target => {
 
   Enhance.originalContextTypes = Target.originalContextTypes || Target.contextTypes
   Enhance.displayName = `mapUIResponseToProps(${Target.displayName})`
+  Enhance.getInitialProps = Target.getInitialProps
   return Enhance
 }
 

--- a/packages/sui-react-domain-connector/src/mapUIServiceToProps.js
+++ b/packages/sui-react-domain-connector/src/mapUIServiceToProps.js
@@ -8,6 +8,7 @@ const toTitle = str => {
 
 const mapUIServiceToProps = (...paths) => Target => class Enhance extends Component {
   static displayName = `mapUIServiceToProps(${Target.displayName})`
+  static getInitialProps = Target.getInitialProps
   static originalContextTypes = Target.originalContextTypes || Target.contextTypes
   static contextTypes = {
     store: PropTypes.object.isRequired

--- a/packages/sui-react-domain-connector/src/withLocalService.js
+++ b/packages/sui-react-domain-connector/src/withLocalService.js
@@ -7,6 +7,7 @@ const snakeToCamel = str => str.replace(/(_\w)/g, match => match[1].toUpperCase(
 const withLocalService = (...services) => Target => {
   class DDDLocalServicesInjector extends Component {
     static displayName = `withLocalService(${Target.displayName})`
+    static getInitialProps = Target.getInitialProps
     static originalContextTypes = Target.originalContextTypes || Target.contextTypes
     static contextTypes = {
       domain: PropTypes.object.isRequired

--- a/packages/sui-react-domain-connector/src/withStreamService.js
+++ b/packages/sui-react-domain-connector/src/withStreamService.js
@@ -6,6 +6,7 @@ const snakeToCamel = str => str.replace(/(_\w)/g, match => match[1].toUpperCase(
 
 const withStreamService = (...services) => Target => class DDDStreamServicesInjector extends Component {
   static displayName = `withStreamService(${Target.displayName})`
+  static getInitialProps = Target.getInitialProps
   static originalContextTypes = Target.originalContextTypes || Target.contextTypes
   static contextTypes = {
     domain: PropTypes.object.isRequired


### PR DESCRIPTION
…hen defined in component.

This PR is created to include the static method getInitialProps when is defined in the base component.

## Description
When trying to use the sui-react-domain-connector in the integration of New Construction Detail page in fotocasa web server, we found a problem that didn't let us to get anything retrieved from the static method getInitialProps (as it is not set in the mapUIServiceToProps) in our component's render function.
After some debugging, we realized that the method was not recovered from the base class, so we have included it in all files.


