### PR TITLE
fix(sui-studio): unescape path separator in regex to avoid error importing demo page.

### DIFF
--- a/packages/sui-studio/src/components/tryRequire.js
+++ b/packages/sui-studio/src/components/tryRequire.js
@@ -75,7 +75,7 @@ export const tryRequireCore = async ({category, component}) => {
   const demo = requireFile({
     defaultValue: false,
     importFile: () =>
-      import(/* webpackExclude: /\/node_modules\/(.*)\/demo/index.js$/ */
+      import(/* webpackExclude: /\/node_modules\/(.*)\/demo\/index.js$/ */
       `${__BASE_DIR__}/demo/${category}/${component}/demo/index.js`)
   })
 


### PR DESCRIPTION
## Description

It seems that there is one path separator ‘/‘ that is unescaped inside the webpackExclude regex, which is making that the studio fails to start.

The error displayed when trying to run `sui-studio start` command is:

```
./components/tryRequire.js 154:31-91
Compilation error while processing magic comment(-s): /* webpackExclude: /\/node_modules\/(.*)\/demo/index.js$/ */: Invalid regular expression flags
```