### PR TITLE
fix(sui-widget-embedder): update bundler version

### DIFF
--- a/packages/sui-widget-embedder/package.json
+++ b/packages/sui-widget-embedder/package.json
@@ -16,7 +16,7 @@
     "babel-cli": "6.26.0"
   },
   "dependencies": {
-    "@s-ui/bundler": "2",
+    "@s-ui/bundler": "3",
     "@s-ui/component-peer-dependencies": "1",
     "@s-ui/helpers": "1",
     "@s-ui/react-domain-connector": "1",


### PR DESCRIPTION
## Description
We need to update the bundler version in order to avoid multiple webpack runtimes collision, if applies.

## Related Issue
https://github.com/SUI-Components/sui/pull/400
