### PR TITLE
feat(sui-test): add overwrite user agent option

### DIFF
--- a/packages/sui-test/README.md
+++ b/packages/sui-test/README.md
@@ -112,6 +112,7 @@ sui-test e2e [options]
     -B, --baseUrl <baseUrl>                  URL of the site to execute tests (in ./test/e2e/) on.
     -S, --screenshotsOnError                 Take screenshots of page on any failure.
     -U, --userAgentAppend <userAgentAppend>  Append string to UserAgent header.
+    -UA, --userAgent <userAgent>             Overwrite string to UserAgent header.
     -G, --gui                                Run the tests in GUI mode.
     -h, --help                               output usage information
 ```
@@ -129,6 +130,10 @@ Tests are executed with [cypress](https://www.cypress.io/). It provides a specia
 #### `sui-test e2e --scope='sub/folder'`
 
 You can execute only a subset of tests in `./test-e2e/`. The example above would only execute tests in `./test-e2e/sub/folder`.
+
+#### `sui-test e2e --userAgent='My custom string'`
+
+Cypress can be detected as a robot if your server has that kind of protection or firewall. In this case, if your server allows an exception by header, you can overwrite the `UserAgent` header a string that cypress will set when opening your site with the browser.
 
 #### `sui-test e2e --userAgentAppend='My custom string'`
 

--- a/packages/sui-test/bin/sui-test-e2e.js
+++ b/packages/sui-test/bin/sui-test-e2e.js
@@ -37,19 +37,32 @@ program
     '-U, --userAgentAppend <userAgentAppend>',
     'Append string to UserAgent header.'
   )
+  .option(
+    '-UA, --userAgent <userAgent>',
+    'Overwrite string to UserAgent header.'
+  )
   .option('-s, --scope <spec>', 'Run tests specifying a subfolder of specs')
   .option('-G, --gui', 'Run the tests in GUI mode.')
   .on('--help', () => console.log(HELP_MESSAGE))
   .parse(process.argv)
 
-const {baseUrl, userAgentAppend, gui, screenshotsOnError, scope} = program
+const {
+  baseUrl,
+  userAgentAppend,
+  userAgent,
+  gui,
+  screenshotsOnError,
+  scope
+} = program
 const cypressConfig = {
   integrationFolder: path.join(TESTS_FOLDER, scope || ''),
   baseUrl,
   fixturesFolder: path.join(TESTS_FOLDER, 'fixtures')
 }
 
-if (userAgentAppend) {
+if (userAgent) {
+  cypressConfig.userAgent = `"${userAgent}"`
+} else if (userAgentAppend) {
   cypressConfig.userAgent = `"${DEFAULT_USER_AGENT} ${userAgentAppend}"`
 }
 


### PR DESCRIPTION
--userAgent option has been added
It is required in order to change the entire user agent.  Alto, --userAgentAppend behavior stays the same.

Related Issue: Fix [#446](https://github.com/SUI-Components/sui/issues/446)

**To test:**
1.  ```cd frontend-mt--e2e-tests```
2. ```node ../sui/packages/sui-test/bin/sui-test.js e2e --baseUrl="http://pre.coches.net"  --scope="coches" --gui --userAgent="Screaming Frog SEO Spider/8.3"```
3. Then, run a test and write ```navigator.userAgent``` in console