### PR TITLE
Load env vars from file on runtime, buid app config object and pass it to the SPA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - npm i -g npm@3
   - npm i -g npx
 install:
-  - npm run phoenix
+  - npm run phoenix -- --no-progress
 script:
   - npm run lint
   - npm run test:ci

--- a/packages/sui-react-initial-props/src/createClientContextFactoryParams.js
+++ b/packages/sui-react-initial-props/src/createClientContextFactoryParams.js
@@ -1,5 +1,6 @@
 export default function createClientContextFactoryParams() {
   return {
+    appConfig: window.__APP_CONFIG__,
     cookies: document.cookie,
     isClient: true,
     pathName: window.location.pathname,

--- a/packages/sui-react-initial-props/src/createServerContextFactoryParams.js
+++ b/packages/sui-react-initial-props/src/createServerContextFactoryParams.js
@@ -2,6 +2,7 @@ export default function createServerContextFactoryParams(req) {
   // we export the request as well in order to allow some customized params
   // for example, we might be using a req.uuid here for each request and want to use on the context
   return {
+    appConfig: req.appConfig,
     req,
     cookies: req.headers.cookie,
     isClient: false,

--- a/packages/sui-ssr/README.md
+++ b/packages/sui-ssr/README.md
@@ -62,9 +62,9 @@ It will, over parameter, make that the express server run over a username and pa
 
 If no outputFileName is provided it will pipe the standard output stream `process.stdout`
 
-## User the ssr output as stream
+## Use the ssr output as stream
 
-It use the stdout stream so you can do things like:
+It uses the stdout stream so you can do things like:
 
 ```ssh
   $ sui-ssr archive > ./myFileNameOrWhatever.zip
@@ -72,9 +72,9 @@ It use the stdout stream so you can do things like:
 
 ## Hooks
 
-If you want change the server´s behavior for very specific business operation like handler error or logging. You must to use the hooks concept.
+If you want to change the server´s behavior for very specific business operation like handling errors or logging you must use hooks.
 
-To do that define a file `src/hooks.js` this file must be something like this:
+To do that define a file `src/hooks.js` which will look as follows:
 
 ```
 import TYPES from '@s-ui/ssr/hooks-types'
@@ -87,11 +87,23 @@ export default {
 }
 ```
 
-Here we implement a direct log into the console. Each hook type could be or a middleware function or an array of middlewares functions.
+Here we implement a direct log into the console. Each hook type could be a middleware function or an array of middlewares functions.
 
-You can checks with hooks there are available in the hooks-types.js file.
+You can check which hooks are available in the hooks-types.js file.
 
 There are two default hooks for 404 and 500 errors. both will look for a 404.html or 500.html file in the src folder and show this file. If you dont define this files, you will get a generic error page.
+
+## Environment variables
+
+You can define environment variables by creating a yml file called `public-env.yml` in your SPA root directory:
+
+```
+API_ENDPOINT: https://api.pre.somedomain.com
+SOME_OTHER_ENV_VAR: https://pre.somedomain.com/contact
+```
+
+- Whatever you add in this file will be available in your context factory as `appConfig.envs` param.
+- This file must not contain secrets as it is meant to be available in both server and client side.
 
 ## Use the ssr in a lambda function
 

--- a/packages/sui-ssr/README.md
+++ b/packages/sui-ssr/README.md
@@ -104,6 +104,7 @@ SOME_OTHER_ENV_VAR: https://pre.somedomain.com/contact
 
 - Whatever you add in this file will be available in your context factory as `appConfig.envs` param.
 - This file must not contain secrets as it is meant to be available in both server and client side.
+- :warning: And of course, this file is not meant to be versioned.
 
 ## Use the ssr in a lambda function
 

--- a/packages/sui-ssr/hooks-types.js
+++ b/packages/sui-ssr/hooks-types.js
@@ -1,5 +1,6 @@
 export default {
   LOGGING: 'logging',
   INTERNAL_ERROR: 'internal_error',
-  NOT_FOUND: 'not_found'
+  NOT_FOUND: 'not_found',
+  APP_CONFIG_SETUP: 'app_config_setup'
 }

--- a/packages/sui-ssr/package.json
+++ b/packages/sui-ssr/package.json
@@ -23,6 +23,7 @@
     "copy-webpack-plugin": "4.5.2",
     "express": "4.16.3",
     "express-basic-auth": "1.1.5",
+    "js-yaml": "3.12.0",
     "rimraf": "2.6.2"
   }
 }

--- a/packages/sui-ssr/server/hooksFactory/index.js
+++ b/packages/sui-ssr/server/hooksFactory/index.js
@@ -29,8 +29,18 @@ const responsePageByStatus = async code => {
   return html
 }
 
+// Build app config and attach it to the request.
+const builAppConfig = (req, res, next) => {
+  req.appConfig = {
+    envs: req.app.locals.publicEnvConfig,
+    hostname: req.hostname
+  }
+  next()
+}
+
 export default {
   [TYPES.LOGGING]: NULL_MDWL,
+  [TYPES.APP_CONFIG_SETUP]: builAppConfig,
   [TYPES.NOT_FOUND]: async (req, res, next) => {
     res.status(404).send(await responsePageByStatus(404))
   },

--- a/packages/sui-ssr/server/index.js
+++ b/packages/sui-ssr/server/index.js
@@ -3,8 +3,22 @@ import ssr from './ssr'
 import hooks from './hooksFactory'
 import TYPES from '../hooks-types'
 import basicAuth from 'express-basic-auth'
+import path from 'path'
+import fs from 'fs'
+import jsYaml from 'js-yaml'
 
 const app = express()
+
+app.set('x-powered-by', false)
+
+// Read public env vars from public-env.yml file and make them available for
+// middlewares by adding them to app.locals
+const publicEnvFile = fs.readFileSync(
+  path.join(process.cwd(), 'public-env.yml'),
+  'utf8'
+)
+app.locals.publicEnvConfig = jsYaml.safeLoad(publicEnvFile)
+
 const {PORT = 3000, AUTH_USERNAME, AUTH_PASSWORD} = process.env
 const runningUnderAuth = AUTH_USERNAME && AUTH_PASSWORD
 const AUTH_DEFINITION = {
@@ -20,6 +34,8 @@ app.get('/_health', (req, res) =>
 runningUnderAuth && app.use(basicAuth(AUTH_DEFINITION))
 app.use(express.static('statics'))
 app.use(express.static('public', {index: false}))
+
+app.use(hooks[TYPES.APP_CONFIG_SETUP])
 
 app.get('*', ssr)
 

--- a/packages/sui-ssr/server/index.js
+++ b/packages/sui-ssr/server/index.js
@@ -13,11 +13,15 @@ app.set('x-powered-by', false)
 
 // Read public env vars from public-env.yml file and make them available for
 // middlewares by adding them to app.locals
-const publicEnvFile = fs.readFileSync(
-  path.join(process.cwd(), 'public-env.yml'),
-  'utf8'
-)
-app.locals.publicEnvConfig = jsYaml.safeLoad(publicEnvFile)
+try {
+  const publicEnvFile = fs.readFileSync(
+    path.join(process.cwd(), 'public-env.yml'),
+    'utf8'
+  )
+  app.locals.publicEnvConfig = jsYaml.safeLoad(publicEnvFile)
+} catch (err) {
+  app.locals.publicEnvConfig = {}
+}
 
 const {PORT = 3000, AUTH_USERNAME, AUTH_PASSWORD} = process.env
 const runningUnderAuth = AUTH_USERNAME && AUTH_PASSWORD

--- a/packages/sui-ssr/server/ssr/index.js
+++ b/packages/sui-ssr/server/ssr/index.js
@@ -28,11 +28,12 @@ const HTTP_PERMANENT_REDIRECT = 301
 const INDEX_HTML_PATH = path.join(process.cwd(), 'public', 'index.html')
 const html = fs.readFileSync(INDEX_HTML_PATH, 'utf8')
 const APP_PLACEHOLDER = '<!-- APP -->'
-const injectDataHydratation = (data = {}) =>
-  `<script>window.__INITIAL_PROPS__ = ${JSON.stringify(data).replace(
+
+const injectDataHydration = ({windowPropertyName, data = {}}) =>
+  `<script>window.${windowPropertyName} = ${JSON.stringify(data).replace(
     /<\//g,
     '<\\/'
-  )}</script>`
+  )};</script>`
 
 const injectDataPerformance = ({
   getInitialProps: server,
@@ -108,7 +109,17 @@ export default (req, res, next) => {
         `</head>${bodyHTML}`
           .replace('<body>', `<body ${bodyAttributes.toString()}>`)
           .replace(APP_PLACEHOLDER, reactString)
-          .replace('</body>', `${injectDataHydratation(initialProps)}</body>`)
+          .replace(
+            '</body>',
+            `${injectDataHydration({
+              windowPropertyName: '__APP_CONFIG__',
+              data: req.appConfig
+            })}
+            ${injectDataHydration({
+              windowPropertyName: '__INITIAL_PROPS__',
+              data: initialProps
+            })}</body>`
+          )
           .replace('</body>', `${injectDataPerformance(performance)}</body>`)
       )
     }


### PR DESCRIPTION
## Description
The main purpose is about being able to set environmental variables on runtime so that:
- you don't have to build the app one time per environment.
- It means that this ease, simplifies and speeds up your CI/CD process.
- Also the code and config are separated so that your app becomes environment agnostic.
- And as your app is built just once you can trust that what you test is exactly what you deploy.

## Additional info
- Note that env file was named with "public" word so that developers have a clue to not add secrets in it. If a secret was needed, the same approach could be applied in an implementation where secrets are read from a `private-env.yml` file with the exception that this data should not be passed to the SPA in any case.
- req.hostname is added to appConfig by default. In the NC project the hostname is needed in order to identify the site the user is going to see and it is used to construct the domain layer. For any other case I thought it could be also useful to have the hostname set from the server by default.

## Example
Create a yaml file and place it in the root directory of your SPA.
```
# mySpa/public-env.yml
API_SOME_ENDPOINT: test.some.com/some/service
API_SOME_OTHER_ENDPOINT: test.some.com/some-other/service
```

Now you can have access to those envs from your app's context factory. You can use it to construct your data layer config.
```
# mySpa/src/contextFactory.js
export default function contextFactory({
  appConfig = {},
  cookies,
  isClient,
  pathName,
  req = {},
  userAgent
}) {
  const domain = new MyDomain(appConfig.envs)
...
```

