### PR TITLE
fix(sui-studio): fix problems with react-hot-loader when linking studio

### DIFF
--- a/packages/sui-studio/bin/sui-studio-dev.js
+++ b/packages/sui-studio/bin/sui-studio-dev.js
@@ -50,6 +50,7 @@ const studioDevConfig = {
   resolve: {
     ...config.resolve,
     alias: {
+      ...config.resolve.alias,
       component: path.join(PWD, 'components', category, component, 'src'),
       package: path.join(
         PWD,


### PR DESCRIPTION
Because studio is messing with alias config and it shouldn't. Bad boy!