### PR TITLE
Feat/root scope

### DIFF
--- a/packages/sui-cz/PrompterManager.js
+++ b/packages/sui-cz/PrompterManager.js
@@ -26,7 +26,10 @@ const scopes = config
 const commitTypes = require('./commitTypes').types
 
 const typesWithOtherScopes = ['feat', 'fix', 'release', 'test', 'docs', 'chore']
-const otherScopes = [{name: 'META'}, {name: 'examples'}]
+const defaultScopes = [{name: 'META'}, {name: 'examples'}]
+const otherScopes = config.hasRootFiles()
+  ? [{name: 'Root'}, ...defaultScopes]
+  : defaultScopes
 const allowedBreakingChanges = ['feat', 'fix']
 const getCommitTypesMapped = () =>
   Object.keys(commitTypes).map(value => ({

--- a/packages/sui-cz/config.js
+++ b/packages/sui-cz/config.js
@@ -17,10 +17,11 @@ function getOrDefault(key, defaultValue) {
 const packagesFolder = getOrDefault('packagesFolder', 'src')
 const deepLevel = getOrDefault('deepLevel', 1)
 const customScopes = getOrDefault('customScopes', [])
+const rootPath = path.join(basePath, packagesFolder)
 
 module.exports = {
   getScopes: function() {
-    const folders = cwds(path.join(basePath, packagesFolder), deepLevel)
+    const folders = cwds(rootPath, deepLevel)
     const scopes = folders.map(folder => {
       const reversedPath = folder.split(path.sep)
       const scope = Array.apply(null, Array(deepLevel)).map(
@@ -38,7 +39,13 @@ module.exports = {
   },
   getPackagesFolder: function() {
     return packagesFolder
-  }
+  },
+  hasRootFiles: () =>
+    Boolean(
+      readdirSync(rootPath)
+        .map(file => path.join(rootPath, file))
+        .find(filePath => statSync(filePath).isFile())
+    )
 }
 
 const getFolders = dir =>


### PR DESCRIPTION
This PR adds some functionality to our commit/release process:

- while commiting your changes, the prompt will show up a new option ('Root') when there are files in the root folder
- while checking for release, the Root scope will be considered for minor version if there are files in the root folder and it's no mono-repo (like sui-theme)
