### PR TITLE
feat(sui-polyfills): add new polyfill for IE11 in order to let .remove method to work on Elements

### DIFF
--- a/packages/sui-polyfills/src/index.js
+++ b/packages/sui-polyfills/src/index.js
@@ -17,4 +17,6 @@ require('core-js/fn/string/includes')
 require('core-js/fn/string/starts-with')
 require('core-js/fn/string/trim')
 
+require('./polyfills/element-remove')
+
 module.exports = {}

--- a/packages/sui-polyfills/src/polyfills/element-remove.js
+++ b/packages/sui-polyfills/src/polyfills/element-remove.js
@@ -1,0 +1,19 @@
+;(function(arr) {
+  arr.forEach(function(item) {
+    if (item.hasOwnProperty('remove')) {
+      return
+    }
+    Object.defineProperty(item, 'remove', {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: function remove() {
+        if (this.parentNode !== null) this.parentNode.removeChild(this)
+      }
+    })
+  })
+})([
+  window.Element.prototype,
+  window.CharacterData.prototype,
+  window.DocumentType.prototype
+])


### PR DESCRIPTION
In order to add the possibility to use `Element.remove` in our developments as it's not supported by IE11. Alternatively, we need to use `element.parentNode.removeChild(element)` everytime we need to remove an element from the DOM.