### PR TITLE
Feature/sort alphabetically props on docs

### DIFF
--- a/packages/sui-studio/package.json
+++ b/packages/sui-studio/package.json
@@ -44,11 +44,11 @@
     "fs.realpath": "1.0.0",
     "gh-pages": "0.4.0",
     "just-debounce-it": "1.0.1",
-    "normalize.css": "4.1.1",
+    "normalize.css": "8.0.0",
     "now-client": "1.1.1",
     "pascal-case": "2.0.0",
     "pmx": "0.6.2",
-    "react-docgen": "2.20.0",
+    "react-docgen": "2.21.0",
     "snarkdown": "1.2.2"
   },
   "suistudio-webpack": {

--- a/packages/sui-studio/src/components/documentation/Api.js
+++ b/packages/sui-studio/src/components/documentation/Api.js
@@ -16,12 +16,12 @@ class Api extends Component {
     const reactDocs = await import('react-docgen')
     const src = await tryRequireRawSrc(this.props.params)
     const docs = reactDocs.parse(src)
-
+    console.log(docs)
     this.setState({docs})
   }
 
   _renderPropsApi({propsApi = {}}) {
-    const keysOfProps = Object.keys(propsApi)
+    const keysOfProps = Object.keys(propsApi).sort((a, b) => a.localeCompare(b))
     // if the component doesn't have props, show a message
     if (keysOfProps.length === 0) {
       return <p>This component doesn't have props</p>

--- a/packages/sui-studio/src/components/documentation/Api.js
+++ b/packages/sui-studio/src/components/documentation/Api.js
@@ -16,7 +16,7 @@ class Api extends Component {
     const reactDocs = await import('react-docgen')
     const src = await tryRequireRawSrc(this.props.params)
     const docs = reactDocs.parse(src)
-    console.log(docs)
+
     this.setState({docs})
   }
 


### PR DESCRIPTION
In order to help developers read and find props, this PR sorts the props of the documentation alphabetically so it's not a mess to consult them.

After:
![image](https://user-images.githubusercontent.com/1561955/44649286-bc805f00-a9e3-11e8-9542-b0c198138f41.png)

Before:
![image](https://user-images.githubusercontent.com/1561955/44649307-c904b780-a9e3-11e8-9b5a-8e5f56fbaa68.png)
