### PR TITLE
fix(sui-bundler): fix Windows RegExp syntax in LoaderConfigBuilder

### DIFF
--- a/packages/sui-bundler/loaders/linkLoaderConfigBuilder.js
+++ b/packages/sui-bundler/loaders/linkLoaderConfigBuilder.js
@@ -57,9 +57,9 @@ module.exports = ({config, packagesToLink}) => {
           test: /\.jsx?$/,
           // TODO: This is crappy, I need better options
           exclude: new RegExp(
-            `node_modules(?!${path.sep}@s-ui${path.sep}(svg|studio)(${
+            `node_modules(?!${path.sep}@s-ui(${path.sep}svg|${
               path.sep
-            }workbench)?${path.sep}src)`
+            }studio)(${path.sep}workbench)?${path.sep}src)`
           ),
           use: {
             loader: 'link-loader',


### PR DESCRIPTION
## Description

Fix Windows RegExp syntax in LoaderConfigBuilder

