### PR TITLE
fix(sui-bundler): add optimization node env overwrite to false in ord…

### DIFF
--- a/packages/sui-bundler/webpack.config.server.js
+++ b/packages/sui-bundler/webpack.config.server.js
@@ -14,6 +14,9 @@ let webpackConfig = {
     chunkFilename: '[name].[chunkhash:8].js',
     filename: '[name].[chunkhash:8].js'
   },
+  optimization: {
+    nodeEnv: false
+  },
   externals: [webpackNodeExternals()],
   plugins: [new webpack.DefinePlugin({'global.GENTLY': false})],
   module: {


### PR DESCRIPTION
## Description

### Whats the problem?
On SSR bundling our NODE_ENV is getting overwritted by the mode base behavior.

### How did we realised about that?
On pre builds we've seen the next warning
<img width="743" alt="captura de pantalla 2018-09-22 a las 3 14 23" src="https://user-images.githubusercontent.com/5639972/45911591-a82e5700-be15-11e8-9968-9990a61b9373.png">

### How we detected that the bug was on that file?

After long time debugging trying to set my node_env to preproduction I realised about the fact that our domain config was printing the console log `ENV: process.env.NODE_ENV` so I decided to check if cloning the env object and printing its cloned .env. `console.log({...process.env}.NODE_ENV)`. I realised that it was equal to 'preproduction' instead of the 'buggy' production variable so... someone was rewriting this variable after this console.log to 'production'.

Doing a cross search on the ma project I did not found anything so I realised about the possibility that some tool or even webpack was modifying it... and... in fact it was:

https://github.com/webpack/webpack/issues/7470


Doing this change we will fix this behavior for our server builds as it seems that are the only ones that are failing (don't really know already why client was working well)

Hope it helps!

