### PR TITLE
fix(sui-bundler): ignore scss import files in server

### DIFF
--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -44,6 +44,7 @@
     "node-sass": "4.9.2",
     "node-sass-json-importer": "3.1.6",
     "npm-run-all": "3.1.2",
+    "null-loader": "0.1.1",
     "object.values": "1.0.4",
     "optimize-css-assets-webpack-plugin": "4.0.0",
     "postcss-loader": "2.1.6",

--- a/packages/sui-bundler/webpack.config.server.js
+++ b/packages/sui-bundler/webpack.config.server.js
@@ -24,7 +24,14 @@ let webpackConfig = {
   externals: [webpackNodeExternals()],
   plugins: [new webpack.DefinePlugin({'global.GENTLY': false})],
   module: {
-    rules: [babelRules]
+    rules: [
+      babelRules,
+      {
+        // ignore scss require/imports files in the server
+        test: /\.scss$/,
+        use: ['null-loader']
+      }
+    ]
   }
 }
 


### PR DESCRIPTION
Fix problems when importing scss files from the server in the sui-bundler. So we should just ignore them.