### PR TITLE
fix(sui-deploy): added branch name in each travis build to deploy our current branch in NOW with his own name.

### DIFF
--- a/packages/sui-deploy/src/utils.js
+++ b/packages/sui-deploy/src/utils.js
@@ -19,7 +19,10 @@ const getDeployNameFromProgram = async program => {
   const deployName =
     deployBaseName +
     (program.branch
-      ? '-' + (process.env.TRAVIS_BRANCH || (await getGitBranch()))
+      ? '-' +
+        (process.env.TRAVIS_PULL_REQUEST_BRANCH ||
+          process.env.TRAVIS_BRANCH ||
+          (await getGitBranch()))
       : '')
   return toKebabCase(deployName)
 }


### PR DESCRIPTION
Travis has changed the way into checkout to other branches in builds. 
- Before this change we were in the current branch of the PR. Then we knew the branch name and we could use it.
- After this change, is a little bit more complicated take the current branch name to use it as url. First of all, we need to use a new environment variable name process.env.TRAVIS_PULL_REQUEST_BRANCH.

As a fallback, we will have process.env.TRAVIS_BRANCH and getGitBranch func.
