### PR TITLE
Fix/node 6 compatibility

### DIFF
--- a/packages/sui-bundler/bin/sui-bundler-lib.js
+++ b/packages/sui-bundler/bin/sui-bundler-lib.js
@@ -48,7 +48,9 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 
 const version = getPackageJson(process.cwd()).version
 const outputFolder = path.join(process.cwd(), output, path.sep, version)
-const webpackConfig = {...config, entry: path.resolve(process.cwd(), entry)}
+const webpackConfig = Object.assign({}, config, {
+  entry: path.resolve(process.cwd(), entry)
+})
 webpackConfig.output.publicPath = publicPath + version + '/'
 webpackConfig.output.path = outputFolder
 

--- a/packages/sui-bundler/shared/define.js
+++ b/packages/sui-bundler/shared/define.js
@@ -16,4 +16,5 @@ const defaults = {
   __BASE_DIR__: JSON.stringify(process.env.PWD)
 }
 
-module.exports = (vars = {}) => new webpack.DefinePlugin({...defaults, ...vars})
+module.exports = (vars = {}) =>
+  new webpack.DefinePlugin(Object.assign({}, defaults, vars))


### PR DESCRIPTION
Use `Object.assign` instead spread operator in order to keep node 6 compatibility for now.