### PR TITLE
feat(sui-widget-embedder): added service worker cdn

### DIFF
--- a/packages/sui-widget-embedder/bin/sui-widget-embedder-build.js
+++ b/packages/sui-widget-embedder/bin/sui-widget-embedder-build.js
@@ -41,7 +41,7 @@ program
   .parse(process.argv)
 
 const remoteCdn = program.remoteCdn || config.remoteCdn
-const serviceWorkerCdn = program.serviceWorkerCdn || config.remoteCdn
+const serviceWorkerCdn = program.serviceWorkerCdn || remoteCdn
 
 if (program.clean) {
   console.log('Removing previous build...')

--- a/packages/sui-widget-embedder/bin/sui-widget-embedder-build.js
+++ b/packages/sui-widget-embedder/bin/sui-widget-embedder-build.js
@@ -24,6 +24,7 @@ const config = pkg['config']['sui-widget-embedder']
 program
   .option('-C, --clean', 'Remove public folder before create a new one')
   .option('-R --remoteCdn <url>', 'Remote url where the downloader will be placed')
+  .option('-D --serviceWorkerCdn <url>', 'Remote url where the browser will register the sw')
   .on('--help', () => {
     console.log('  Description:')
     console.log('')
@@ -40,6 +41,7 @@ program
   .parse(process.argv)
 
 const remoteCdn = program.remoteCdn || config.remoteCdn
+const serviceWorkerCdn = program.serviceWorkerCdn || config.remoteCdn
 
 if (program.clean) {
   console.log('Removing previous build...')
@@ -106,7 +108,8 @@ const createDownloader = () =>
         staticModule({
           'static-manifests': () => JSON.stringify(staticManifests),
           'static-pathnamesRegExp': () => JSON.stringify(staticPathnamesRegExp),
-          'static-cdn': () => JSON.stringify(remoteCdn)
+          'static-cdn': () => JSON.stringify(remoteCdn),
+          'service-worker-cdn': () => JSON.stringify(serviceWorkerCdn)
         })
       )
       .pipe(minifyStream({ sourceMap: false }))
@@ -142,7 +145,8 @@ const createSW = () =>
       .pipe(
         staticModule({
           'static-cache': () => JSON.stringify(staticCache),
-          'static-cdn': () => JSON.stringify(remoteCdn)
+          'static-cdn': () => JSON.stringify(remoteCdn),
+          'service-worker-cdn': () => JSON.stringify(serviceWorkerCdn)
         })
       )
       .pipe(minifyStream({ sourceMap: false }))

--- a/packages/sui-widget-embedder/downloader/index.js
+++ b/packages/sui-widget-embedder/downloader/index.js
@@ -3,6 +3,7 @@
   var manifests = require('static-manifests')()
   var pathnamesRegExp = require('static-pathnamesRegExp')()
   var cdn = require('static-cdn')()
+  var serviceWorkerCdn = require('service-worker-cdn')()
   // https://davidwalsh.name/javascript-loader
   var load = (function () {
     function loaderFor (tag) {
@@ -125,7 +126,7 @@
 
   if ('serviceWorker' in navigator) {
     navigator.serviceWorker
-      .register(cdn + '/sw.js')
+      .register(serviceWorkerCdn + '/sw.js')
       .then(function (registration) {
         console.log(
           'Service Worker registration successful with scope: ',


### PR DESCRIPTION
## Description
Added serviceWorkerCdn option to allow have different urls for the widget statics and for the
service worker as we need an url over https and same placed as the site domain.

Now we are setting the static-cdn as our default cdn for ALL the resources. As sw.js need to run over an ssl url and over THE SAME domain as our target site we need to have a different URL to make it work.


We are guaranteeing retro-compatibility by setting as a fallback var the remoteCdn variable.