### PR TITLE
perf(sui-studio): load chunk of React Doc Gen only when needed

### DIFF
--- a/packages/sui-studio/src/components/documentation/ReactDocGen.js
+++ b/packages/sui-studio/src/components/documentation/ReactDocGen.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types'
 import React, { Component, Fragment } from 'react'
 import tryRequire from './try-require'
-const reactDocs = require('react-docgen')
 
 class ReactDocGen extends Component {
   static propTypes = {
@@ -14,9 +13,12 @@ class ReactDocGen extends Component {
   state = { docs: false }
 
   componentDidMount () {
-    tryRequire(this.props.params).then(([src, _]) =>
-      this.setState({ docs: reactDocs.parse(src) })
-    )
+    require.ensure([], require => {
+      const reactDocs = require('react-docgen')
+      tryRequire(this.props.params).then(([src, _]) =>
+        this.setState({ docs: reactDocs.parse(src) })
+      )
+    })
   }
 
   _renderPropsApi ({ propsApi = {} }) {

--- a/packages/sui-studio/src/components/documentation/ReactDocGen.js
+++ b/packages/sui-studio/src/components/documentation/ReactDocGen.js
@@ -18,7 +18,7 @@ class ReactDocGen extends Component {
       tryRequire(this.props.params).then(([src, _]) =>
         this.setState({ docs: reactDocs.parse(src) })
       )
-    })
+    }, 'ReactDocgen')
   }
 
   _renderPropsApi ({ propsApi = {} }) {


### PR DESCRIPTION
Load the chunk of React Doc Gen only when needed as it's pretty big in the bundle (33% of the bundle is that dependency) so we try to not rebuild everytime a change is detected and also to speed up the boot-up of the studio. So, the chunk will be loaded only when the user open the API tab.

Before:
![image](https://user-images.githubusercontent.com/1561955/35747931-7441b1d2-084c-11e8-931d-9c5903d7e074.png)

After:
![image](https://user-images.githubusercontent.com/1561955/35747950-859e2064-084c-11e8-8c01-f1f728e1a0b1.png)
