### PR TITLE
feat(sui-mono): add npm 6 support for phoenix

### DIFF
--- a/packages/sui-mono/bin/sui-mono-phoenix.js
+++ b/packages/sui-mono/bin/sui-mono-phoenix.js
@@ -28,7 +28,10 @@ program
   })
   .parse(process.argv)
 
-const RIMRAF_CMD = [require.resolve('rimraf/bin'), ['node_modules']]
+const RIMRAF_CMD = [
+  require.resolve('rimraf/bin'),
+  ['package-lock.json', 'node_modules']
+]
 const NPM_CMD = ['npm', ['install']]
 let {chunk = DEFAULT_CHUNK} = program
 chunk = Number(chunk)


### PR DESCRIPTION
While we're supposed to support npm 3, node 8 and node 10 comes with greater versions. So some developers are not getting the latest update in the @s-ui/studio because they've package-lock files after the installs. For the sake of not having to support them, I'm adding a feature to support latest npm version removing the package-lock.json file in the phoenix. If the file is not present, it gets ignored. So, completely compat with previous versions.