### PR TITLE
Fix sui deploy

### DIFF
--- a/packages/sui-deploy/src/client/now.js
+++ b/packages/sui-deploy/src/client/now.js
@@ -17,7 +17,9 @@ const getNowCommandArgs = ({name, dir, auth, token}) => {
 
 const getDeploymentsByName = async (now, name) => {
   const deployments = await now.getDeployments()
-  return deployments.filter(d => d.name === name)
+  return deployments
+    .filter(d => d.name === name)
+    .sort((a, b) => b.created - a.created)
 }
 
 const setAliasToLastDeploy = async (now, name) => {
@@ -55,7 +57,6 @@ class NowDeployClient {
     const deployments = await getDeploymentsByName(this.now, this.deployName)
     return Promise.all(
       deployments
-        .sort((a, b) => b.created - a.created)
         .slice(deploysToMaintain)
         .map(({uid}) => this.now.deleteDeployment(uid))
     )

--- a/packages/sui-deploy/src/client/now.js
+++ b/packages/sui-deploy/src/client/now.js
@@ -1,7 +1,10 @@
 const NowClient = require('now-client')
 const {join} = require('path')
 const {writeFile, removeFile} = require('@s-ui/helpers/file')
+const {resolveLazyNPMBin} = require('@s-ui/helpers/packages')
+const {getSpawnPromise} = require('@s-ui/helpers/cli')
 const DEFAULT_DIR = join(process.cwd(), 'public')
+const NOW_VERSION = '11.2.8'
 
 // Get args of `now` command according to params
 const getNowCommandArgs = ({name, dir, auth, token}) => {
@@ -63,10 +66,12 @@ class NowDeployClient {
   }
 
   async deploy(dir = DEFAULT_DIR, {auth} = {}) {
-    const {getSpawnPromise} = require('@s-ui/helpers/cli')
     const {deployName: name, nowToken: token} = this
-
-    await getSpawnPromise('now', getNowCommandArgs({name, token, dir, auth}))
+    const nowBinPath = await resolveLazyNPMBin('.bin/now', `now@${NOW_VERSION}`)
+    await getSpawnPromise(
+      nowBinPath,
+      getNowCommandArgs({name, token, dir, auth})
+    )
     this.deletePreviousDeployments(1)
     return setAliasToLastDeploy(this.now, this.deployName)
   }

--- a/packages/sui-helpers/packages.js
+++ b/packages/sui-helpers/packages.js
@@ -137,7 +137,9 @@ const resolveLazyNPMBin = async (binPath, pkg) => {
       `It looks like the lazy installed dep '${pkg}' is missing. It will be installed now.`
         .cyan
     )
-    return getSpawnPromise('npm', ['install', `${pkg}`]).then(resolvePkgBin)
+    return getSpawnPromise('npm', ['install', `${pkg}`, '--no-save']).then(
+      resolvePkgBin
+    )
   }
 }
 

--- a/packages/sui-helpers/packages.js
+++ b/packages/sui-helpers/packages.js
@@ -1,3 +1,4 @@
+/* eslint no-console:0 */
 const path = require('path')
 
 /**
@@ -130,9 +131,11 @@ const resolveLazyNPMBin = async (binPath, pkg) => {
   try {
     return resolvePkgBin()
   } catch (e) {
-    const {getSpawnPromise, showWarning} = require('./cli')
-    showWarning(
+    const {getSpawnPromise} = require('./cli')
+    require('colors')
+    console.log(
       `It looks like the lazy installed dep '${pkg}' is missing. It will be installed now.`
+        .cyan
     )
     return getSpawnPromise('npm', ['install', `${pkg}`]).then(resolvePkgBin)
   }

--- a/packages/sui-test/bin/sui-test-e2e.js
+++ b/packages/sui-test/bin/sui-test-e2e.js
@@ -3,9 +3,8 @@
 
 const path = require('path')
 const program = require('commander')
-const chalk = require('chalk')
 const {getSpawnPromise, showError} = require('@s-ui/helpers/cli')
-
+const {resolveLazyNPMBin} = require('@s-ui/helpers/packages')
 const CYPRESS_VERSION = '2.1.0'
 const CYPRESS_FOLDER_PATH = path.resolve(__dirname, 'cypress')
 const TESTS_FOLDER = process.cwd() + '/test-e2e'
@@ -54,31 +53,7 @@ if (screenshotsOnError) {
   cypressConfig.screenshotsFolder = SCREENSHOTS_FOLDER
 }
 
-// Resolve path for cypress in current working directory
-const resolveCypressBin = () =>
-  require.resolve('cypress/bin/cypress', {
-    paths: [path.resolve(process.cwd(), 'node_modules')]
-  })
-
-// Get cypress bin path. If not found, install cypress and then return its path
-const getCypressBinPath = async () => {
-  try {
-    return Promise.resolve(resolveCypressBin())
-  } catch (e) {
-    console.log(
-      chalk.magenta(
-        'It looks like this is your first time using sui-test e2e.' +
-          '\nCypress will be installed to setup your project for end-to-end testing.'
-      )
-    )
-    return getSpawnPromise('npm', [
-      'install',
-      `cypress@${CYPRESS_VERSION}`
-    ]).then(resolveCypressBin)
-  }
-}
-
-getCypressBinPath()
+resolveLazyNPMBin('cypress/bin/cypress', `cypress@${CYPRESS_VERSION}`)
   .then(cypressBinPath =>
     getSpawnPromise(cypressBinPath, [
       gui ? 'open' : 'run',


### PR DESCRIPTION
Lazy loading of now in sui-deploy to avoid:
* to have to install it globally (in travis for instance)
* to have it install with sui-deploy before having to do a deployment, which is not a common task.

Plus, a helper has been created to avoid duplicated code and cypress in sui-test is now lazy loaded the same way.
