### PR TITLE
perf(sui-studio): use babel-standalone from cdn instead as package dependency

### DIFF
--- a/packages/sui-studio/package.json
+++ b/packages/sui-studio/package.json
@@ -32,7 +32,6 @@
     "@s-ui/polyfills": "1",
     "@s-ui/react-domain-connector": "1",
     "@schibstedspain/ddd-react-redux": "2",
-    "babel-standalone": "6.12.0",
     "bundle-loader": "0.5.4",
     "codemirror": "5.16.0",
     "colors": "1.1.2",

--- a/packages/sui-studio/src/components/preview/index.js
+++ b/packages/sui-studio/src/components/preview/index.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 
 import React, { Component } from 'react'
 import ReactDOM from 'react-dom'
-import { transform } from 'babel-standalone'
 
 const ERROR_TIMEOUT = 500
 
@@ -45,7 +44,7 @@ export default class Preview extends Component {
         ${this.props.code}
       });`
 
-    return transform(code, {
+    return window.Babel.transform(code, {
       presets: ['es2015', 'stage-3', 'react']
     }).code
   }

--- a/packages/sui-studio/src/index.html
+++ b/packages/sui-studio/src/index.html
@@ -1,7 +1,9 @@
 <title>SUI Studio</title>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
-<link id='async-css' rel="async-stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/github-markdown-css/2.4.1/github-markdown.min.css">
+<link rel='preload' href='https://unpkg.com/@babel/standalone@7.0.0-beta.38/babel.min.js' as='script'>
+<link id='async-css' rel="async-stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/2.4.1/github-markdown.min.css">
+<script src='https://unpkg.com/@babel/standalone@7.0.0-beta.38/babel.min.js'></script>
 
 <div id="root"></div>
 


### PR DESCRIPTION
While far from ideal, that gives a boost over the build time as babel-standalone is a huge dependency. So that ignores it and use directly from a cdn, giving some seconds of boost over initial build and incremental builds.

- [x] Use babel-standalone from CDN and remove from dependencies.

From node_modules (before):
![image](https://user-images.githubusercontent.com/1561955/35104338-d459ec64-fc68-11e7-8c0e-163185ed3e59.png)

From CDN (now):
![image](https://user-images.githubusercontent.com/1561955/35104311-c1c37688-fc68-11e7-9091-8ed57e2fd4c8.png)
