### PR TITLE
fix(sui-lint): ignore comments on .gitignore files to avoid putting them in the .gitignore

### DIFF
--- a/packages/sui-lint/src/helpers.js
+++ b/packages/sui-lint/src/helpers.js
@@ -47,10 +47,10 @@ const getFileLinesAsArray = path => {
 }
 
 /**
- * Get as array .gitignore files
+ * Get as array .gitignore files and filter lines that are comments
  * @returns {Array<String>}
  */
-const getGitIgnoredFiles = () => getFileLinesAsArray(GIT_IGNORE_PATH)
+const getGitIgnoredFiles = () => getFileLinesAsArray(GIT_IGNORE_PATH).filter(line => !line.startsWith('#'))
 
 /**
  * Get multiple value arg


### PR DESCRIPTION
Ignore comments on .gitignore file in order to avoid problems when adding them in the ignore-pattern.

Fixes: https://github.com/SUI-Components/sui/issues/264