### PR TITLE
avoid multiple webpack runtimes collision

### DIFF
--- a/packages/sui-bundler/webpack.config.lib.js
+++ b/packages/sui-bundler/webpack.config.lib.js
@@ -12,10 +12,10 @@ module.exports = {
   },
   entry: config.vendor
     ? {
-      app: MAIN_ENTRY_POINT,
-      jsonpFunction: 'suiWebpackJsonp',
-      vendor: config.vendor
-    }
+        app: MAIN_ENTRY_POINT,
+        jsonpFunction: 'suiWebpackJsonp',
+        vendor: config.vendor
+      }
     : MAIN_ENTRY_POINT,
   target: 'web',
   output: {

--- a/packages/sui-bundler/webpack.config.lib.js
+++ b/packages/sui-bundler/webpack.config.lib.js
@@ -12,9 +12,10 @@ module.exports = {
   },
   entry: config.vendor
     ? {
-        app: MAIN_ENTRY_POINT,
-        vendor: config.vendor
-      }
+      app: MAIN_ENTRY_POINT,
+      jsonpFunction: 'suiWebpackJsonp',
+      vendor: config.vendor
+    }
     : MAIN_ENTRY_POINT,
   target: 'web',
   output: {


### PR DESCRIPTION
## Description
Since in Motor sites we started to use the Domain as UMD module, we could realise multiple webpack runtimes in the same webpage may collide. So that a `jsonpFunction` name is required to avoid it.

More info: https://webpack.js.org/configuration/output/#output-jsonpfunction
