### PR TITLE
Sui mono phoenix

### DIFF
--- a/packages/sui-helpers/cli.js
+++ b/packages/sui-helpers/cli.js
@@ -87,8 +87,10 @@ function getSpawnPromiseFactory (bin, args, options) {
  */
 function getSpawnPromise (bin, args, options = {}) {
   return new Promise(function (resolve, reject) {
-    log('')
-    log(getCommandCallMessage(bin, args, options))
+    if (options.stdio !== 'ignore') {
+      log('')
+      log(getCommandCallMessage(bin, args, options))
+    }
     getSpawnProcess(bin, args, options).on('exit', code => {
       code === CODE_OK ? resolve(code) : reject(code)
     })

--- a/packages/sui-mono/README.md
+++ b/packages/sui-mono/README.md
@@ -34,6 +34,17 @@ $ sui-mono run-parallel rm -Rf node_modules
 $ sui-mono run-parallel npm install
 ```
 
+### Phoenix
+
+To reset your project and all its contained packages.
+
+```sh
+sui-mono phoenix
+```
+
+Equivalent to 'rm -Rf node_modules && npm i' but works on any environment and
+executes it concurrently on each package (and/or on your project root folder).
+
 ### Link
 
 Is you want to link all packages between each other, to ease development:

--- a/packages/sui-mono/bin/sui-mono-phoenix.js
+++ b/packages/sui-mono/bin/sui-mono-phoenix.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/* eslint no-console:0 */
+require('colors')
+const program = require('commander')
+const {basename} = require('path')
+const config = require('../src/config')
+const {serialSpawn, showError} = require('@s-ui/helpers/cli')
+const Listr = require('listr')
+
+program
+  .on('--help', () => {
+    console.log(`
+  Description:
+    Removes node_modules folder and reinstalls dependencies
+    in all packages.
+    Equivalent to 'rm -Rf node_modules && npm i' but works on any environment and
+    executes it concurrently on each package (and/or on your project root folder).
+
+  Examples:
+    $ sui-mono phoenix`)
+  })
+  .parse(process.argv)
+
+const RIMRAF_CMD = [require.resolve('rimraf/bin'), ['node_modules']]
+const NPM_CMD = ['npm', ['install']]
+
+const executePhoenixOnPackages = () => {
+  if (config.isMonoPackage()) {
+    return
+  }
+  const taskList = config.getScopesPaths()
+    .map(cwd => [
+      [...RIMRAF_CMD, {cwd, stdio: 'ignore'}],
+      [...NPM_CMD, {cwd, stdio: 'ignore'}]
+    ])
+    .map((commands) => ({
+      title: 'rimraf node_modules && npm i ' + ('@' + basename(commands[0][2].cwd)).grey,
+      task: () => new Promise(resolve => {
+        serialSpawn(commands).then(resolve)
+          .catch(error => console.log(error))
+      })
+    }))
+  const tasks = new Listr(taskList, {concurrent: true})
+  return tasks.run()
+}
+
+serialSpawn([
+  RIMRAF_CMD,
+  NPM_CMD
+])
+  .then(executePhoenixOnPackages)
+  .catch(showError)

--- a/packages/sui-mono/bin/sui-mono.js
+++ b/packages/sui-mono/bin/sui-mono.js
@@ -32,4 +32,7 @@ program
 program
   .command('run-parallel', 'Run a command on each package, in parallel')
 
+program
+  .command('phoenix', 'Reset project and packages reinstalling all dependencies')
+
 program.parse(process.argv)

--- a/packages/sui-mono/package.json
+++ b/packages/sui-mono/package.json
@@ -17,9 +17,12 @@
   "dependencies": {
     "@s-ui/cz": "1",
     "@s-ui/helpers": "1",
+    "colors": "1.3.0",
     "commander": "2.9.0",
     "commitizen": "2.8.6",
-    "conventional-changelog": "1.1.0"
+    "conventional-changelog": "1.1.0",
+    "listr": "0.14.1",
+    "rimraf": "2.6.2"
   },
   "repository": {
     "type": "git",

--- a/packages/sui-mono/src/config.js
+++ b/packages/sui-mono/src/config.js
@@ -31,6 +31,10 @@ module.exports = {
 
     return flatten(scopes, customScopes)
   },
+  getScopesPaths: function () {
+    const packagesDir = path.join(process.cwd(), this.getPackagesFolder())
+    return this.getScopes().map(pkg => path.join(packagesDir, pkg))
+  },
   getPackagesFolder: function () {
     return packagesFolder
   },

--- a/packages/sui-mono/src/run.js
+++ b/packages/sui-mono/src/run.js
@@ -1,14 +1,12 @@
-const path = require('path')
 const program = require('commander')
 const config = require('../src/config')
-const PACKAGES_DIR = path.join(process.cwd(), config.getPackagesFolder())
 
 /**
  * Get array of commands to execute on all folders
  * @return {Array<Array>}
  */
 function getAllTaskArrays () {
-  const cwds = config.getScopes().map(pkg => path.join(PACKAGES_DIR, pkg))
+  const cwds = config.getScopesPaths()
   return cwds.map(getTaskArray)
 }
 

--- a/packages/sui-test/bin/karma/patch.js
+++ b/packages/sui-test/bin/karma/patch.js
@@ -18,7 +18,7 @@ process.stdout.write = msg => {
   }
 
   // Ignore total output since we only have one browser:
-  if (msg.match(/\u001b\[32mTOTAL: /)) return
+  if (msg.match(/\u001b\[32mTOTAL: /)) return // eslint-disable-line no-control-regex
 
   return write.call(process.stdout, msg)
 }


### PR DESCRIPTION
As part of windows compatibility, we need a command that avoid use "rm -Rf" and doesn't rely on having installed 'rimraf' globally. 

So, now we have an `sui-mono phoenix` command that is even more optimized that the classic `rm -Rf node_modules && npm i && sui-mono run-parallel rm -Rf node_modules && sui-mono run-parallel npm i` as it runs more in parralel.