### PR TITLE
feat(sui-test): support file option added to e2e tests

### DIFF
--- a/packages/sui-test/README.md
+++ b/packages/sui-test/README.md
@@ -107,6 +107,19 @@ If you need to have support files, then create a `./test-e2e/support` directory,
 
 Support files runs before every single spec file and you don't have to import it in spec file.
 
+Example: 
+
+`./test-e2e/support/index.js`
+
+```js
+/* globals Cypress, cy */
+Cypress.Commands.add('login', () => {
+  // Here the command code
+})
+```
+
+Then you can use in your specs `cy.login()`
+
 ### Options
 
 ```sh

--- a/packages/sui-test/README.md
+++ b/packages/sui-test/README.md
@@ -101,6 +101,12 @@ sui-test e2e [options]
 
 **Important:** If you need to have fixtures files (or helpers), put them in the `./test-e2e/fixtures` so they aren't executed as spec files.
 
+### Support files
+
+If you need to have support files, then create a `./test-e2e/support` directory, it will be detected and added to the `cypress.json` configuration.
+
+Support files runs before every single spec file and you don't have to import it in spec file.
+
 ### Options
 
 ```sh

--- a/packages/sui-test/bin/sui-test-e2e.js
+++ b/packages/sui-test/bin/sui-test-e2e.js
@@ -3,6 +3,7 @@
 
 const path = require('path')
 const program = require('commander')
+const fs = require('fs')
 const {getSpawnPromise, showError} = require('@s-ui/helpers/cli')
 const {resolveLazyNPMBin} = require('@s-ui/helpers/packages')
 const CYPRESS_VERSION = '3.0.3'
@@ -23,6 +24,8 @@ const objectToCommaString = obj =>
   Object.keys(obj)
     .map(key => `${key}=${obj[key]}`)
     .join(',')
+
+const supportFilesFolderPath = path.join(TESTS_FOLDER, 'support')
 
 program
   .option(
@@ -58,6 +61,10 @@ const cypressConfig = {
   integrationFolder: path.join(TESTS_FOLDER, scope || ''),
   baseUrl,
   fixturesFolder: path.join(TESTS_FOLDER, 'fixtures')
+}
+
+if (fs.existsSync(supportFilesFolderPath)) {
+  cypressConfig.supportFile = supportFilesFolderPath
 }
 
 if (userAgent) {

--- a/packages/sui-test/package.json
+++ b/packages/sui-test/package.json
@@ -26,6 +26,7 @@
     "chalk": "2.3.0",
     "commander": "2.12.1",
     "envify": "4.1.0",
+    "file-system": "^2.2.2",
     "karma": "1.7.1",
     "karma-browserify": "5.1.2",
     "karma-chrome-launcher": "2.2.0",

--- a/packages/sui-test/package.json
+++ b/packages/sui-test/package.json
@@ -26,7 +26,7 @@
     "chalk": "2.3.0",
     "commander": "2.12.1",
     "envify": "4.1.0",
-    "file-system": "^2.2.2",
+    "file-system": "2.2.2",
     "karma": "1.7.1",
     "karma-browserify": "5.1.2",
     "karma-chrome-launcher": "2.2.0",

--- a/packages/sui-test/package.json
+++ b/packages/sui-test/package.json
@@ -26,7 +26,6 @@
     "chalk": "2.3.0",
     "commander": "2.12.1",
     "envify": "4.1.0",
-    "file-system": "2.2.2",
     "karma": "1.7.1",
     "karma-browserify": "5.1.2",
     "karma-chrome-launcher": "2.2.0",


### PR DESCRIPTION
Motor frontends need to have support files in order to configurate a custom command with the user login.

## Description
sui-test e2e does not accept supportFile directory

ISSUES CLOSED: #459
