### PR TITLE
feat(sui-bundler): Add sourcemaps support to improve sentry integration

### DIFF
--- a/packages/sui-bundler/README.md
+++ b/packages/sui-bundler/README.md
@@ -148,6 +148,10 @@ This tool works with zero configuration out the box but you could use some confi
     "scripts": {
       "prefetch": "low-priority-chunk.js",
       "preload": ["page1.js", "page2.js"]
+    },
+    "sourcemaps": {
+      "dev": "cheap-module-eval-source-map",
+      "prod": "hidden-source-map"
     }
   }
 }
@@ -230,6 +234,25 @@ Use in case of generated code, for example
 ```sh
 > sui-bundler dev --no-pre-loader
 ```
+
+## Configuring source map generation
+
+SUI-bundler generates no sourcemaps by default but you can change this behaviour and configure them in the sui-bundler section of your package.json. 
+Different values can be configured for development (`dev`) and production (`prod`) webpack configs.
+
+```json
+{
+  "sui-bundler": {
+    "sourcemaps": {
+      "dev": "cheap-module-eval-source-map",
+      "prod": "hidden-source-map"
+    }
+  }
+}
+```
+
+
+Check all possible values accepted by webpack in the [devtool webpack docs](https://webpack.js.org/configuration/devtool/#devtool)   
 
 ## Contributing
 

--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -53,6 +53,7 @@
     "rimraf": "2.6.2",
     "sass-loader": "6.0.7",
     "script-ext-html-webpack-plugin": "2.1.3",
+    "source-map-loader": "0.2.4",
     "style-loader": "0.23.1",
     "sw-precache-webpack-plugin": "0.11.5",
     "thread-loader": "1.1.5",

--- a/packages/sui-bundler/shared/module-rules-babel.js
+++ b/packages/sui-bundler/shared/module-rules-babel.js
@@ -3,12 +3,15 @@ const {sep} = require('path')
 module.exports = {
   test: /\.jsx?$/,
   exclude: new RegExp(`node_modules(?!${sep}@s-ui${sep}studio${sep}src)`),
-  use: {
-    loader: require.resolve('babel-loader'),
-    options: {
-      babelrc: false,
-      compact: true,
-      presets: [require.resolve('babel-preset-sui')]
-    }
-  }
+  use: [
+    {
+      loader: require.resolve('babel-loader'),
+      options: {
+        babelrc: false,
+        compact: true,
+        presets: [require.resolve('babel-preset-sui')]
+      }
+    },
+    'source-map-loader'
+  ]
 }

--- a/packages/sui-bundler/shared/uglify.js
+++ b/packages/sui-bundler/shared/uglify.js
@@ -3,5 +3,5 @@ const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
 module.exports = new UglifyJsPlugin({
   cache: true,
   parallel: true,
-  sourceMap: true // set to true if you want JS source maps
+  sourceMap: true
 })

--- a/packages/sui-bundler/shared/uglify.js
+++ b/packages/sui-bundler/shared/uglify.js
@@ -3,5 +3,5 @@ const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
 module.exports = new UglifyJsPlugin({
   cache: true,
   parallel: true,
-  sourceMap: false // set to true if you want JS source maps
+  sourceMap: true // set to true if you want JS source maps
 })

--- a/packages/sui-bundler/webpack.config.dev.js
+++ b/packages/sui-bundler/webpack.config.dev.js
@@ -90,7 +90,9 @@ let webpackConfig = {
         use: ['style-loader', 'css-loader', 'postcss-loader', 'sass-loader']
       }
     ]
-  }
+  },
+  devtool:
+    config.sourcemaps && config.sourcemaps.dev ? config.sourcemaps.dev : 'none'
 }
 
 module.exports = webpackConfig

--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -25,6 +25,10 @@ require('./shared/shims')
 const PUBLIC_PATH = process.env.CDN || config.cdn || '/'
 
 module.exports = {
+  devtool:
+    config.sourcemaps && config.sourcemaps.prod
+      ? config.sourcemaps.prod
+      : 'none',
   mode: 'production',
   context: path.resolve(process.cwd(), 'src'),
   resolve: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds sourcemap generation support for sui-bundler. It expects a new section `sourcemaps` in the sui-bundler project package.json configuration to get from there the desired devtool webpack value. By default, the behaviour would be same as it is now and no sourcemaps are generated if this section is not present.

A new source-map-loader has been added for all js/jsx files in the babel rules config and the flag for sourcemaps in the uglifyJS plugin config has been changed.

## Example
```json
{
  "sui-bundler": {
    "sourcemaps": {
      "dev": "cheap-module-eval-source-map",
      "prod": "hidden-source-map"
    }
  }
}
```
