### PR TITLE
feat(sui-component-peer-dependencies): update sui peer dependencies to latest React and React Router

### DIFF
--- a/packages/sui-component-peer-dependencies/package.json
+++ b/packages/sui-component-peer-dependencies/package.json
@@ -11,9 +11,9 @@
   "license": "MIT",
   "dependencies": {
     "prop-types": "15.6",
-    "react": "15.4",
-    "react-dom": "15.4",
-    "react-router": "2"
+    "react": "16.2",
+    "react-dom": "16.2",
+    "react-router": "3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updating sui-component-peer-dependencies to latest React and React Router.

Specially important to be able to use new <Fragment> API https://reactjs.org/docs/react-api.html#reactfragment.

React Router 3 is needed as the 2 version is not longer compatible with React 16.