### PR TITLE
feat(babel-preset-sui): use better targeting browsers in order to make more sense

### DIFF
--- a/packages/babel-preset-sui/lib/index.js
+++ b/packages/babel-preset-sui/lib/index.js
@@ -3,17 +3,17 @@ const cleanList = require('./clean-list')
 
 module.exports = {
   'presets': cleanList([
-    ["env", {
-      "debug": false,
-      "targets": {
-        "node": "6.0.0",
-        "browsers": [
-          "> 1%",
-          "last 4 versions",
-          "Firefox ESR",
-          "Safari >= 6",
-          "iOS >= 7",
-          "not ie < 11"
+    ['env', {
+      'debug': false,
+      'targets': {
+        'node': '6.0.0',
+        'browsers': [
+          '> 0.25%',
+          'Firefox ESR',
+          'Safari >= 8',
+          'iOS >= 8',
+          'ie >= 11',
+          'not op_mini all'
         ]
       }
     }],


### PR DESCRIPTION
As some of you may know, the `last 4 versions` in browserlist is considered harmful. Why? Well, basically because we're aiming the last 4 versions OF ALL THE BROWSERS IN THE HISTORY OF THE BROWSERS. 🤯

It does mean we're supporting even IE7, old browsers as IE Mobile or not longer developed browsers like Opera Mini. In order to try a better aiming to our browsers, this PR try to use a best approach.

You could check the browsers supported in these new lines:

Before:
http://browserl.ist/?q=%3E+1%25%2C+last+4+versions%2C+Firefox+ESR%2C+Safari+%3E%3D+6%2C+iOS+%3E%3D+7%2C+not+ie+%3C+11

After:
http://browserl.ist/?q=%3E+0.25%25%2CFirefox+ESR%2CSafari+%3E%3D+8%2CiOS+%3E%3D+8%2Cie+%3E%3D+11%2Cnot+op_mini+all