### PR TITLE
fix(sui-helpers): fixed bug related to colors prototype inheritance b…

### DIFF
--- a/packages/sui-helpers/cli.js
+++ b/packages/sui-helpers/cli.js
@@ -1,9 +1,9 @@
 /* eslint no-console:0 */
-require('colors')
 const processSpawn = require('child_process').spawn
-const program = require('commander')
 const CODE_OK = 0
 const log = console.log
+const colors = require('colors')
+
 
 /**
  * Spawn several commands in children processes, in series
@@ -105,12 +105,14 @@ function getCommandCallMessage (bin, args, options = {}) {
 /*
  * Shows an error in the command line and exits process
  * It also outputs help content of the command
+ * The program param will have commander instance to output the help command
  * @param  {String} msg
+ * @param  {Object} program
  * @return
  */
-const showError = (msg) => {
-  program.outputHelp(txt => txt.red)
-  console.log(msg.red) // eslint-disable-line no-console
+const showError = (msg, program) => {
+  program.outputHelp(txt => colors.red(txt))
+  console.error(colors.red(msg))// eslint-disable-line no-console
   process.exit(1)
 }
 

--- a/packages/sui-helpers/cli.js
+++ b/packages/sui-helpers/cli.js
@@ -5,7 +5,6 @@ const log = console.log
 const colors = require('colors')
 const program = require('commander')
 
-
 /**
  * Spawn several commands in children processes, in series
  * @param  {Array} commands Binary with array of args, like ['npm', ['run', 'test']]

--- a/packages/sui-helpers/cli.js
+++ b/packages/sui-helpers/cli.js
@@ -3,6 +3,7 @@ const processSpawn = require('child_process').spawn
 const CODE_OK = 0
 const log = console.log
 const colors = require('colors')
+const program = require('commander')
 
 
 /**
@@ -107,11 +108,11 @@ function getCommandCallMessage (bin, args, options = {}) {
  * It also outputs help content of the command
  * The program param will have commander instance to output the help command
  * @param  {String} msg
- * @param  {Object} program
+ * @param  {Object} foreignProgram
  * @return
  */
-const showError = (msg, program) => {
-  program.outputHelp(txt => colors.red(txt))
+const showError = (msg, foreignProgram) => {
+  foreignProgram ? foreignProgram.outputHelp(txt => colors.red(txt)) : program.outputHelp(txt => colors.red(txt))
   console.error(colors.red(msg))// eslint-disable-line no-console
   process.exit(1)
 }


### PR DESCRIPTION
## Description
This PR fixes two strange behaviors related with the usage of sui-helpers/cli.

1. The no existence of the colors prototype properties on String javascript class due that the string that we are passing to the showError function once instantiated doesn't have all the prototype modifications needed to have the 'red' property. This was throwing the next error with an undefined print on the end that is not on the screenshot: 
<img width="305" alt="captura de pantalla 2018-02-12 a las 19 36 33" src="https://user-images.githubusercontent.com/5639972/36113118-111af11c-102c-11e8-8906-8fabd419bf00.png">

This undefined print is the problem itself. Why its undefined? Because wen console.log evals the msg.red the 'red' property is undefined, this is caused because when msg was 'instantiated' String prototype wasn't modified yet by colors library.

With the fix this is what we will see:
<img width="1001" alt="captura de pantalla 2018-02-12 a las 19 33 10" src="https://user-images.githubusercontent.com/5639972/36112980-96eb7dd0-102b-11e8-9687-fd2ecd770dcf.png">


2. The no co-relation between our commander instance and the error origin commander. We've been instantiating a new commander that doesn't match with the commander that throws the error. So, when the commander execute the outputHelp function it shows a default message:
<img width="1232" alt="captura de pantalla 2018-02-12 a las 19 25 42" src="https://user-images.githubusercontent.com/5639972/36112870-4d3e9c94-102b-11e8-894c-919c821251eb.png">

If we pass the commander instance to the function and execute the outputHelp method we will see the helper information related with who executed the commander:
<img width="914" alt="captura de pantalla 2018-02-12 a las 19 32 33" src="https://user-images.githubusercontent.com/5639972/36112947-82404848-102b-11e8-80cd-271bec99be2b.png">
