### PR TITLE
refactor(sui-studio): changed the theme to be used on our index.scss from theme-basic to sui-theme

### DIFF
--- a/packages/sui-studio/bin/sui-studio-generate.js
+++ b/packages/sui-studio/bin/sui-studio-generate.js
@@ -141,7 +141,7 @@ export default ${componentInPascal}`
 
   writeFile(
   COMPONENT_ENTRY_SCSS_POINT_FILE,
-  `@import '~@schibstedspain/theme-basic/lib/index';
+  `@import '~@schibstedspain/sui-theme/lib/index';
 
 .${prefix}-${componentInPascal} {
   // Do your magic


### PR DESCRIPTION
## Description
refactor(sui-studio): changed the theme to be used on our index.scss from theme-basic to sui-theme
Now the index.scss files inside our created components will have the sui-theme import intead of have the theme-basic
Changed generator to have the import of sui-theme

## Related Issue
https://jira.scmspain.com/browse/SM-2721
