### PR TITLE
fix(sui-lint): upgrade babel-eslint version and fix problems with decorators

### DIFF
--- a/packages/sui-lint/package.json
+++ b/packages/sui-lint/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "@s-ui/helpers": "1",
-    "babel-eslint": "8.2.2",
+    "babel-eslint": "8.2.3",
     "commander": "2.15.1",
     "eslint": "4.19.1",
     "eslint-config-prettier": "2.9.0",


### PR DESCRIPTION
Some methods are marked as unused because it doesn't detect decorators. It seems that's a problem from a babel-eslint subdependency. In order to try to fix that, we're upgrading the babel-eslint version to the latest as in local it fixed the problem.