### PR TITLE
feat(string): adding query-string utility

### DIFF
--- a/packages/sui-js/README.md
+++ b/packages/sui-js/README.md
@@ -63,9 +63,9 @@ console.log(removeAccents('París')) // "Paris"
 console.log(hasAccents('Árbol')) // true
 
 
-import {queryStringUtility} from '@s-ui/js/lib/string'
+import {parseQueryString} from '@s-ui/js/lib/string'
 
-console.log(queryStringUtility.parse('?targetPage=pta')) // {targetPage: "pta"}
+console.log(parseQueryString('?targetPage=pta')) // {targetPage: "pta"}
 ```
 
 ## ua-parser

--- a/packages/sui-js/README.md
+++ b/packages/sui-js/README.md
@@ -54,13 +54,18 @@ console.log(md5Hash) // f97ed77ff4770b7d8f0a018223823d3b
 ```
 
 ## string
-A bunch of string utilities: remove accents, ...
+A bunch of string utilities: remove accents, parse query strings...
 
 ```js
 import { removeAccents, hasAccents } from '@s-ui/js/lib/string'
 
 console.log(removeAccents('París')) // "Paris"
 console.log(hasAccents('Árbol')) // true
+
+
+import {queryStringUtility} from '@s-ui/js/lib/string'
+
+console.log(queryStringUtility.parse('?targetPage=pta')) // {targetPage: "pta"}
 ```
 
 ## ua-parser

--- a/packages/sui-js/package.json
+++ b/packages/sui-js/package.json
@@ -13,6 +13,7 @@
     "cookie": "0.3.1",
     "js-cookie": "2.1.4",
     "lodash.kebabcase": "4.1.1",
+    "query-string": "6.1.0",
     "remove-accents": "0.4.2"
   },
   "license": "MIT",

--- a/packages/sui-js/src/string/index.js
+++ b/packages/sui-js/src/string/index.js
@@ -1,12 +1,4 @@
-import queryString from 'query-string'
+export {parse as parseQueryString} from 'query-string'
 export {fromSnakeToCamelCase, fromCamelToSnakeCase} from './snake-case'
 export {has as hasAccents, remove as removeAccents} from 'remove-accents'
-export {default as toKebabCase} from 'lodash.kebabcase'
-
-const parse = data => queryString.parse(data)
-const stringify = data => queryString.stringify(data)
-
-export const queryStringUtility = {
-  parse,
-  stringify
-}
+export toKebabCase from 'lodash.kebabcase'

--- a/packages/sui-js/src/string/index.js
+++ b/packages/sui-js/src/string/index.js
@@ -1,3 +1,12 @@
+import queryString from 'query-string'
 export {fromSnakeToCamelCase, fromCamelToSnakeCase} from './snake-case'
 export {has as hasAccents, remove as removeAccents} from 'remove-accents'
 export {default as toKebabCase} from 'lodash.kebabcase'
+
+const parse = data => queryString.parse(data)
+const stringify = data => queryString.stringify(data)
+
+export const queryStringUtility = {
+  parse,
+  stringify
+}


### PR DESCRIPTION
## Description
import `query-string` library parse method to be used in motor domain as `parseQueryString`.

## Example
https://github.schibsted.io/scmspain/frontend-mt--lib-motor/pull/346/files/39c994ed364ef3dda144ad309a377e3d1a53bf40#diff-5e0c506e61dc67658876dd8cd35e014d
