### PR TITLE
Fix/fixed sui decorator test

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,5 @@
 var TARGET = process.env.npm_lifecycle_event
 var config = {
-  singleRun: true,
 
   basePath: '',
 
@@ -9,6 +8,10 @@ var config = {
   files: [
     'node_modules/babel-polyfill/browser.js',
     'packages/*/test/**/*Spec.js'
+  ],
+
+  exclude: [
+    'packages/*/test/server/*Spec.js'
   ],
 
   reporters: ['spec'],
@@ -21,7 +24,7 @@ var config = {
 
   // browserify configuration
   browserify: {
-    debug: true,
+    debug: false,
     transform: [
       ['babelify', {
         presets: ['sui']

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "lint": "sui-lint js && sui-lint sass",
     "test": "NODE_ENV=test npm run test:client && NODE_ENV=test npm run test:server",
     "test:ci": "NODE_ENV=test ./node_modules/.bin/karma start --single-run --browsers Firefox",
-    "test:client": "NODE_ENV=test karma start",
+    "test:client": "NODE_ENV=test karma start --single-run",
     "test:client:watch": "npm run test:client -- --no-single-run",
-    "test:server": "NODE_ENV=test mocha ./packages/*/test --require babel-core/register --recursive",
+    "test:server": "NODE_ENV=test mocha './packages/*/test/!(browser)/*.js' --require babel-core/register --recursive",
     "test:server:watch": "npm run test:server -- --watch",
     "wiki:pull": "git subtree pull --prefix=.wiki https://github.com/SUI-Components/sui.wiki.git master --squash",
     "wiki:push": "git subtree push --prefix=.wiki https://github.com/SUI-Components/sui.wiki.git master",
@@ -46,7 +46,8 @@
     "karma-spec-reporter": "0.0.31",
     "mocha": "^4.0.1",
     "validate-commit-msg": "2.12.2",
-    "watchify": "3.9.0"
+    "sinon": "1.17.7",
+    "watchify": "3.8.0"
   },
   "config": {
     "sui-mono": {

--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
     "karma-firefox-launcher": "1.0.1",
     "karma-mocha": "1.3.0",
     "karma-spec-reporter": "0.0.31",
-    "mocha": "^4.0.1",
+    "mocha": "4.0.1",
     "validate-commit-msg": "2.12.2",
     "sinon": "1.17.7",
-    "watchify": "3.8.0"
+    "watchify": "3.9.0"
   },
   "config": {
     "sui-mono": {

--- a/packages/sui-decorators/test/browser/cacheSpec.js
+++ b/packages/sui-decorators/test/browser/cacheSpec.js
@@ -11,7 +11,7 @@ describe('Cache', () => {
   })
 
   describe('should be able use others method in this instance', () => {
-    xit('return the response of other instance´s method', () => {
+    it('return the response of other instance´s method', () => {
       class Buz {
         constructor () {
           this.rnd = () => Math.random()
@@ -30,7 +30,7 @@ describe('Cache', () => {
     beforeEach(() => clock = sinon.useFakeTimers())
     afterEach(() => clock.restore())
 
-    xit('return same value for long TTL and different for short TTL', () => {
+    it('return same value for long TTL and different for short TTL', () => {
       class Foo {
         @cache()
         syncRndNumber (num) { return Math.random() }
@@ -54,7 +54,7 @@ describe('Cache', () => {
   })
 
   describe('should decorate an async method', () => {
-    xit('return twice the same random number without params', (done) => {
+    it('return twice the same random number without params', (done) => {
       class Dummy {
         @cache()
         asyncRndNumber (num) { return new Promise(resolve => setTimeout(resolve, 100, Math.random())) }
@@ -89,7 +89,7 @@ describe('Cache', () => {
   })
 
   describe('should decorate a sync method', () => {
-    xit('return twice time the same random number without params', () => {
+    it('return twice time the same random number without params', () => {
       class Dummy {
         @cache()
         syncRndNumber (num) { return Math.random() }
@@ -107,7 +107,7 @@ describe('Cache', () => {
       expect(dummy.syncRndNumber(1)).to.be.not.eql(dummy.syncRndNumber(2))
     })
 
-    xit('return same numbers with same params', () => {
+    it('return same numbers with same params', () => {
       class Dummy {
         @cache()
         syncRndNumber (num) { return Math.random() }
@@ -132,7 +132,7 @@ describe('Cache', () => {
         expect(dummy.syncRndNumber(123)).to.be.not.eql(firstCall)
       })
 
-      xit('remain the cache before ttl ms', () => {
+      it('remain the cache before ttl ms', () => {
         class Dummy {
           @cache() // 500ms by default
           syncRndNumber (num) { return Math.random() }
@@ -143,7 +143,7 @@ describe('Cache', () => {
         expect(dummy.syncRndNumber(1234)).to.be.eql(firstCall)
       })
 
-      xit('remain the cache before not default ttl ms', () => {
+      it('remain the cache before not default ttl ms', () => {
         class Dummy {
           @cache({ttl: 700})
           syncRndNumber (num) { return Math.random() }
@@ -155,7 +155,7 @@ describe('Cache', () => {
       })
 
       describe('Should be able setting the TTL using a string', () => {
-        xit('return the same value when you call faster', () => {
+        it('return the same value when you call faster', () => {
           class Biz {
             constructor () {
               this.rnd = () => Math.random()

--- a/packages/sui-decorators/test/server/cacheSpec.js
+++ b/packages/sui-decorators/test/server/cacheSpec.js
@@ -75,7 +75,7 @@ describe('Cache', () => {
       expect(_sendSpy.notCalled).to.be.ok
     })
 
-    it('NodeTracker must track to the server pass 20 seconds from the last track', () => {
+    xit('NodeTracker must track to the server pass 20 seconds from the last track', () => {
       class Biz {
         constructor () {
           this.rnd = () => Math.random()

--- a/packages/sui-decorators/test/server/cacheSpec.js
+++ b/packages/sui-decorators/test/server/cacheSpec.js
@@ -7,7 +7,7 @@ import cache from '../../src/decorators/cache'
 import NodeTracker from '../../src/decorators/cache/tracker/NodeTracker'
 
 describe('Cache', () => {
-  xit('should ignore the cache in Node by default', () => {
+  it('should ignore the cache in Node by default', () => {
     class Buz {
       constructor () {
         this.rnd = () => Math.random()
@@ -75,7 +75,7 @@ describe('Cache', () => {
       expect(_sendSpy.notCalled).to.be.ok
     })
 
-    xit('NodeTracker must track to the server pass 20 seconds from the last track', () => {
+    it('NodeTracker must track to the server pass 20 seconds from the last track', () => {
       class Biz {
         constructor () {
           this.rnd = () => Math.random()

--- a/packages/sui-decorators/test/server/streamifySpec.js
+++ b/packages/sui-decorators/test/server/streamifySpec.js
@@ -92,10 +92,11 @@ describe('Streamify', () => {
       } catch (e) {}
     })
 
-    xit('Notify Async errors', (done) => {
+    it('Notify Async errors', (done) => {
       const onError = ({params, error}) => {
         expect(params).to.be.eql([])
-        expect(error).to.be.eql('asyncThrowError')
+
+        expect(error).to.be.eql(new Error('throwError'))
         done()
       }
 


### PR DESCRIPTION
## Description
The next PR fix partially the pending test with 'xit' on sui-decorator. 

What was happening with those tests was that on the new karma conf we've taking to run also the 'server' folder as karma valid tests. As we need to run those test on the server side the test were failing.

On the other hand we have the reverse case of the browse tests that were ran with mocha and should be ran by karma.

The strange thing here is that avoiding my errors on the implementation of the test runner in fact we have at least 2 server test that were not working even if they're ran by the test runner configured on its own package.

I've fixed one that were expecting an error object and we were passing a string with the error type.

## Pending to check

The other one is this one:
`NodeTracker must track to the server pass 20 seconds from the last track`

I'm not able to track what is happening here as my knowledge in this field is bad. Someone should help on that.

