### PR TITLE
Feature/new props page and optimizations

### DIFF
--- a/packages/sui-studio/package.json
+++ b/packages/sui-studio/package.json
@@ -24,13 +24,13 @@
     "updtr": "0.2.0"
   },
   "dependencies": {
-    "@s-ui/deploy": "1",
-    "@s-ui/react-domain-connector": "1",
     "@s-ui/bundler": "2",
     "@s-ui/component-peer-dependencies": "latest",
+    "@s-ui/deploy": "1",
     "@s-ui/helpers": "1",
     "@s-ui/mono": "1",
     "@s-ui/polyfills": "1",
+    "@s-ui/react-domain-connector": "1",
     "@schibstedspain/ddd-react-redux": "2",
     "babel-standalone": "6.12.0",
     "bundle-loader": "0.5.4",
@@ -49,11 +49,9 @@
     "pascal-case": "2.0.0",
     "pmx": "0.6.2",
     "react-codemirror": "1.0.0",
-    "react-docgen": "2.9.1",
-    "react-docs-markdown": "0.3.4",
-    "react-render-html": "0.5.0",
+    "react-docgen": "2.20.0",
     "react-test-renderer": "15.3.2",
-    "showdown": "1.7.3"
+    "snarkdown": "1.2.2"
   },
   "suistudio-webpack": {
     "vendor": [

--- a/packages/sui-studio/src/components/documentation/Markdown.js
+++ b/packages/sui-studio/src/components/documentation/Markdown.js
@@ -1,13 +1,6 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import showdown from 'showdown'
-import renderHTML from 'react-render-html'
-
-const converter = new showdown.Converter()
-converter.setOption('tables', true)
-converter.setOption('simpleLineBreaks', true)
-converter.setOption('ghCompatibleHeaderId', true)
-converter.setFlavor('github')
+import snarkdown from 'snarkdown'
 
 export default class Markdown extends Component {
   propTypes = {
@@ -17,9 +10,9 @@ export default class Markdown extends Component {
   render () {
     const {content} = this.props
     return (content &&
-      <div className='markdown-body'>
-        {renderHTML(converter.makeHtml(content))}
-      </div>
+      <div
+        className='markdown-body'
+        dangerouslySetInnerHTML={{ __html: snarkdown(content) }} />
     )
   }
 }

--- a/packages/sui-studio/src/components/documentation/ReactDocGen.js
+++ b/packages/sui-studio/src/components/documentation/ReactDocGen.js
@@ -30,8 +30,13 @@ class ReactDocGen extends Component {
       const { defaultValue = {}, required, type, description } = propsApi[propName]
       const { value = undefined } = defaultValue
 
+      if (typeof type === 'undefined') {
+        console.warn('It seem that you might have a prop with a defaultValue but it does not exist as propType')
+        return
+      }
+
       return (
-        <div className='sui-StudioProps-prop' key='propName'>
+        <div className='sui-StudioProps-prop' key={propName}>
           <h3>{propName}</h3>
           <div className='sui-StudioProps-tags'>
             <div className='sui-StudioProps-tag sui-StudioProps-required'>

--- a/packages/sui-studio/src/components/documentation/ReactDocGen.js
+++ b/packages/sui-studio/src/components/documentation/ReactDocGen.js
@@ -1,8 +1,6 @@
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import React, { Component, Fragment } from 'react'
 import tryRequire from './try-require'
-import docsToMarkdown from 'react-docs-markdown'
-import Markdown from './Markdown'
 const reactDocs = require('react-docgen')
 
 class ReactDocGen extends Component {
@@ -13,23 +11,68 @@ class ReactDocGen extends Component {
     })
   }
 
-  state = { parsed: false }
+  state = { docs: false }
 
   componentDidMount () {
     tryRequire(this.props.params).then(([src, _]) =>
-      this.setState({ parsed: reactDocs.parse(src) })
+      this.setState({ docs: reactDocs.parse(src) })
     )
   }
 
-  render () {
-    const { parsed } = this.state
-    let markdown = null
-    if (parsed) {
-      const { params: { category, component } } = this.props
-      const componentTitle = `${parsed.displayName} (${category}/${component})`
-      markdown = docsToMarkdown(parsed, componentTitle)
+  _renderPropsApi ({ propsApi = {} }) {
+    const keysOfProps = Object.keys(propsApi)
+    // if the component doesn't have props, show a message
+    if (keysOfProps.length === 0) {
+      return <p>This component doesn't have props</p>
     }
-    return markdown && <Markdown content={markdown} />
+    // if we have props, render all of them using React
+    const renderedProps = keysOfProps.map(propName => {
+      const { defaultValue = {}, required, type, description } = propsApi[propName]
+      const { value = undefined } = defaultValue
+
+      return (
+        <div className='sui-StudioProps-prop' key='propName'>
+          <h3>{propName}</h3>
+          <div className='sui-StudioProps-tags'>
+            <div className='sui-StudioProps-tag sui-StudioProps-required'>
+              <span>required</span>
+              <span className={required ? 'is-required' : ''}>{required ? 'yes' : 'no'}</span>
+            </div>
+            <div className='sui-StudioProps-tag sui-StudioProps-type'>
+              <span>type</span>
+              <span>{type.name}</span>
+            </div>
+            {value && <div className='sui-StudioProps-tag sui-StudioProps-default'>
+              <span>defaultValue</span>
+              <span>{value}</span>
+            </div>}
+          </div>
+          {description && <p>{description}</p>}
+        </div>
+      )
+    })
+    // return all the rendered props with a title
+    return [
+      <h2 key='propTitles'>Props</h2>,
+      ...renderedProps
+    ]
+  }
+
+  render () {
+    const { docs } = this.state
+    if (docs) {
+      const { params: { category, component } } = this.props
+      const componentTitle = `${docs.displayName} (${category}/${component})`
+      const { props } = docs
+
+      return (
+        <Fragment>
+          <h1>{componentTitle}</h1>
+          {this._renderPropsApi({propsApi: props})}
+        </Fragment>
+      )
+    }
+    return null
   }
 }
 

--- a/packages/sui-studio/src/components/documentation/_style.scss
+++ b/packages/sui-studio/src/components/documentation/_style.scss
@@ -10,6 +10,7 @@
 
   &-tag {
     display: inline-flex;
+    margin-bottom: 8px;
     margin-right: 16px;
   }
 

--- a/packages/sui-studio/src/components/documentation/_style.scss
+++ b/packages/sui-studio/src/components/documentation/_style.scss
@@ -1,31 +1,54 @@
 .sui-StudioProps {
-  td {
-    padding-bottom: 8px;
-    padding-right: 32px;
-    padding-top: 8px;
+  &-prop {
+    padding-left: 16px;
+
+    &:not(:last-child) {
+      border-bottom: 1px solid $c-gray-light;
+      padding-bottom: 16px;
+    }
   }
 
-  &-head {
+  &-tag {
+    display: inline-flex;
+    margin-right: 16px;
+  }
+
+  &-tag span {
+    background: $bgc-tag;
+    border-radius: 3px;
     color: $c-gray;
-    font-size: $fz-l;
-    font-weight: 100;
-  }
-
-  &-property {
-    color: $c-gray-dark;
-    font-size: $fz-m;
-  }
-
-  &-type {
-    font-family: monospace;
-  }
-
-  &-required {
-    background-color: $c-gray-lightest;
-    color: $c-black;
     font-size: $fz-s;
-    font-weight: 600;
-    padding: 4px;
-    vertical-align: top;
+    font-weight: $fw-ultra-light;
+    padding: 4px 8px;
+
+    &:not(:last-child) {
+      border-bottom-right-radius: 0;
+      border-top-right-radius: 0;
+    }
+
+    &:not(:first-child) {
+      border-bottom-left-radius: 0;
+      border-top-left-radius: 0;
+    }
+  }
+
+  &-required span:last-child {
+    background: $c-green;
+    color: $c-white;
+
+    &.is-required {
+      background: $c-accent;
+    }
+  }
+
+  &-default span:last-child {
+    background: $c-green;
+    color: $c-white;
+  }
+
+  &-type span:last-child {
+    background: $c-primary;
+    color: $c-white;
+    font-family: monospace;
   }
 }

--- a/packages/sui-studio/src/components/documentation/try-require.js
+++ b/packages/sui-studio/src/components/documentation/try-require.js
@@ -14,7 +14,7 @@ const getMarkdownFile = (category, component, fileName) => new Promise(resolve =
   require.ensure([], () => {
     try {
       const bundler = reqComponentsMarkdown(`./${category}/${component}/${fileName}.md`)
-      bundler(src => resolve(src))
+      bundler(resolve)
     } catch (e) {
       return resolve(`### ${category}/${component} does not contain any ${fileName}.md file`)
     }
@@ -39,7 +39,7 @@ const tryRequire = ({category, component}) => {
         bundler = reqComponentsSrcIndex(`./${category}/${component}/src/index.jsx`)
       }
 
-      bundler(src => resolve(src))
+      bundler(resolve)
     })
   })
 

--- a/packages/sui-studio/src/components/root/index.js
+++ b/packages/sui-studio/src/components/root/index.js
@@ -1,9 +1,9 @@
-import React from 'react'
+import React, { Component } from 'react'
 import {Router, browserHistory} from 'react-router'
 import routes from '../../routes'
 import '../../index.scss'
 
-export default class Root extends React.Component {
+export default class Root extends Component {
   render () {
     return <Router routes={routes} history={browserHistory} />
   }

--- a/packages/sui-studio/src/components/workbench/index.js
+++ b/packages/sui-studio/src/components/workbench/index.js
@@ -12,7 +12,13 @@ export default class Workbench extends Component {
 
     const Tab = ({ name, path }) => (
       <li className={TAB_CLASS}>
-        <Link to={`/workbench/${category}/${component}/${path}`} className={LINK_CLASS} activeClassName={ACTIVE_CLASS} >{name}</Link>
+        <Link
+          activeClassName={ACTIVE_CLASS}
+          className={LINK_CLASS}
+          to={`/workbench/${category}/${component}/${path}`}
+        >
+          {name}
+        </Link>
       </li>
     )
 

--- a/packages/sui-studio/src/styles/_settings.scss
+++ b/packages/sui-studio/src/styles/_settings.scss
@@ -1,6 +1,6 @@
 // --- Colors --- //
 $c-primary: #09f !default;
-
+$c-accent: #ff3860 !default;
 $c-white: #ffffff !default;
 $c-white-light: lighten($c-white, 33%) !default;
 
@@ -11,9 +11,13 @@ $c-gray-dark: darken($c-gray, 20%) !default;
 $c-gray-light: lighten($c-gray, 33%) !default;
 $c-gray-lightest: lighten($c-gray-light, 15%) !default;
 
+$c-green: #23d160  !default;
+
 $c-font-base: $c-gray-dark !default;
 $c-font-accent: $c-primary !default;
 $c-font-link: $c-font-accent !default;
+
+$bgc-tag: #eeeeee;
 
 // --- Fonts --- //
 
@@ -21,6 +25,7 @@ $c-font-link: $c-font-accent !default;
 $ff-sans-serif: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol' !default;
 
 // Font weights
+$fw-ultra-light: 100 !default;
 $fw-light: 300 !default;
 $fw-regular: 400 !default;
 $fw-semi-bold: 600 !default;


### PR DESCRIPTION
- [x] Remove heavy dependencies used for markdown.
- [x] Create API page with only React components.
- [x] Fix problem that showed props not required when they were.
- [x] Better layour for understanding the needed props.
- [x] Improved build time by 10 seconds (75 sec vs 65 secs with node 8) after removing heavy dependencies.
- [x] Using snarkdown for Markdown, far faster than the old dependency.

Before:
![image](https://user-images.githubusercontent.com/1561955/35099817-b2d04cf0-fc59-11e7-92c4-52f518c7681f.png)

Now: 
![image](https://user-images.githubusercontent.com/1561955/35099794-a5ef20a6-fc59-11e7-88bb-dbf9479281af.png)
