### PR TITLE
feat(sui-js): add getjson method

### DIFF
--- a/packages/sui-js/src/cookie/index.js
+++ b/packages/sui-js/src/cookie/index.js
@@ -3,11 +3,13 @@ import jsCookie from 'js-cookie'
 
 const parse = (cookie) => parseCookie(cookie)
 const get = (key) => jsCookie.get(key)
+const getJSON = (key) => jsCookie.getJSON(key)
 const set = (key, val) => jsCookie.set(key, val)
 
 const cookie = {
   parse,
   get,
+  getJSON,
   set
 }
 

--- a/packages/sui-js/src/cookie/index.js
+++ b/packages/sui-js/src/cookie/index.js
@@ -5,12 +5,14 @@ const parse = (cookie) => parseCookie(cookie)
 const get = (key) => jsCookie.get(key)
 const getJSON = (key) => jsCookie.getJSON(key)
 const set = (key, val) => jsCookie.set(key, val)
+const remove = (key) => jsCookie.remove(key)
 
 const cookie = {
   parse,
   get,
   getJSON,
-  set
+  set,
+  remove
 }
 
 export default cookie


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds support for `getJSON` method that will return the parsed representation of the string stored in the cookie according to `JSON.parse`.

## Example
```
jsCookie.getJSON('myKey'); // => { foo: 'bar' }
```