### PR TITLE
fix(sui-bundler): fix regression that runtime has not been created

### DIFF
--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -47,6 +47,7 @@ module.exports = {
       }),
       new OptimizeCSSAssetsPlugin({})
     ],
+    runtimeChunk: true,
     splitChunks: {
       cacheGroups: {
         vendor: {


### PR DESCRIPTION
This PR fixes a regression from the latest major as the runtime chunk is not being generated and hashes are being generated again and again.