### PR TITLE
fix(babel-preset-sui): add default value for opts

### DIFF
--- a/packages/babel-preset-sui/lib/index.js
+++ b/packages/babel-preset-sui/lib/index.js
@@ -1,7 +1,7 @@
 const isInstalled = require('./is-installed')
 const cleanList = require('./clean-list')
 
-function plugins(api, opts) {
+function plugins(api, opts = {}) {
   const {isDevelopment} = opts
 
   return cleanList([


### PR DESCRIPTION
Don't assume that the opts are being used when using the babel-preset-sui. Get a default value with an empty object to avoid problems like this one:

```
TypeError: Cannot destructure property `isDevelopment` of 'undefined' or 'null'. (While processing preset: "/Users/carlos.villuendas/Developer/frontend-ma--lib-milanuncios/node_modules/babel-preset-sui/lib/index.js")
```