### PR TITLE
feat(sui-js): add an string method to convert objects to query strings

### DIFF
--- a/packages/sui-js/src/string/index.js
+++ b/packages/sui-js/src/string/index.js
@@ -1,4 +1,7 @@
-export {parse as parseQueryString} from 'query-string'
+export {
+  parse as parseQueryString,
+  stringify as toQueryString
+} from 'query-string'
 export {fromSnakeToCamelCase, fromCamelToSnakeCase} from './snake-case'
 export {has as hasAccents, remove as removeAccents} from 'remove-accents'
 export toKebabCase from 'lodash.kebabcase'


### PR DESCRIPTION
## Description
Cover the need of stringify query string objects/params.

## Example
```js
import { stringify } from 'query-string';

const filters = {
  brand: "CITROEN",
  price_min: 3000,
  provinces: ["alicante", "barcelona"]
};

console.log(stringify(filters)); // brand=CITROEN&price_min=3000&provinces=alicante&provinces=barcelona
```