### PR TITLE
fix(sui-studio): rollback import context as it's causing to import wrong files

### DIFF
--- a/packages/sui-studio/src/components/demo/try-require.js
+++ b/packages/sui-studio/src/components/demo/try-require.js
@@ -7,12 +7,20 @@ const requireFile = async ({ defaultValue, extractDefault = true, importFile }) 
   return extractDefault ? file.default : file
 }
 
+const reqComponentsSrc =
+  require.context(`bundle-loader?lazy!${__BASE_DIR__}/components`, true, /^\.\/\w+\/\w+\/src\/index\.jsx?/)
+
 const tryRequire = async ({category, component}) => {
-  const exports = requireFile({
-    extractDefault: false,
-    importFile: () => import(`${__BASE_DIR__}/components/${category}/${component}/src/index.js`).catch(_ =>
-      import(`${__BASE_DIR__}/components/${category}/${component}/src/index.jsx`)
-    )
+  const exports = new Promise(resolve => {
+    require.ensure([], () => {
+      let bundler
+      try {
+        bundler = reqComponentsSrc(`./${category}/${component}/src/index.js`)
+      } catch (e) {
+        bundler = reqComponentsSrc(`./${category}/${component}/src/index.jsx`)
+      }
+      bundler(resolve)
+    })
   })
 
   const pkg = requireFile({


### PR DESCRIPTION
This fixes the studio as the import with context is causing to import the wrong files as the variables are causing webpack to go through the whole tree (node_modules included) to search a `/src/index.js`. Rollback the way we import this until we figure out how to deal with it.