### PR TITLE
feat(sui-polyfills): use latest core-js to use same version as latest babel-polyfill used

### DIFF
--- a/packages/sui-polyfills/package.json
+++ b/packages/sui-polyfills/package.json
@@ -7,7 +7,7 @@
   "keywords": [],
   "author": "Miguel Angel Duran <miduga@gmail.com>",
   "dependencies": {
-    "core-js": "2.5.0"
+    "core-js": "2.5.7"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Avoid installing two different versions of core-js so we use the latest version as it's being used by babel-polyfill.

![image](https://user-images.githubusercontent.com/1561955/43830275-3306f96e-9b01-11e8-8868-4fb6fc1e4355.png)
