### PR TITLE
fix(sui-widget-embedder): remove undefined vendor from webpack's config

### DIFF
--- a/packages/sui-widget-embedder/compiler/production.js
+++ b/packages/sui-widget-embedder/compiler/production.js
@@ -26,6 +26,10 @@ module.exports = ({page, remoteCdn, globalConfig}) => {
     path.resolve(process.cwd(), 'widgets', page, 'package')
   )
 
+  const entry = {app: MAIN_ENTRY_POINT}
+  if (config.vendor) {
+    entry['vendor'] = config.vendor
+  }
   return webpack({
     ...prodConfig,
     context: path.resolve(process.cwd(), 'widgets', page),
@@ -33,10 +37,7 @@ module.exports = ({page, remoteCdn, globalConfig}) => {
       ...prodConfig.resolve,
       alias: globalConfig.alias
     },
-    entry: {
-      app: MAIN_ENTRY_POINT,
-      vendor: config.vendor
-    },
+    entry,
     output: {
       ...prodConfig.output,
       path: path.resolve(process.cwd(), 'public', page),


### PR DESCRIPTION
build failing because of 

```
WebpackOptionsValidationError: Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration.entry should be one of these:
   object { <key>: non-empty string | [non-empty string] } | non-empty string | [non-empty string] | function
   -> The entry point(s) of the compilation.
   Details:
    * configuration.entry['vendor'] should be a string.
      -> The string is resolved to a module which is loaded upon startup.
    * configuration.entry['vendor'] should be an array:
      [non-empty string]
    * configuration.entry should be a string.
      -> An entry point without name. The string is resolved to a module which is loaded upon startup.
    * configuration.entry should be an array:
      [non-empty string]
    * configuration.entry should be an instance of function
```