### PR TITLE
feat(sui-widget-embedder): allow to add a blacklist of reg exps

### DIFF
--- a/packages/sui-widget-embedder/README.md
+++ b/packages/sui-widget-embedder/README.md
@@ -1,4 +1,5 @@
 # sui-widget-embedder
+
 > Widget development server and build for production
 
 ## Motivation
@@ -67,9 +68,9 @@ Note that the quotes here are not 'optional' you can add an expresion without qu
 
 Inside your project-level package.json, you could config the library,
 
-* alias [OPTIONAL]: create aliases to `import` certain modules more easily or to avoid importing them in production.
-* remoteCdn [OPTIONAL] (default: `'/'`): the base path of the cdn where your assets will be located.
-* devPort [OPTIONAL] (default: `3000`): Port where your development server will be listening.
+- alias [OPTIONAL]: create aliases to `import` certain modules more easily or to avoid importing them in production.
+- remoteCdn [OPTIONAL] (default: `'/'`): the base path of the cdn where your assets will be located.
+- devPort [OPTIONAL] (default: `3000`): Port where your development server will be listening.
 
 ### Page config
 
@@ -78,6 +79,10 @@ Inside each page you must create a package.json file.
 ```
 {
   "pathnameRegExp": "/d\\w+\\.html",
+  "blacklistedRegExps": [
+    "about.html",
+    "contact.html"
+  ],
   "vendor": [
     "react",
     "react-dom"
@@ -85,8 +90,9 @@ Inside each page you must create a package.json file.
 }
 ```
 
-* pathnameRegExp [REQUIRED]: RegExp to identify the pathname of the page where this list of widgets must work
-* vendor [OPTIONAL]: In case you want to have a vendor file for this page only.
+- pathnameRegExp [REQUIRED]: RegExp to identify the pathname of the page where this list of widgets must work.
+- blacklistedRegExps [OPTIONAL]: List of RegExps to identify the pathname of the pages where the widgets don't need to work at.
+- vendor [OPTIONAL]: In case you want to have a vendor file for this page only.
 
 ## Working with React
 
@@ -98,12 +104,12 @@ import Widgets from '@s-ui/widget-embedder/react/Widgets'
 import render from '@s-ui/widget-embedder/react/render'
 ```
 
-* render: A method that expects a tree of React components starting with a Widgets root
-* Widgets: React component that encapsules all your widgets
-* Widget: React component that renders the children as a new React tree in another place of the page.
-** i18n: I18n library
-** domain: Domain library for your widgets
-** node: css path that indicates where you want create the new React tree. If that node doesnt exist in the current page you will get a warning in the console.
+- render: A method that expects a tree of React components starting with a Widgets root
+- Widgets: React component that encapsules all your widgets
+- Widget: React component that renders the children as a new React tree in another place of the page.
+  ** i18n: I18n library
+  ** domain: Domain library for your widgets
+  \*\* node: css path that indicates where you want create the new React tree. If that node doesnt exist in the current page you will get a warning in the console.
 
 ## How to develop
 

--- a/packages/sui-widget-embedder/README.md
+++ b/packages/sui-widget-embedder/README.md
@@ -91,7 +91,7 @@ Inside each page you must create a package.json file.
 ```
 
 - pathnameRegExp [REQUIRED]: RegExp to identify the pathname of the page where this list of widgets must work.
-- blacklistedRegExps [OPTIONAL]: List of RegExps to identify the pathname of the pages where the widgets don't need to work at.
+- blacklistedRegExps [OPTIONAL]: List of RegExps to identify the pathname of the pages where the widgets don't have to work at.
 - vendor [OPTIONAL]: In case you want to have a vendor file for this page only.
 
 ## Working with React

--- a/packages/sui-widget-embedder/bin/sui-widget-embedder-build.js
+++ b/packages/sui-widget-embedder/bin/sui-widget-embedder-build.js
@@ -105,27 +105,30 @@ const manifests = () =>
     return acc
   }, {})
 
