### PR TITLE
Remove not needed preload webpack plugin and fix node6 compatibility

### DIFF
--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -48,7 +48,6 @@
     "optimize-css-assets-webpack-plugin": "4.0.0",
     "ora": "1.3.0",
     "postcss-loader": "2.1.3",
-    "preload-webpack-plugin": "3.0.0-alpha.1",
     "prompt": "1.0.0",
     "raw-loader": "0.5.1",
     "replace": "0.3.0",

--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -85,7 +85,7 @@ module.exports = {
         useShortDoctype: true
       }
     }),
-    new ScriptExtHtmlWebpackPlugin(Object.assign({}, {
+    new ScriptExtHtmlWebpackPlugin(Object.assign({
       defaultAttribute: 'defer',
       inline: 'runtime',
       prefetch: {

--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -1,19 +1,18 @@
 /* eslint-disable no-console */
-const webpack = require('webpack')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
-const PreloadWebpackPlugin = require('preload-webpack-plugin')
-const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin')
 const ManifestPlugin = require('webpack-manifest-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
+const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin')
+const path = require('path')
+const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin')
 const SWPrecacheWebpackPlugin = require('sw-precache-webpack-plugin')
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
-const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin')
-const LoaderUniversalOptionsPlugin = require('./plugins/loader-options')
-const Externals = require('./plugins/externals')
-const path = require('path')
+const webpack = require('webpack')
 
-const {when, cleanList, envVars, MAIN_ENTRY_POINT, config} = require('./shared')
 const {navigateFallbackWhitelist, navigateFallback, runtimeCaching, directoryIndex} = require('./shared/precache')
+const {when, cleanList, envVars, MAIN_ENTRY_POINT, config} = require('./shared')
+const Externals = require('./plugins/externals')
+const LoaderUniversalOptionsPlugin = require('./plugins/loader-options')
 require('./shared/shims')
 
 // hack for Windows, as process.env.PWD is undefined in that environment
@@ -86,12 +85,14 @@ module.exports = {
         useShortDoctype: true
       }
     }),
-    new ScriptExtHtmlWebpackPlugin({
+    new ScriptExtHtmlWebpackPlugin(Object.assign({}, {
       defaultAttribute: 'defer',
       inline: 'runtime',
-      ...config.scripts
-    }),
-    new PreloadWebpackPlugin({ rel: 'prefetch' }),
+      prefetch: {
+        test: /\.js$/,
+        chunks: 'all'
+      }
+    }, config.scripts)),
     new ManifestPlugin({
       fileName: 'asset-manifest.json'
     }),


### PR DESCRIPTION
- [fix] Use Object.assign instead spread operator in order to keep compatibility with node 6.
- [refactor] Remove not needed preload webpack plugin as we're doing the same with the scriptExtPlugin.
- [style] Sort imports of the file for clarity.