### PR TITLE
fix(sui-bundler): set fixed react-dev-utils version

### DIFF
--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -48,7 +48,7 @@
     "optimize-css-assets-webpack-plugin": "5.0.1",
     "postcss-loader": "2.1.6",
     "raw-loader": "0.5.1",
-    "react-dev-utils": ">=5.0.2",
+    "react-dev-utils": "5.0.3",
     "rimraf": "2.6.2",
     "sass-loader": "6.0.7",
     "script-ext-html-webpack-plugin": "2.1.3",


### PR DESCRIPTION
`>= 5.0.2` is installing `v7.x.x` which breaks our studios when running them on IE11, `v6` doesn't work either