### PR TITLE
fix(sui-deploy): don't try to alias when alias is present

### DIFF
--- a/packages/sui-deploy/src/client/now.js
+++ b/packages/sui-deploy/src/client/now.js
@@ -29,7 +29,12 @@ const setAliasToLastDeploy = async (now, name) => {
   const deployments = await getDeploymentsByName(now, name)
   if (deployments.length) {
     const lastDeployId = deployments.pop().uid
-    await now.createAlias(lastDeployId, name)
+    const aliases = await now.getAliases(lastDeployId)
+    if (!aliases.length) {
+      await now.createAlias(lastDeployId, name)
+    } else {
+      return `https://${aliases[0].alias}`
+    }
   }
   return `https://${name}.now.sh`
 }


### PR DESCRIPTION
## Description
When a deploy is made with the same source code, deploy is omitted and then the alias should not be tried to set. This wsa throwing a 409 error.
