### PR TITLE
feat(sui-test): added support dynamic import when we run ci test

### DIFF
--- a/packages/sui-test/bin/karma/config.js
+++ b/packages/sui-test/bin/karma/config.js
@@ -36,9 +36,10 @@ const config = {
 
 if (TARGET === 'test:ci') {
   config.reporters = ['coverage'].concat(config.reporters)
-  config.browserify.transform = [require('browserify-babel-istanbul')].concat(
-    config.browserify.transform
-  )
+  config.browserify.transform = [
+    ...config.browserify.transform,
+    require('browserify-babel-istanbul')
+  ]
   config.coverageReporter = {
     dir: `${CWD}/coverage`,
     reporters: [


### PR DESCRIPTION
## Description
We have recently added support for dynamic imports in client and server side but we found that is necessary that Istanbul reads the code after been "transpiled", for this reason, the order is important and has changed in this PR. Now we have first the transform plugins and later Istanbul package for test coverage.

