### PR TITLE
fix(sui-widget-embedder): ad a / on the remoteCDN publicPath to avoid…

### DIFF
--- a/packages/sui-widget-embedder/compiler/production.js
+++ b/packages/sui-widget-embedder/compiler/production.js
@@ -31,7 +31,7 @@ module.exports = ({page, remoteCdn}) => {
     output: {
       ...prodConfig.output,
       path: path.resolve(process.cwd(), 'public', page),
-      publicPath: remoteCdn ? `${remoteCdn}/${page}` : prodConfig.output.publicPath
+      publicPath: remoteCdn ? `${remoteCdn}/${page}/` : prodConfig.output.publicPath
     },
     plugins: pipe(
       removePlugin('HtmlWebpackPlugin'),


### PR DESCRIPTION
## Description
ad a / on the remoteCDN publicPath to avoid request call errors
