### PR TITLE
feat(sui-mono): better error handling when no files staged for commiting

### DIFF
--- a/packages/sui-mono/bin/sui-mono-commit.js
+++ b/packages/sui-mono/bin/sui-mono-commit.js
@@ -24,19 +24,11 @@ function getDiffedFiles ({ checkIfStaged = false } = {}) {
 }
 
 /**
- * Check if the user has stagged files
- */
-async function checkHasStagedFiles () {
-  const staged = await getDiffedFiles({ checkIfStaged: true })
-  return staged.hasFiles
-}
-
-/**
  * Start the commiting process, making some verifications to avoid further problems for the user
  */
 async function initCommit () {
-  const hasFiles = await checkHasStagedFiles()
-  if (hasFiles === false) {
+  const { hasFiles: hasStagedFiles } = await getDiffedFiles({ checkIfStaged: true })
+  if (hasStagedFiles === false) {
     console.log('No files added to staging! Did you forget to run git add?\n')
     const modified = await getDiffedFiles()
     if (modified.hasFiles) {

--- a/packages/sui-mono/bin/sui-mono-commit.js
+++ b/packages/sui-mono/bin/sui-mono-commit.js
@@ -1,11 +1,58 @@
 /* eslint no-console:0 */
 const path = require('path')
+const {exec} = require('child_process')
 const bootstrap = require('commitizen/dist/cli/git-cz').bootstrap
 
-bootstrap({
-  debug: false,
-  cliPath: path.join(process.cwd(), 'node_modules/commitizen'),
-  config: {
-    path: './node_modules/@s-ui/cz'
+/**
+ * Get a list of the modified files by the user
+ * @param {boolean} checkIfStaged Determine if we should change if the modified file is staged
+ */
+function getDiffedFiles ({ checkIfStaged = false } = {}) {
+  return new Promise((resolve, reject) => {
+    let command = 'git diff --name-only'
+    if (checkIfStaged) command += ' --cached'
+    exec(command, (err, stdout) => {
+      if (err) return reject(err)
+      const output = stdout || ''
+
+      resolve({
+        hasFiles: output.trim().length > 0,
+        files: output
+      })
+    })
+  })
+}
+
+/**
+ * Check if the user has stagged files
+ */
+async function checkHasStagedFiles () {
+  const staged = await getDiffedFiles({ checkIfStaged: true })
+  return staged.hasFiles
+}
+
+/**
+ * Start the commiting process, making some verifications to avoid further problems for the user
+ */
+async function initCommit () {
+  const hasFiles = await checkHasStagedFiles()
+  if (hasFiles === false) {
+    console.log('No files added to staging! Did you forget to run git add?\n')
+    const modified = await getDiffedFiles()
+    if (modified.hasFiles) {
+      console.log('Showing the files that you could add:')
+      console.log(modified.files)
+    }
+    return
   }
-})
+
+  bootstrap({
+    debug: false,
+    cliPath: path.join(process.cwd(), 'node_modules/commitizen'),
+    config: {
+      path: './node_modules/@s-ui/cz'
+    }
+  })
+}
+
+initCommit()


### PR DESCRIPTION
Better error handling when user doesn't have staged files. So, now, instead having a cryptic error message, we show a grateful one telling the user the files he could add to the commit.

Before:
![image](https://user-images.githubusercontent.com/1561955/39433890-524c8dce-4c97-11e8-87f6-f43ba93f705f.png)

After:
![image](https://user-images.githubusercontent.com/1561955/39433827-34b420ec-4c97-11e8-8a64-0700d2e78555.png)
