### PR TITLE
Feature/pass env vars to now deployer

### DIFF
--- a/packages/sui-deploy/README.md
+++ b/packages/sui-deploy/README.md
@@ -79,6 +79,14 @@ $ sui-deploy spa test-project --now -b -a 'my-user:my-password'
 
 If your branch is `my-feature`, your code will be deployed to test-project-my-feature.now.sh
 
+### `-e, --environmentVars`
+
+Append multiple env vars that will be passed to our deployer
+
+```sh
+$ sui-deploy spa test-project --now -b -a 'my-user:my-password' -e NODE_ENV=preproduction -e GH_AUTH_TOKEN=secret
+```
+
 ## Authentification
 
 **When --now option is set**, `sui-deploy` needs a now token to deploy files. The token is obtain from the env variable `NOW_TOKEN`

--- a/packages/sui-deploy/bin/sui-deploy-dir.js
+++ b/packages/sui-deploy/bin/sui-deploy-dir.js
@@ -5,10 +5,21 @@ const program = require('commander')
 const {showError} = require('@s-ui/helpers/cli')
 const {getDeployClientFromProgram} = require('../src/utils')
 
+function collect(value, variables) {
+  variables.push(value)
+  return variables
+}
+
 program
   .usage(`[options] <name> <folder>`)
   .option('-n, --now', 'Deploy to now.sh')
   .option('-b, --branch', 'Append name of the current branch to name')
+  .option(
+    '-e, --environmentVars [environmentVars]',
+    'One or more enviornment variables that will be passed to the deployer command',
+    collect,
+    []
+  )
   .on('--help', () => {
     console.log('  Description:')
     console.log('')
@@ -25,9 +36,10 @@ program
 
 const executeDeploy = async program => {
   const [, buildFolder] = program.args
+  const environmentVars = program.environmentVars
   const deployer = await getDeployClientFromProgram(program)
-  const deploytUrl = await deployer.deploy(buildFolder)
-  console.log(`Deployment URL: ${deploytUrl}`)
+  const deployUrl = await deployer.deploy(buildFolder, {environmentVars})
+  console.log(`Deployment URL: ${deployUrl}`)
 }
 
 executeDeploy(program).catch(err => {

--- a/packages/sui-deploy/bin/sui-deploy-spa.js
+++ b/packages/sui-deploy/bin/sui-deploy-spa.js
@@ -5,6 +5,11 @@ const program = require('commander')
 const {showError, showWarning} = require('@s-ui/helpers/cli')
 const {getDeployClientFromProgram} = require('../src/utils')
 
+function collect(value, variables) {
+  variables.push(value)
+  return variables
+}
+
 program
   .usage(`[options] <name> [folder]`)
   .option('-n, --now', 'Deploy to now.sh')
@@ -12,6 +17,12 @@ program
   .option(
     '-a, --auth <user:password>',
     "HTTP authentication user and pass separated by ':' ( -a 'my-user:my-password' )"
+  )
+  .option(
+    '-e, --environmentVars [environmentVars]',
+    'One or more enviornment variables that will be passed to the deployer command',
+    collect,
+    []
   )
   .option('-p, --public', 'Skip HTTP authentication')
   .on('--help', () => {
@@ -53,8 +64,12 @@ if (forcePublic) {
 
 const executeDeploy = async program => {
   const [, buildFolder] = program.args
+  const environmentVars = program.environmentVars
   const deployer = await getDeployClientFromProgram(program)
-  const deploytUrl = await deployer.deployAsSPA(buildFolder, {auth})
+  const deploytUrl = await deployer.deployAsSPA(buildFolder, {
+    auth,
+    environmentVars
+  })
 
   console.log(`Deployment URL: ${deploytUrl}`)
 }


### PR DESCRIPTION
## Description
This PR allows our tool to receive -e option in order to do deploys with environment vars to NOW.sh or the deployer that we setted up.

## Example
More info on readme
