### PR TITLE
feat(sui-react-initial-props): add displayName for server component

### DIFF
--- a/packages/sui-react-initial-props/src/loadPage.js
+++ b/packages/sui-react-initial-props/src/loadPage.js
@@ -39,6 +39,8 @@ const createUniversalPage = (contextFactory, routeInfo) => ({
   )
   // recover the initialProps if in the server we have retrieved them
   ServerPage.contextTypes = {initialProps: PropTypes.object}
+  // recover the displayName from the original page
+  ServerPage.displayName = Page.displayName
   // detect if the page has getInitialProps and wrap it with the routeInfo
   // if we don't have any getInitialProps, just use a empty function returning an empty object
   ServerPage.getInitialProps = context =>


### PR DESCRIPTION
Keep displayName for server wrapped components in react-initial-props.