### PR TITLE
Feat/adds ur ifriendly string normalizer

### DIFF
--- a/packages/sui-js/README.md
+++ b/packages/sui-js/README.md
@@ -54,13 +54,14 @@ console.log(md5Hash) // f97ed77ff4770b7d8f0a018223823d3b
 ```
 
 ## string
-A bunch of string utilities: remove accents, ...
+A bunch of string utilities: remove accents and uri friendly string Normalizer
 
 ```js
-import { removeAccents, hasAccents } from '@s-ui/js/lib/string'
+import { removeAccents, hasAccents, uriNormalizer } from '@s-ui/js/lib/string'
 
 console.log(removeAccents('París')) // "Paris"
 console.log(hasAccents('Árbol')) // true
+console.log(uriNormalizer("España y L'Hóspitalët")) // espana-y-l-hospitalet
 ```
 
 ## ua-parser

--- a/packages/sui-js/README.md
+++ b/packages/sui-js/README.md
@@ -54,7 +54,9 @@ console.log(md5Hash) // f97ed77ff4770b7d8f0a018223823d3b
 ```
 
 ## string
-A bunch of string utilities: remove accents and uri friendly string Normalizer
+A bunch of string utilities: remove accents and uri friendly string Normalizer.
+`uriNormalizer` uses [slugify](https://www.npmjs.com/package/slugify) to replace characters based on its own charmap.
+It might be extended adding more keys to `customCharMap` const.
 
 ```js
 import { removeAccents, hasAccents, uriNormalizer } from '@s-ui/js/lib/string'

--- a/packages/sui-js/package.json
+++ b/packages/sui-js/package.json
@@ -13,7 +13,8 @@
     "cookie": "0.3.1",
     "js-cookie": "2.1.4",
     "lodash.kebabcase": "4.1.1",
-    "remove-accents": "0.4.2"
+    "remove-accents": "0.4.2",
+    "slugify": "1.3.1"
   },
   "license": "MIT",
   "repository": {

--- a/packages/sui-js/src/string/index.js
+++ b/packages/sui-js/src/string/index.js
@@ -1,3 +1,4 @@
 export {fromSnakeToCamelCase, fromCamelToSnakeCase} from './snake-case'
+export {uriNormalizer} from './uri-normalizer'
 export {has as hasAccents, remove as removeAccents} from 'remove-accents'
 export {default as toKebabCase} from 'lodash.kebabcase'

--- a/packages/sui-js/src/string/uri-normalizer.js
+++ b/packages/sui-js/src/string/uri-normalizer.js
@@ -1,7 +1,9 @@
+import slugify from 'slugify'
+
+const customCharMap = {
+  "'": '_'
+}
 export const uriNormalizer = str => {
-  return str
-    .toLowerCase()
-    .replace(/[\s']/g, '-')
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
+  slugify.extend(customCharMap)
+  return slugify(str).toLowerCase()
 }

--- a/packages/sui-js/src/string/uri-normalizer.js
+++ b/packages/sui-js/src/string/uri-normalizer.js
@@ -1,0 +1,7 @@
+export const uriNormalizer = str => {
+  return str
+    .toLowerCase()
+    .replace(/[\s']/g, '-')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+}


### PR DESCRIPTION
## Description
This function normalices capital letters, spaces, accents and any other non standard ASCII character into an URI friendly string.

## Example
`console.log(uriNormalizer("España y L'Hóspitalët")) // espana-y-l-hospitalet`

Please review