### PR TITLE
feat(sui-ssr): fix an error that was causing a false no renderProps error on our ssr server

### DIFF
--- a/packages/sui-ssr/server/ssr/index.js
+++ b/packages/sui-ssr/server/ssr/index.js
@@ -48,16 +48,16 @@ export default (req, res, next) => {
   match(
     {routes, location: url},
     async (error, redirectLocation, renderProps) => {
-      if (error || !renderProps) {
-        return next(error || new Error(`No renderProps for ${url}`))
-      }
-
-      if (redirectLocation) {
+      if (!error && redirectLocation) {
         const queryString = Object.keys(query).length
           ? `?${qs.stringify(query)}`
           : ''
         const destination = `${redirectLocation.pathname}${queryString}`
         return res.redirect(HTTP_PERMANENT_REDIRECT, destination)
+      }
+
+      if (error || !renderProps) {
+        return next(error || new Error(`No renderProps for ${url}`))
       }
 
       const [criticalHTML, bodyHTML] = html.split('</head>')


### PR DESCRIPTION
## Description
The error was caused when we tried to redirect from the root of our application to another route.
 
So if we have a kind of this router structure:

```javascript
  <Router>
    <Route path="/" getComponent={App}>
      <IndexRedirect to="/bar">
      <Route path="/bar">
         <IndexRoute getComponent={LoadAlertasPage} />
      </Route>
    </Route>
  </Router>
```

As we had the code it will throw an error here `if (error || !renderProps) {` because the redirect does not have any renderProp but have a redirectLocation object.
