### PR TITLE
feat(babel-preset-sui): remove POC flow usage on babel-preset-sui not supported on our platforms

### DIFF
--- a/packages/babel-preset-sui/README.md
+++ b/packages/babel-preset-sui/README.md
@@ -12,7 +12,7 @@ It provides:
 $ npm install babel-preset-sui --save-dev
 ```
 
-## Presets and plugins 
+## Presets and plugins
 
 This preset always includes the following plugins and presets:
 - [babel-preset-env](https://www.npmjs.com/package/babel-preset-env)
@@ -28,9 +28,6 @@ This preset always includes the following plugins and presets:
 If `react` or `preact` is installed:
   - [babel-preset-react](https://www.npmjs.com/package/babel-preset-react)
   - [react-hot-loader/babel](https://www.npmjs.com/package/react-hot-loader)
-  
-If `flow-bin` is installed:
-  - [babel-preset-flow](https://www.npmjs.com/package/babel-preset-flow)
 
 ## Usage
 

--- a/packages/babel-preset-sui/lib/clean-list.js
+++ b/packages/babel-preset-sui/lib/clean-list.js
@@ -1,3 +1,3 @@
-module.exports = function (list) {
+module.exports = function(list) {
   return list.filter(Boolean)
 }

--- a/packages/babel-preset-sui/lib/index.js
+++ b/packages/babel-preset-sui/lib/index.js
@@ -20,8 +20,7 @@ module.exports = {
         }
       }
     ],
-    isInstalled(['preact', 'react'], 'babel-preset-react'),
-    isInstalled('flow-bin', 'babel-preset-flow')
+    isInstalled(['preact', 'react'], 'babel-preset-react')
   ]),
   plugins: [
     require('babel-plugin-transform-async-generator-functions'),

--- a/packages/babel-preset-sui/lib/is-installed.js
+++ b/packages/babel-preset-sui/lib/is-installed.js
@@ -1,6 +1,8 @@
-module.exports = function (packagesToTest, moduleToRequire) {
+module.exports = function(packagesToTest, moduleToRequire) {
   // check if the param is an array, if not, convert to it
-  packagesToTest = Array.isArray(packagesToTest) ? packagesToTest : [packagesToTest]
+  packagesToTest = Array.isArray(packagesToTest)
+    ? packagesToTest
+    : [packagesToTest]
   // we only need to check if one package is installed of all the list
   const isInstalled = packagesToTest.some(pkg => {
     try {

--- a/packages/babel-preset-sui/package.json
+++ b/packages/babel-preset-sui/package.json
@@ -17,7 +17,6 @@
     "babel-plugin-transform-react-remove-prop-types": "0.4.15",
     "babel-plugin-transform-runtime": "6.23.0",
     "babel-preset-env": "1.7.0",
-    "babel-preset-flow": "6.23.0",
     "babel-preset-react": "6.24.1",
     "react-hot-loader": "4.3.5"
   },


### PR DESCRIPTION
Remove flow temp support for the POC in our babel-preset-sui.