### PR TITLE
feat(sui-svg): remove title tag on build

### DIFF
--- a/packages/sui-svg/bin/sui-svg-build.js
+++ b/packages/sui-svg/bin/sui-svg-build.js
@@ -64,7 +64,8 @@ fg([`${SVG_FOLDER}/**/*.svg`]).then(entries =>
         data,
         {
           template,
-          expandProps: false
+          expandProps: false,
+          removeTitle: true
         },
         {componentName: 'SVGComponent'}
       )


### PR DESCRIPTION
Exporting svgs from illustrator adds a title which shouldn't be needed, this PR removes the title tag when converting into a react component