### PR TITLE
Windows cmd compatibility

### DIFF
--- a/packages/sui-helpers/cli.js
+++ b/packages/sui-helpers/cli.js
@@ -1,5 +1,5 @@
 /* eslint no-console:0 */
-const processSpawn = require('cross-spawn')
+const processSpawn = require('child_process').spawn
 const CODE_OK = 0
 const log = console.log
 const colors = require('colors')
@@ -7,6 +7,7 @@ const program = require('commander')
 const execa = require('execa')
 const Listr = require('listr')
 const figures = require('figures')
+const path = require('path')
 const { splitArray } = require('./array')
 
 /**
@@ -106,8 +107,9 @@ function getSpawnProcess (bin, args, options = {}) {
     { shell: true, stdio: 'inherit', cwd: process.cwd() },
     options
   )
-
-  return processSpawn(bin, args, options)
+  return path.isAbsolute(bin) // check if it's a file or an alias
+    ? processSpawn('node', [bin, ...args], options)
+    : processSpawn(bin, ...args, options)
 }
 
 /**

--- a/packages/sui-helpers/cli.js
+++ b/packages/sui-helpers/cli.js
@@ -111,7 +111,10 @@ function getSpawnProcess (bin, args, options = {}) {
 }
 
 /**
- * Returns modified command to work on linux, osx and windows
+ * Returns modified command to work on linux, osx and windows.
+ * The flag '#!/usr/bin/env node' is ignored by Windows. So the scripts must
+ * be executed by node explicitely.
+ * We assume that if `bin` is an abolsute path, it's always a js file to execute.
  * @param  {String} bin     Binary path or alias
  * @param  {Array} args    Array of args, like ['npm', ['run', 'test']]
  * @param  {Object} opts to pass to child_process.spawn call

--- a/packages/sui-helpers/cli.js
+++ b/packages/sui-helpers/cli.js
@@ -51,7 +51,7 @@ function parallelSpawn (commands, options = {}) {
 function spawnList (commands, listrOptions = {}, chunks = 15) {
   let taskList = commands.map(([bin, args, opts, title]) => ({
     title: title || getCommandCallMessage(bin, args, opts),
-    task: () => execa(bin, args, opts)
+    task: () => execa(...getArrangedCommand(bin, args, opts))
   }))
 
   if (!listrOptions.concurrent && chunks && taskList.length > chunks) {
@@ -107,9 +107,20 @@ function getSpawnProcess (bin, args, options = {}) {
     { shell: true, stdio: 'inherit', cwd: process.cwd() },
     options
   )
+  return processSpawn(...getArrangedCommand(bin, args, options))
+}
+
+/**
+ * Returns modified command to work on linux, osx and windows
+ * @param  {String} bin     Binary path or alias
+ * @param  {Array} args    Array of args, like ['npm', ['run', 'test']]
+ * @param  {Object} opts to pass to child_process.spawn call
+ * @returns {Object} {bin, args, options}
+ */
+function getArrangedCommand (bin, args, opts) {
   return path.isAbsolute(bin) // check if it's a file or an alias
-    ? processSpawn('node', [bin, ...args], options)
-    : processSpawn(bin, ...args, options)
+    ? ['node', [bin, ...args], opts]
+    : [bin, args, opts]
 }
 
 /**

--- a/packages/sui-helpers/cli.js
+++ b/packages/sui-helpers/cli.js
@@ -7,6 +7,7 @@ const program = require('commander')
 const execa = require('execa')
 const Listr = require('listr')
 const figures = require('figures')
+const path = require('path')
 const { splitArray } = require('./array')
 
 /**
@@ -106,7 +107,9 @@ function getSpawnProcess (bin, args, options = {}) {
     { shell: true, stdio: 'inherit', cwd: process.cwd() },
     options
   )
-  return processSpawn(bin, args, options)
+  return path.isAbsolute(bin) // check if it's a file or an alias
+    ? processSpawn('node', [bin, ...args], options)
+    : processSpawn(bin, ...args, options)
 }
 
 /**

--- a/packages/sui-helpers/cli.js
+++ b/packages/sui-helpers/cli.js
@@ -1,5 +1,5 @@
 /* eslint no-console:0 */
-const processSpawn = require('child_process').spawn
+const processSpawn = require('cross-spawn')
 const CODE_OK = 0
 const log = console.log
 const colors = require('colors')
@@ -7,7 +7,6 @@ const program = require('commander')
 const execa = require('execa')
 const Listr = require('listr')
 const figures = require('figures')
-const path = require('path')
 const { splitArray } = require('./array')
 
 /**
@@ -107,9 +106,8 @@ function getSpawnProcess (bin, args, options = {}) {
     { shell: true, stdio: 'inherit', cwd: process.cwd() },
     options
   )
-  return path.isAbsolute(bin) // check if it's a file or an alias
-    ? processSpawn('node', [bin, ...args], options)
-    : processSpawn(bin, ...args, options)
+
+  return processSpawn(bin, args, options)
 }
 
 /**

--- a/packages/sui-helpers/package.json
+++ b/packages/sui-helpers/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "colors": "1.1.2",
     "commander": "2.9.0",
+    "cross-spawn": "6.0.5",
     "execa": "0.10.0",
     "figures": "2.0.0",
     "fs-extra": "4.0.1",

--- a/packages/sui-helpers/package.json
+++ b/packages/sui-helpers/package.json
@@ -7,7 +7,6 @@
   "dependencies": {
     "colors": "1.1.2",
     "commander": "2.9.0",
-    "cross-spawn": "6.0.5",
     "execa": "0.10.0",
     "figures": "2.0.0",
     "fs-extra": "4.0.1",

--- a/packages/sui-test/bin/sui-test-e2e.js
+++ b/packages/sui-test/bin/sui-test-e2e.js
@@ -22,7 +22,7 @@ const HELP_MESSAGE = `
 
 const objectToCommaString = obj =>
   Object.keys(obj)
-    .map(key => `${key}='${obj[key]}'`)
+    .map(key => `${key}=${obj[key]}`)
     .join(',')
 
 program


### PR DESCRIPTION
## Description
This PR was originally created to make sui-test commands compatible with windows.

## Related Issue
`#!/usr/bin/env node` doesn't work on windows.
