### PR TITLE
fix(sui-bundler): sui-bundler dev not using babel-preset-sui

### DIFF
--- a/packages/sui-bundler/shared/module-rules-babel.js
+++ b/packages/sui-bundler/shared/module-rules-babel.js
@@ -1,0 +1,9 @@
+module.exports = {
+  test: /\.jsx?$/,
+  exclude: /node_modules(?!\/@s-ui\/studio\/src)/,
+  loader: 'babel-loader',
+  query: {
+    babelrc: false,
+    presets: ['sui']
+  }
+}

--- a/packages/sui-bundler/webpack.config.dev.js
+++ b/packages/sui-bundler/webpack.config.dev.js
@@ -2,6 +2,7 @@ const path = require('path')
 const webpack = require('webpack')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const LoaderUniversalOptionsPlugin = require('./plugins/loader-options')
+const babelRules = require('./shared/module-rules-babel')
 require('./shared/shims')
 
 const {
@@ -44,18 +45,7 @@ let webpackConfig = {
   ],
   module: {
     rules: [
-      {
-        test: /\.jsx?$/,
-        include: /src/,
-        exclude: /node_modules(?!\/@s-ui\/studio\/src)/,
-        use: {
-          loader: 'babel-loader',
-          options: {
-            babelrc: false,
-            presets: ['sui']
-          }
-        }
-      },
+      babelRules,
       {
         test: /(\.css|\.scss)$/,
         use: ['style-loader', 'css-loader', 'postcss-loader', 'sass-loader']

--- a/packages/sui-bundler/webpack.config.lib.js
+++ b/packages/sui-bundler/webpack.config.lib.js
@@ -2,6 +2,7 @@ const webpack = require('webpack')
 const {cleanList, envVars, MAIN_ENTRY_POINT, config} = require('./shared')
 const uglifyJsPlugin = require('./shared/uglify')
 const definePlugin = require('./shared/define')
+const babelRules = require('./shared/module-rules-babel')
 require('./shared/shims')
 
 module.exports = {
@@ -29,16 +30,7 @@ module.exports = {
     definePlugin
   ]),
   module: {
-    rules: [
-      {
-        test: /\.jsx?$/,
-        exclude: /node_modules/,
-        loader: 'babel-loader',
-        query: {
-          presets: ['sui']
-        }
-      }
-    ]
+    rules: [babelRules]
   },
   node: {
     fs: 'empty',

--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -9,6 +9,7 @@ const SWPrecacheWebpackPlugin = require('sw-precache-webpack-plugin')
 const uglifyJsPlugin = require('./shared/uglify')
 const webpack = require('webpack')
 const definePlugin = require('./shared/define')
+const babelRules = require('./shared/module-rules-babel')
 
 const {
   navigateFallbackWhitelist,
@@ -136,14 +137,7 @@ module.exports = {
   ]),
   module: {
     rules: [
-      {
-        test: /\.jsx?$/,
-        exclude: /node_modules(?!\/@s-ui\/studio\/src)/,
-        loader: 'babel-loader',
-        query: {
-          presets: ['sui']
-        }
-      },
+      babelRules,
       {
         test: /(\.css|\.scss)$/,
         use: [

--- a/packages/sui-bundler/webpack.config.server.js
+++ b/packages/sui-bundler/webpack.config.server.js
@@ -1,6 +1,7 @@
 const webpack = require('webpack')
 const webpackNodeExternals = require('webpack-node-externals')
 const path = require('path')
+const babelRules = require('./shared/module-rules-babel')
 
 let webpackConfig = {
   context: path.resolve(process.cwd(), 'src'),
@@ -15,18 +16,7 @@ let webpackConfig = {
   externals: [webpackNodeExternals()],
   plugins: [new webpack.DefinePlugin({'global.GENTLY': false})],
   module: {
-    rules: [
-      {
-        test: /\.jsx?$/,
-        exclude: /node_modules(?!\/@s-ui\/studio\/src)/,
-        use: {
-          loader: 'babel-loader',
-          options: {
-            presets: ['sui']
-          }
-        }
-      }
-    ]
+    rules: [babelRules]
   }
 }
 


### PR DESCRIPTION
## Description
dev config had a bad format. So babel-preset-sui was not used and "env" was used instead.
This causes problems in studios that use spread operators in they demo files for instance.
