### PR TITLE
feat(sui-i18n): add format method for minor types, add tests

### DIFF
--- a/packages/sui-i18n/README.md
+++ b/packages/sui-i18n/README.md
@@ -49,6 +49,7 @@ i18n.culture = 'es-ES';
 i18n.t('HELLO_WORLD') //=> ¡Hola mundo!
 i18n.n(1000) //=> 1.000
 i18n.n(1000000) //=> 1.000.000
+i18n.f('phone', '123123123') //=> '123 123 123'
 ```
 
 From now on, the library will use Polyglot to translate your literals anywhere in your app.
@@ -135,6 +136,17 @@ i18n.culture = 'en-GB';
 i18n.currency = 'GBP';
 i18n.c(1000) //=> £1,000
 i18n.c(1000000) //=> £1,000,000
+```
+
+### Formatting minor types
+
+`i18n.f` provides some formatting functionality for less frequent but still useful needs.
+
+```js
+// phone
+i18n.f('phone', '123123123') //=> '123 123 123'
+i18n.f('phone', '1 23 12312 3') //=> '123 123 123'
+i18n.f('phone', '123123123', {separator: '-'}) //=> '123-123-123'
 ```
 
 ### Use with ReactJS

--- a/packages/sui-i18n/src/i18n.js
+++ b/packages/sui-i18n/src/i18n.js
@@ -69,6 +69,33 @@ export default class Rosetta {
     })
   }
 
+  /**
+   * Format minor types.
+   *
+   * @param {String} type The kind of value to be formatted:
+   *                        - phone
+   * @param {} value The value to be formatted
+   * @param {Object} options Specific options for the specified type
+   */
+  f(type, value, options = {}) {
+    if (typeof type !== 'string')
+      throw new Error('i18n.f should receive a string as a first argument.')
+    if (typeof value === 'undefined')
+      throw new Error('i18n.f should receive any value as a second argument.')
+
+    switch (type) {
+      case 'phone': {
+        const {separator = ' '} = options
+        return value
+          .replace(/ /g, '') // reset all spaces
+          .match(/.{1,3}/g) // group by chunks of 3
+          .join(separator)
+      }
+    }
+
+    return value
+  }
+
   url(urlPattern) {
     return urlPattern
       .split('/')

--- a/packages/sui-i18n/src/i18n.js
+++ b/packages/sui-i18n/src/i18n.js
@@ -79,9 +79,9 @@ export default class Rosetta {
    */
   f(type, value, options = {}) {
     if (typeof type !== 'string')
-      throw new Error('i18n.f should receive a string as a first argument.')
+      throw new Error('i18n.f should receive a string as a first argument')
     if (typeof value === 'undefined')
-      throw new Error('i18n.f should receive any value as a second argument.')
+      throw new Error('i18n.f should receive any value as a second argument')
 
     switch (type) {
       case 'phone': {
@@ -93,7 +93,7 @@ export default class Rosetta {
       }
     }
 
-    return value
+    throw new Error(`Invalid type '${type}' passed to i18n.f`)
   }
 
   url(urlPattern) {

--- a/packages/sui-i18n/test/i18nSpec.js
+++ b/packages/sui-i18n/test/i18nSpec.js
@@ -142,6 +142,12 @@ describe('I18N', () => {
           it('from wrong spaced groups', () => {
             expect(i18n.f('phone', '1 23 12312 3')).to.eql('123 123 123')
           })
+
+          it('with custom separator', () => {
+            expect(i18n.f('phone', '123123123', {separator: '-'})).to.eql(
+              '123-123-123'
+            )
+          })
         })
       })
     })

--- a/packages/sui-i18n/test/i18nSpec.js
+++ b/packages/sui-i18n/test/i18nSpec.js
@@ -132,6 +132,18 @@ describe('I18N', () => {
       it('translates "literalOne" properly', () => {
         expect(i18n.t('literalOne')).to.eql('TranslateOneEsES')
       })
+
+      describe('properly formats minor types like', () => {
+        describe('phone', () => {
+          it('from agglomerated digits', () => {
+            expect(i18n.f('phone', '123123123')).to.eql('123 123 123')
+          })
+
+          it('from wrong spaced groups', () => {
+            expect(i18n.f('phone', '1 23 12312 3')).to.eql('123 123 123')
+          })
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
## Todo
- [x] Add format method
- [x] Add tests
- [x] Add documentation

## Description
Proposal to address #491. The current solution considers holding future "minor types" if necessary (any suggestions for better naming?). Is this a suitable approach?

Note: If the proposal were to be accepted, it would be necessary to add proper documentation [into the README](https://github.com/SUI-Components/sui/blob/master/packages/sui-i18n/README.md).

## Example
```js
i18n.f('phone', '123123123') // outputs '123 123 123'
```
