### PR TITLE
Feature/mmaa 4032 add auth to ssr

### DIFF
--- a/packages/sui-decorators/test/server/cacheSpec.js
+++ b/packages/sui-decorators/test/server/cacheSpec.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-expressions */
-
+/* eslint-disable no-unused-vars */
 import {expect} from 'chai'
 
 import cache from '../../src/decorators/cache'

--- a/packages/sui-ssr/README.md
+++ b/packages/sui-ssr/README.md
@@ -37,6 +37,8 @@ Generate a static version of the server w/out dependencies in the server folder.
 
 Create a zip file with all assets needed to run the server in any infra.
 
+It will, over parameter, make that the express server run over a username and password in a htpasswd way.
+
 ```
   Usage: sui-ssr-archive [options]
 
@@ -44,6 +46,7 @@ Create a zip file with all assets needed to run the server in any infra.
 
     -C, --clean  Remove previous zip
     -h, --help   output usage information
+    -A, --auth <username:password> Will build the express definition under authentication htpassword like.
   Description:
 
   Examples:

--- a/packages/sui-ssr/archive/Dockerfile.tpl
+++ b/packages/sui-ssr/archive/Dockerfile.tpl
@@ -7,6 +7,10 @@ COPY ./public ./public
 COPY ./server ./server
 COPY ./statics ./statics
 
+# HERE BEGIN THE AUTH ENV VARIABLES
+{{AUTH_VARIABLES}}
+####################################
+
 EXPOSE 3000
 
 CMD [ "pm2-runtime", "start", "pm2.json"]

--- a/packages/sui-ssr/archive/authDefinitionBuilder.js
+++ b/packages/sui-ssr/archive/authDefinitionBuilder.js
@@ -1,0 +1,14 @@
+module.exports = ([username, password]) => {
+  console.log('')
+  console.log('->'.bold, ' AUTH'.blue.bold, 'option setted'.bold)
+  console.log(
+    '-> Web server will run over'.bold,
+    ' authentication 🔐'.blue.bold
+  )
+  console.log('')
+  console.log('         -> USERNAME:'.bold, username.cyan)
+  console.log('         -> PASSWORD:'.bold, password.replace(/(.?)/g, '*').cyan)
+  console.log('')
+
+  return `ENV AUTH_USERNAME ${username}\nENV AUTH_PASSWORD ${password}`
+}

--- a/packages/sui-ssr/bin/sui-ssr-archive.js
+++ b/packages/sui-ssr/bin/sui-ssr-archive.js
@@ -3,14 +3,17 @@
 const program = require('commander')
 const rimraf = require('rimraf')
 const path = require('path')
-
 const archive = require('../archive')
+require('colors')
 
-const OUTPUT_ZIP_PATH = path.join(process.cwd(), 'server.zip')
 const pkg = require(path.join(process.cwd(), 'package.json'))
-
+const REMOVE_ZIP_PATH = path.join(process.cwd(), '*.zip')
 program
   .option('-C, --clean', 'Remove previous zip')
+  .option(
+    '-A, --auth <auth>',
+    'A string based on username:password that will be used in order to log-in inside our website'
+  )
   .on('--help', () => {
     console.log('  Description:')
     console.log('')
@@ -20,14 +23,21 @@ program
     console.log('')
     console.log('    $ sui-ssr archive')
     console.log('')
+    console.log('')
+    console.log('')
+    console.log('    $ sui-ssr archive --auth="foo:bar"')
+    console.log('')
   })
   .parse(process.argv)
 
 if (program.clean) {
-  console.log('Removing previous zip...')
-  rimraf.sync(OUTPUT_ZIP_PATH)
+  console.log(' -> Removing ALL previous zip files 🗑 ...'.yellow.bold)
+  rimraf.sync(REMOVE_ZIP_PATH)
+  console.log(' -> Removed! ✅'.green.bold)
 }
 
+const OUTPUT_ZIP_PATH = path.join(process.cwd(), 'server.zip')
 ;(async () => {
+  console.log(' -> Compressing files... 🗄'.yellow)
   await archive({outputZipPath: OUTPUT_ZIP_PATH, pkg})
 })()

--- a/packages/sui-ssr/package.json
+++ b/packages/sui-ssr/package.json
@@ -17,10 +17,11 @@
   },
   "dependencies": {
     "@s-ui/hoc": "1.5.0",
-    "archiver": "2.1.1",
+    "archiver": "^2.1.1",
     "commander": "2.15.1",
     "copy-paste": "1.3.0",
     "express": "4.16.3",
+    "express-basic-auth": "^1.1.5",
     "rimraf": "2.6.2"
   }
 }

--- a/packages/sui-ssr/server/index.js
+++ b/packages/sui-ssr/server/index.js
@@ -1,12 +1,17 @@
 import express from 'express'
 import ssr from './ssr'
+import basicAuth from 'express-basic-auth'
 
 const app = express()
-const {PORT = 3000} = process.env
-
+const {PORT = 3000, AUTH_USERNAME, AUTH_PASSWORD} = process.env
+const runningUnderAuth = AUTH_USERNAME && AUTH_PASSWORD
+const AUTH_DEFINITION = {
+  users: {[AUTH_USERNAME]: AUTH_PASSWORD},
+  challenge: true
+}
+runningUnderAuth && app.use(basicAuth(AUTH_DEFINITION))
 app.use(express.static('statics'))
 app.use(express.static('public', {index: false}))
-
 app.get('/_health', (req, res) =>
   res.status(200).json({uptime: process.uptime()})
 )


### PR DESCRIPTION
## Description
In order to allow developers to have a ssr server protected over user and password I've added the --auth parameter to the ssr.

The parameter is injecting two ENV vars on the dockerfile that will be getted from express on request run-time and passed to a middleware that will prompt us asking for credentials.

I've also improved the console output in order to be more user friendly.

## Example
![ezgif com-video-to-gif 9](https://user-images.githubusercontent.com/5639972/42377219-b72f214c-8122-11e8-8eba-371510e65d8b.gif)
