### PR TITLE
fix(sui-studio): generate components without linter errors nor warnings

### DIFF
--- a/packages/sui-studio/bin/sui-studio-generate.js
+++ b/packages/sui-studio/bin/sui-studio-generate.js
@@ -149,7 +149,8 @@ ${componentInPascal}.displayName = '${componentInPascal}'
 // ${componentInPascal}.propTypes = {}
 // ${componentInPascal}.defaultProps = {}
 
-export default ${componentInPascal}`
+export default ${componentInPascal}
+`
   ),
 
   writeFile(
@@ -158,7 +159,8 @@ export default ${componentInPascal}`
 
 .${prefix}-${componentInPascal} {
   // Do your magic
-}`
+}
+`
   ),
 
   writeFile(


### PR DESCRIPTION
Avoid generating a new component with sass and js lint errors. For that, we're adding an empty line to the end of the generated file.