### PR TITLE
Fix/studio on internet explorer

### DIFF
--- a/packages/sui-studio/package.json
+++ b/packages/sui-studio/package.json
@@ -29,7 +29,6 @@
     "@s-ui/deploy": "1",
     "@s-ui/helpers": "1",
     "@s-ui/mono": "1",
-    "@s-ui/polyfills": "1",
     "@s-ui/react-domain-connector": "1",
     "@schibstedspain/ddd-react-redux": "2",
     "bundle-loader": "0.5.4",
@@ -55,8 +54,7 @@
   "suistudio-webpack": {
     "vendor": [
       "react",
-      "react-dom",
-      "@s-ui/polyfills"
+      "react-dom"
     ]
   },
   "repository": {

--- a/packages/sui-studio/src/app.js
+++ b/packages/sui-studio/src/app.js
@@ -1,4 +1,3 @@
-import '@s-ui/polyfills'
 import React from 'react'
 import reactDOM from 'react-dom'
 import { AppContainer } from 'react-hot-loader'

--- a/packages/sui-studio/src/components/demo/index.js
+++ b/packages/sui-studio/src/components/demo/index.js
@@ -48,6 +48,7 @@ const cleanDisplayName = displayName => {
 }
 const pipe = (...funcs) => arg =>
   funcs.reduce((value, func) => func(value), arg)
+
 const removeDefaultContext = exports =>
   Object.keys(exports)
     .filter(key => key !== DEFAULT_CONTEXT)

--- a/packages/sui-studio/src/index.html
+++ b/packages/sui-studio/src/index.html
@@ -2,6 +2,8 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel='preload' href='https://unpkg.com/@babel/standalone@7.0.0-beta.38/babel.min.js' as='script'>
+<link rel='preload' href='https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.26.0/polyfill.min.js' as='script'>
+
 <link id='async-css' rel="async-stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/2.4.1/github-markdown.min.css">
 
 <script src='https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.26.0/polyfill.min.js'></script>

--- a/packages/sui-studio/src/index.html
+++ b/packages/sui-studio/src/index.html
@@ -3,6 +3,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel='preload' href='https://unpkg.com/@babel/standalone@7.0.0-beta.38/babel.min.js' as='script'>
 <link id='async-css' rel="async-stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/2.4.1/github-markdown.min.css">
+
+<script src='https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.26.0/polyfill.min.js'></script>
 <script src='https://unpkg.com/@babel/standalone@7.0.0-beta.38/babel.min.js'></script>
 
 <div id="root"></div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1561955/35685363-cab478f8-0769-11e8-80c3-2505914d7bbe.png)

- [x] Make SuiStudio work with IE11, Firefox and Safari old versions.
- [x] Use directly babel-polyfill for covering babel-standalone needed polyfills and remove 