### PR TITLE
Fix/sui bundler link problems

### DIFF
--- a/packages/sui-bundler/factories/createCompiler.js
+++ b/packages/sui-bundler/factories/createCompiler.js
@@ -7,8 +7,8 @@ const ncp = require('copy-paste')
 const isInteractive = process.stdout.isTTY
 let compiler
 
-const printInstructions = urls => {
-  ncp.copy(urls.localUrlForBrowser)
+const printInstructions = ({urls, copyToClipboard}) => {
+  copyToClipboard && ncp.copy(urls.localUrlForBrowser)
   console.log(`
   ${chalk.bold('Local:')}            ${urls.localUrlForTerminal}
   ${chalk.bold('On Your Network:')}  ${urls.lanUrlForTerminal}
@@ -33,6 +33,8 @@ module.exports = (config, urls) => {
     console.log('Compiling...')
   })
 
+  let isFirstCompile = true
+
   compiler.hooks.done.tap('done', stats => {
     if (isInteractive) {
       clearConsole()
@@ -40,12 +42,13 @@ module.exports = (config, urls) => {
 
     const messages = formatWebpackMessages(stats.toJson({}, true))
     const isSuccessful = !messages.errors.length
+
     if (isSuccessful) {
       console.log(chalk.green('Compiled successfully!'))
     }
 
     if (isSuccessful && isInteractive) {
-      printInstructions(urls)
+      printInstructions({urls, copyToClipboard: isFirstCompile})
     }
 
     if (messages.errors.length) {
@@ -62,6 +65,8 @@ module.exports = (config, urls) => {
       console.log(chalk.yellow('Compiled with warnings:\n'))
       console.log(messages.warnings.join('\n\n'))
     }
+
+    isFirstCompile = false
   })
   return compiler
 }

--- a/packages/sui-bundler/loaders/LinkLoader.js
+++ b/packages/sui-bundler/loaders/LinkLoader.js
@@ -1,14 +1,24 @@
+const createMatchTransformer = linkedPackagePath => match => {
+  // we have to detect if the last char is a quote or /lib to add the correct suffix
+  const suffix = match[match.length - 1] === "'" ? "'" : '/lib'
+  return `${linkedPackagePath}${suffix}`
+}
+
 function linkLoader(source) {
-  const entries = this.query.entryPoints
-
-  const linkedSource = Object.keys(entries).reduce((modifySource, entry) => {
-    return modifySource.replace(
-      new RegExp(`~?${entry}(\\/lib)?`, 'g'),
-      entries[entry]
-    )
+  // extract all the packages that we want to link
+  const {entryPoints: packagesToLink} = this.query
+  // pass the code through a reduce to change the import of the package
+  // with the absolute path of the linked one
+  return Object.keys(packagesToLink).reduce((modifiedSource, pkg) => {
+    // create a regex for detecting if the package is used in the source
+    // we have to check if it ends with quote (normal import)
+    // or with /lib, as we might be importing a submodule of a package
+    const regex = new RegExp(`${pkg}(\\/lib|')`, 'g')
+    // create a function that will be used when match ocurred
+    const transformMatch = createMatchTransformer(packagesToLink[pkg])
+    // replace all the uses of the package by using the function
+    return modifiedSource.replace(regex, transformMatch)
   }, source)
-
-  return linkedSource
 }
 
 module.exports = linkLoader

--- a/packages/sui-bundler/loaders/linkLoaderConfigBuilder.js
+++ b/packages/sui-bundler/loaders/linkLoaderConfigBuilder.js
@@ -64,7 +64,7 @@ module.exports = ({config, packagesToLink}) => {
     },
     resolveLoader: {
       alias: {
-        'link-loader': require.resolve('./linkLoader')
+        'link-loader': require.resolve('./LinkLoader')
       }
     }
   }

--- a/packages/sui-bundler/loaders/sassLinkLoader.js
+++ b/packages/sui-bundler/loaders/sassLinkLoader.js
@@ -1,0 +1,15 @@
+const createSassLinkLoader = entryPoints => url => {
+  if (Object.keys(entryPoints).find(pkg => url.match(`${pkg}/`))) {
+    const [org, name] = url.split(/\//)
+    const pkg = [org.replace('~', ''), name].join('/')
+
+    const absoluteUrl = url.replace(
+      new RegExp(`~?${pkg}(\\/lib)?`, 'g'),
+      entryPoints[pkg]
+    )
+    return {file: absoluteUrl}
+  }
+  return null
+}
+
+module.exports = createSassLinkLoader

--- a/packages/sui-bundler/webpack.config.dev.js
+++ b/packages/sui-bundler/webpack.config.dev.js
@@ -18,6 +18,12 @@ let webpackConfig = {
   mode: 'development',
   context: path.resolve(process.env.PWD, 'src'),
   resolve: {
+    alias: {
+      // this alias is needed so react-hot-loader works with linked packages on dev mode
+      'react-hot-loader': path.resolve(
+        path.join(process.env.PWD, './node_modules/react-hot-loader')
+      )
+    },
     extensions: ['*', '.js', '.jsx', '.json']
   },
   entry: cleanList([


### PR DESCRIPTION
- [x] Fix `react-hot-loader` problems. Alias react-hot-loader for avoiding problems with linked packages so it's using only the one from the root project.
- [x] Fix copied to clipboard the url of the server on every compilation. Now is done only in the first one.
- [x] Fix problems with Regex when linking similar dependencies names. For example linking a package named `card-property` caused problems with `card-property-experiment` packages.
- [x] Fix problems on linking subdependencies. Now, even linking a deep dependenc of the project should be working.
- [x] Add a bunch of comments and a better separation of things on the complicated javascritpLinkLoader so... next time it's not going to be hard to touch it :D
- [x] Add some useful logging in order to know if packages are being linked correctly and which one are being linked!