### PR TITLE
Feature/transpile dynamic imports

### DIFF
--- a/packages/babel-preset-sui/lib/index.js
+++ b/packages/babel-preset-sui/lib/index.js
@@ -2,39 +2,46 @@ const isInstalled = require('./is-installed')
 const cleanList = require('./clean-list')
 
 module.exports = {
-  'presets': cleanList([
-    ['env', {
-      'debug': false,
-      'targets': {
-        'node': '6.0.0',
-        'browsers': [
-          '> 0.25%',
-          'Firefox ESR',
-          'Safari >= 8',
-          'iOS >= 8',
-          'ie >= 11',
-          'not op_mini all'
-        ]
+  presets: cleanList([
+    [
+      'env',
+      {
+        debug: false,
+        targets: {
+          node: '6.0.0',
+          browsers: [
+            '> 0.25%',
+            'Firefox ESR',
+            'Safari >= 8',
+            'iOS >= 8',
+            'ie >= 11',
+            'not op_mini all'
+          ]
+        }
       }
-    }],
+    ],
     isInstalled(['preact', 'react'], 'babel-preset-react'),
     isInstalled('flow-bin', 'babel-preset-flow')
   ]),
-  'plugins': [
+  plugins: [
     require('babel-plugin-transform-async-generator-functions'),
     require('babel-plugin-transform-decorators-legacy').default,
     require('babel-plugin-transform-class-properties'),
     require('babel-plugin-transform-object-rest-spread'),
     require('babel-plugin-transform-runtime'),
+    require('babel-plugin-dynamic-import-webpack'),
     require('babel-plugin-syntax-dynamic-import'),
     require('babel-plugin-transform-export-extensions'),
-    [require('babel-plugin-transform-react-remove-prop-types').default, {
-      mode: 'wrap'
-    }]
+    [
+      require('babel-plugin-transform-react-remove-prop-types').default,
+      {
+        mode: 'wrap'
+      }
+    ]
   ],
-  'env': {
-    'development': {
-      'plugins': cleanList([
+  env: {
+    development: {
+      plugins: cleanList([
         isInstalled(['preact', 'react'], 'react-hot-loader/babel')
       ])
     }

--- a/packages/babel-preset-sui/lib/index.js
+++ b/packages/babel-preset-sui/lib/index.js
@@ -29,7 +29,7 @@ module.exports = {
     require('babel-plugin-transform-class-properties'),
     require('babel-plugin-transform-object-rest-spread'),
     require('babel-plugin-transform-runtime'),
-    require('babel-plugin-dynamic-import-webpack'),
+    require('babel-plugin-dynamic-import-webpack').default,
     require('babel-plugin-syntax-dynamic-import'),
     require('babel-plugin-transform-export-extensions'),
     [

--- a/packages/babel-preset-sui/package.json
+++ b/packages/babel-preset-sui/package.json
@@ -7,18 +7,19 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "babel-plugin-dynamic-import-webpack": "1.0.2",
     "babel-plugin-syntax-dynamic-import": "6.18.0",
     "babel-plugin-transform-async-generator-functions": "6.24.1",
     "babel-plugin-transform-class-properties": "6.24.1",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "babel-plugin-transform-export-extensions": "6.22.0",
     "babel-plugin-transform-object-rest-spread": "6.26.0",
-    "babel-plugin-transform-react-remove-prop-types": "0.4.8",
+    "babel-plugin-transform-react-remove-prop-types": "0.4.15",
     "babel-plugin-transform-runtime": "6.23.0",
-    "babel-preset-env": "1.6.0",
+    "babel-preset-env": "1.7.0",
     "babel-preset-flow": "6.23.0",
     "babel-preset-react": "6.24.1",
-    "react-hot-loader": "4.3.3"
+    "react-hot-loader": "4.3.5"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- [x] Add babel-plugin-dynamic-import-webpack in order to support dynamic imports in our code to be transpiled and compatible. Important: It removes the magic comment, if you still want the naming of your chunk, you should use require.ensure directly.
- [x] Upgrade some dependencies.
- [x] Prettify code.

In the future, we hope to implement our plugin in order to keep the webpack magic comment somehow.