-const pathnamesRegExp = () =>
-  pagesFor({path: PAGES_PATH}).reduce((acc, page) => {
-    acc[page] = require(resolve(
-      process.cwd(),
-      PAGES_FOLDER,
-      page,
-      'package.json'
-    )).pathnameRegExp
-    return acc
-  }, {})
+const pageConfigs = () =>
+  pagesFor({path: PAGES_PATH}).reduce(
+    (acc, page) => ({
+      ...acc,
+      [page]: require(resolve(
+        process.cwd(),
+        PAGES_FOLDER,
+        page,
+        'package.json'
+      ))
+    }),
+    {}
+  )
 
 const createDownloader = () =>
   // eslint-disable-next-line
   new Promise((res, rej) => {
     const staticManifests = manifests()
-    const staticPathnamesRegExp = pathnamesRegExp()
+    const staticPageConfigs = pageConfigs()
     createReadStream(resolve(__dirname, '..', 'downloader', 'index.js'))
       .pipe(
         staticModule({
           'static-manifests': () => JSON.stringify(staticManifests),
-          'static-pathnamesRegExp': () => JSON.stringify(staticPathnamesRegExp),
+          'static-pageConfigs': () => JSON.stringify(staticPageConfigs),
           'static-cdn': () => JSON.stringify(remoteCdn),
           'service-worker-cdn': () => JSON.stringify(serviceWorkerCdn)
         })

--- a/packages/sui-widget-embedder/downloader/index.js
+++ b/packages/sui-widget-embedder/downloader/index.js
@@ -115,9 +115,9 @@
     if (
       blacklistedRegExps &&
       blacklistedRegExps.length > 0 &&
-      !blacklistedRegExps.some(regExp =>
-        window.location.pathname.match(new RegExp(regExp))
-      )
+      !blacklistedRegExps.some(function(regExp) {
+        return window.location.pathname.match(new RegExp(regExp))
+      })
     ) {
       pages.push(page)
     } else if (window.location.pathname.match(new RegExp(pathnameRegExp))) {

--- a/packages/sui-widget-embedder/downloader/index.js
+++ b/packages/sui-widget-embedder/downloader/index.js
@@ -114,6 +114,7 @@
 
     if (
       blacklistedRegExps &&
+      blacklistedRegExps.length > 0 &&
       !blacklistedRegExps.some(regExp =>
         window.location.pathname.match(new RegExp(regExp))
       )

--- a/packages/sui-widget-embedder/downloader/index.js
+++ b/packages/sui-widget-embedder/downloader/index.js
@@ -1,7 +1,7 @@
 ;(function() {
   'use strict'
   var manifests = require('static-manifests')()
-  var pathnamesRegExp = require('static-pathnamesRegExp')()
+  var pageConfigs = require('static-pageConfigs')()
   var serviceWorkerCdn = require('service-worker-cdn')()
   // https://davidwalsh.name/javascript-loader
   var load = (function() {
@@ -108,11 +108,22 @@
   }
 
   var pages = []
-  for (var key in pathnamesRegExp) {
-    if (window.location.pathname.match(new RegExp(pathnamesRegExp[key]))) {
-      pages.push(key)
+  for (var page in pageConfigs) {
+    var blacklistedRegExps = pageConfigs[page].blacklistedRegExps
+    var pathnameRegExp = pageConfigs[page].pathnameRegExp
+
+    if (
+      blacklistedRegExps &&
+      !blacklistedRegExps.some(regExp =>
+        window.location.pathname.match(new RegExp(regExp))
+      )
+    ) {
+      pages.push(page)
+    } else if (window.location.pathname.match(new RegExp(pathnameRegExp))) {
+      pages.push(page)
     }
   }
+
   pages.length !== 0 &&
     !window.location.host.match(/localhost/) &&
     promiseInSerie(

--- a/packages/sui-widget-embedder/downloader/index.js
+++ b/packages/sui-widget-embedder/downloader/index.js
@@ -107,20 +107,17 @@
     })
   }
 
+  function matchPathnameWithRegExp(regExp) {
+    return window.location.pathname.match(new RegExp(regExp))
+  }
+
   var pages = []
   for (var page in pageConfigs) {
-    var blacklistedRegExps = pageConfigs[page].blacklistedRegExps
+    var blacklistedRegExps = pageConfigs[page].blacklistedRegExps || []
     var pathnameRegExp = pageConfigs[page].pathnameRegExp
+    var isBlacklisted = blacklistedRegExps.some(matchPathnameWithRegExp)
 
-    if (
-      blacklistedRegExps &&
-      blacklistedRegExps.length > 0 &&
-      !blacklistedRegExps.some(function(regExp) {
-        return window.location.pathname.match(new RegExp(regExp))
-      })
-    ) {
-      pages.push(page)
-    } else if (window.location.pathname.match(new RegExp(pathnameRegExp))) {
+    if (!isBlacklisted && matchPathnameWithRegExp(pathnameRegExp)) {
       pages.push(page)
     }
   }


### PR DESCRIPTION
## Description
Regarding the best practice of loading one widget bundle by page, in the most cases we'll need to load that bundle on a specific number of pages, via the existing param `pathnameRegExp`, but sometimes we'll want to load it everywhere but not on those pages, so that, the param `blacklistedRegExps` will help us to skip them.

## Example
```js
// pages/all-not-static.js
{
  "version": "1.0.0",
  "private": true,
  "pathnameRegExp": ".*",
  "blacklistedRegExps": [
    "contact.html",
    "about.html"
  ]
}
```
