### PR TITLE
perf(sui-polyfills): use same core-js as @babel/runtime to avoid packing twice same library with different versions

### DIFF
--- a/packages/sui-polyfills/package.json
+++ b/packages/sui-polyfills/package.json
@@ -7,7 +7,7 @@
   "keywords": [],
   "author": "Miguel Angel Duran <miduga@gmail.com>",
   "dependencies": {
-    "core-js": "2.5.7"
+    "core-js": "2.6.3"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Update core-js of polyfills to avoid packing twice same library as noted here:

```
> CDN=/ NODE_ENV=production sui-bundler analyzer

🔎  Bundler Analyzer
Building and analyzing...

Bundle analyzed successfully
core-js
  Multiple versions of core-js found:
    2.5.7 /Users/miguelangel.duran/Dev/frontend-fc--web-server/~/@s-ui/polyfills/~/core-js from /Users/miguelangel.duran/Dev/frontend-fc--web-server/~/@s-ui/polyfills/~/core-js/modules/es7.array.includes.js
    2.6.3 /Users/miguelangel.duran/Dev/frontend-fc--web-server/~/core-js from /Users/miguelangel.duran/Dev/frontend-fc--web-server/~/core-js/library/modules/_array-includes.js

regenerator-runtime
  Multiple versions of regenerator-runtime found:
    0.11.1 /Users/miguelangel.duran/Dev/frontend-fc--web-server/~/babel-runtime/~/regenerator-runtime from /Users/miguelangel.duran/Dev/frontend-fc--web-server/~/babel-runtime/regenerator/index.js
```