### PR TITLE
Fix/replace querystring lib

### DIFF
--- a/packages/sui-js/package.json
+++ b/packages/sui-js/package.json
@@ -15,7 +15,7 @@
     "lodash.camelcase": "4.3.0",
     "lodash.capitalize": "4.2.1",
     "lodash.kebabcase": "4.1.1",
-    "query-string": "6.1.0",
+    "qs": "6.6.0",
     "remove-accents": "0.4.2"
   },
   "license": "MIT",

--- a/packages/sui-js/src/string/index.js
+++ b/packages/sui-js/src/string/index.js
@@ -1,7 +1,4 @@
-export {
-  parse as parseQueryString,
-  stringify as toQueryString
-} from 'query-string'
+export {parse as parseQueryString, stringify as toQueryString} from 'qs'
 export {fromSnakeToCamelCase, fromCamelToSnakeCase} from './snake-case'
 export {default as toCamelCase} from 'lodash.camelcase'
 export {default as toCapitalCase} from 'lodash.capitalize'

--- a/packages/sui-js/src/string/index.js
+++ b/packages/sui-js/src/string/index.js
@@ -1,4 +1,6 @@
-export {parse as parseQueryString, stringify as toQueryString} from 'qs'
+import {parse} from 'qs'
+export const parseQueryString = query => parse(query, {ignoreQueryPrefix: true})
+export {stringify as toQueryString} from 'qs'
 export {fromSnakeToCamelCase, fromCamelToSnakeCase} from './snake-case'
 export {default as toCamelCase} from 'lodash.camelcase'
 export {default as toCapitalCase} from 'lodash.capitalize'

--- a/packages/sui-js/test/stringSpec.js
+++ b/packages/sui-js/test/stringSpec.js
@@ -1,0 +1,19 @@
+/* eslint-env mocha */
+import {expect} from 'chai'
+import {parseQueryString, toQueryString} from '../src/string/index'
+
+describe('@s-ui/js', () => {
+  describe('when working with query params', () => {
+    const input = {a: 1, b: 'test'}
+    const query = 'a=1&b=test'
+    const output = {a: '1', b: 'test'}
+
+    it('should convert to string', () => {
+      expect(toQueryString(input)).to.be.equal(query)
+    })
+
+    it('should parse to object', () => {
+      expect(parseQueryString(query)).to.deep.equal(output)
+    })
+  })
+})

--- a/packages/sui-js/test/stringSpec.js
+++ b/packages/sui-js/test/stringSpec.js
@@ -4,16 +4,16 @@ import {parseQueryString, toQueryString} from '../src/string/index'
 
 describe('@s-ui/js', () => {
   describe('when working with query params', () => {
-    const input = {a: 1, b: 'test'}
-    const query = 'a=1&b=test'
-    const output = {a: '1', b: 'test'}
-
     it('should convert to string', () => {
-      expect(toQueryString(input)).to.be.equal(query)
+      const params = {a: 1, b: 'test'}
+      const query = 'a=1&b=test'
+      expect(toQueryString(params)).to.be.equal(query)
     })
 
     it('should parse to object', () => {
-      expect(parseQueryString(query)).to.deep.equal(output)
+      const query = '?a=1&b=test'
+      const params = {a: '1', b: 'test'}
+      expect(parseQueryString(query)).to.deep.equal(params)
     })
   })
 })


### PR DESCRIPTION
The `query-string` lib was not transpiled to es5 and therefore full of arrow functions which does not work with IE11.

I've substituted that lib by [`qs`](https://www.npmjs.com/package/qs) which is transpiled. In order to maintain backward compatibility I had to pass by the `{ignoreQueryPrefix: true}` param to the parse function