### PR TITLE
Feature/sui widget embedder add charset to avoid encoding errors

### DIFF
--- a/packages/sui-widget-embedder/downloader/index.js
+++ b/packages/sui-widget-embedder/downloader/index.js
@@ -23,7 +23,7 @@
           switch (tag) {
             case 'script':
               element.async = true
-              element.charset="UTF-8"
+              element.charset = 'UTF-8'
               break
             case 'link':
               element.type = 'text/css'

--- a/packages/sui-widget-embedder/downloader/index.js
+++ b/packages/sui-widget-embedder/downloader/index.js
@@ -23,6 +23,7 @@
           switch (tag) {
             case 'script':
               element.async = true
+              element.charset="UTF-8"
               break
             case 'link':
               element.type = 'text/css'


### PR DESCRIPTION
## Description
We found collisions between widget charset encoding and native monolith charset encoding. So we must specify that our widgets are scripts encoded in UTF8 to ensure the well representation of our texts.