### PR TITLE
fix(sui-widget-embedder): disable zindex optimization on cssnano

### DIFF
--- a/packages/sui-widget-embedder/compiler/production.js
+++ b/packages/sui-widget-embedder/compiler/production.js
@@ -1,6 +1,8 @@
 const path = require('path')
 const webpack = require('webpack')
 const prodConfig = require('@s-ui/bundler/webpack.config.prod')
+const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin')
+const uglifyJsPlugin = require('@s-ui/bundler/shared/uglify')
 
 const MAIN_ENTRY_POINT = './index.js'
 
@@ -44,6 +46,17 @@ module.exports = ({page, remoteCdn, globalConfig}) => {
       publicPath: remoteCdn
         ? `${remoteCdn}/${page}/`
         : prodConfig.output.publicPath
+    },
+    optimization: {
+      ...prodConfig.optimization,
+      minimizer: [
+        uglifyJsPlugin,
+        new OptimizeCSSAssetsPlugin({
+          cssProcessorOptions: {
+            zindex: false
+          }
+        })
+      ]
     },
     plugins: pipe(
       removePlugin('HtmlWebpackPlugin'),


### PR DESCRIPTION
## Description
Once I've been working with widgets integrating the IAB modal I've seen that even if I was forcing z-index to high values my final result bundled was always less than the number that I was setting (for example if I setted z-index: 2500 my bundled value was 2)

This is caused by a default behavior of cssnano (more info here):
https://github.com/ben-eb/gulp-cssnano/issues/8

In fact we are not using css nano directly but we are using optimize-css-assets-webpack-plugin which is using cssnano as a dependency.

In order to fix that ONLY ON THE WIDGETS I've decided to modify the widget package as if I modify the webpack.conf of the bundler we could step into unexpected behaviors on all the sites that are using s-ui/bundler.
