### PR TITLE
Fix/react hot loader link package

### DIFF
--- a/packages/babel-preset-sui/lib/index.js
+++ b/packages/babel-preset-sui/lib/index.js
@@ -1,5 +1,9 @@
+const isInstalled = require('./is-installed')
+
 function plugins(api, opts) {
-  return [
+  const {isDevelopment} = opts
+
+  return cleanList([
     require('@babel/plugin-syntax-dynamic-import').default,
     [require('@babel/plugin-proposal-decorators').default, {legacy: true}],
     [require('@babel/plugin-proposal-class-properties').default, {loose: true}],
@@ -19,8 +23,9 @@ function plugins(api, opts) {
         corejs: false,
         regenerator: true
       }
-    ]
-  ]
+    ],
+    isDevelopment && isInstalled(['preact', 'react'], 'react-hot-loader/babel')
+  ])
 }
 
 function presets(api, opts) {

--- a/packages/babel-preset-sui/package.json
+++ b/packages/babel-preset-sui/package.json
@@ -18,7 +18,8 @@
     "@babel/preset-react": "7.0.0",
     "@babel/runtime": "7.2.0",
     "babel-plugin-transform-react-remove-prop-types": "0.4.21",
-    "babel-runtime": "6.26.0"
+    "babel-runtime": "6.26.0",
+    "react-hot-loader": "4.6.3"
   },
   "repository": {
     "type": "git",

--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -49,7 +49,6 @@
     "postcss-loader": "2.1.6",
     "raw-loader": "0.5.1",
     "react-dev-utils": ">=5.0.2",
-    "react-hot-loader": "4.6.3",
     "rimraf": "2.6.2",
     "sass-loader": "6.0.7",
     "script-ext-html-webpack-plugin": "2.1.3",

--- a/packages/sui-bundler/webpack.config.dev.js
+++ b/packages/sui-bundler/webpack.config.dev.js
@@ -8,6 +8,12 @@ require('./shared/shims')
 
 const {envVars, MAIN_ENTRY_POINT, config, cleanList} = require('./shared')
 
+const EXCLUDED_FOLDERS_REGEXP = new RegExp(
+  `node_modules(?!${path.sep}@s-ui(${path.sep}svg|${path.sep}studio)(${
+    path.sep
+  }workbench)?${path.sep}src)`
+)
+
 let webpackConfig = {
   mode: 'development',
   context: path.resolve(process.env.PWD, 'src'),
@@ -53,19 +59,11 @@ let webpackConfig = {
             loader: require.resolve('eslint-loader')
           }
         ],
-        exclude: new RegExp(
-          `node_modules(?!${path.sep}@s-ui(${path.sep}svg|${path.sep}studio)(${
-            path.sep
-          }workbench)?${path.sep}src)`
-        )
+        exclude: EXCLUDED_FOLDERS_REGEXP
       },
       {
         test: /\.jsx?$/,
-        exclude: new RegExp(
-          `node_modules(?!${path.sep}@s-ui(${path.sep}svg|${path.sep}studio)(${
-            path.sep
-          }workbench)?${path.sep}src)`
-        ),
+        exclude: EXCLUDED_FOLDERS_REGEXP,
         use: [
           {
             loader: require.resolve('thread-loader'),
@@ -79,8 +77,14 @@ let webpackConfig = {
               babelrc: false,
               cacheDirectory: true,
               highlightCode: true,
-              presets: [require.resolve('babel-preset-sui')],
-              plugins: [require.resolve('react-hot-loader/babel')]
+              presets: [
+                [
+                  require.resolve('babel-preset-sui'),
+                  {
+                    isDevelopment: true
+                  }
+                ]
+              ]
             }
           }
         ]


### PR DESCRIPTION
- Fix react-hot-loader problems with linked packages.
- Keep the possibility of using it on sui-bundler dev even with NODE_ENV=preproduction by using an option of the babel-preset-sui.
- Reuse exclude folders.