### PR TITLE
feat(sui-bundler): adds relative to absolute path conversion

### DIFF
--- a/packages/sui-bundler/loaders/linkLoaderConfigBuilder.js
+++ b/packages/sui-bundler/loaders/linkLoaderConfigBuilder.js
@@ -14,11 +14,13 @@ module.exports = ({config, packagesToLink}) => {
     return [...plugins.slice(0, pos), ...plugins.slice(pos + 1)]
   }
 
-  const entryPoints = packagesToLink.reduce((acc, packagePath) => {
-    const pkg = require(path.join(packagePath, 'package.json'))
-    acc[pkg.name] = path.join(packagePath, 'src')
-    return acc
-  }, {})
+  const entryPoints = packagesToLink
+    .map(p => path.resolve(p))
+    .reduce((acc, packagePath) => {
+      const pkg = require(path.join(packagePath, 'package.json'))
+      acc[pkg.name] = path.join(packagePath, 'src')
+      return acc
+    }, {})
 
   const nextConfig = {
     ...config,


### PR DESCRIPTION
## Description
This PR adds the ability to easily link a package using relative path to your linked component

### Simplifying linking with SuiBundler
The current Sui-Bundler allows to link packages using absolute paths like this:
`./node_modules/@s-ui/bundler/bin/sui-bundler-dev.js --link-package User/david.garcia/www/frontend-fc--lib-real-estate`

### After this PR will be like this:
Linking the Domain to Web Server:
`./node_modules/@s-ui/bundler/bin/sui-bundler-dev.js --link-package ../frontend-fc--lib-real-estate`

_Notice the relative path to the linked component_

To make it even easier, you can create an alias function in your .bashrc/.zshrc config file so the execution to link the real-estate domain to the Web Server will be:
`sblink ../frontend-fc--lib-real-estate`

## Example
Linking the Domain to Web Server:
`./node_modules/@s-ui/bundler/bin/sui-bundler-dev.js --link-package ../frontend-fc--lib-real-estate`

Linking the Detail Header component to Web Server using the **Optional Bash Script**:
`sblink ../frontend-fc--uilib-components/components/detail/header/`

## Optional Bash Script to make linking Sui-Bundler easier
In addition to the feature added in this PR. You can decide to add this bash script to make the execution on Sui-Bundler easier. If not included it will work eitherway. **Is completely optional**
This is the bash function:
```bash
# Linking with SUI-Bundler
function sblink_func () {
  links=()
  for arg in "$@"
    do
      links+=("--link-package=$arg")
    done
  params=$(IFS=$' '; echo "${links[*]}")
  echo $params
  echo "./node_modules/.bin/sui-bundler dev $params"
  ./node_modules/.bin/sui-bundler dev $params
}

alias sblink=sblink_func
# Kudos to Miguel Ángel for this awesome shell script 💻
```

I hope you find it useful! 
🐼