### PR TITLE
feat(sui-js): added utils to suit class names

### DIFF
--- a/packages/sui-js/README.md
+++ b/packages/sui-js/README.md
@@ -105,3 +105,14 @@ const {isMobile, osName} = stats(userAgent)
 domain.config('isMobile', isMobile) // bool
 domain.config('osName', osName) // string
 ```
+
+## classes
+Utilities to easily format classNames following the current convention for component-{children}-element--modifier
+
+```js
+import {suitClass} from '@s-ui/js/lib/classes'
+const baseComponent = suitClass('baseComponent')
+const childrenComponent = baseComponent({children: 'childrenComponent'})
+
+const className = childrenComponent({element: 'element', modifier: 'modifier'}) // outputs: baseComponent-childrenComponent-element--modifier
+```

--- a/packages/sui-js/src/classes/index.js
+++ b/packages/sui-js/src/classes/index.js
@@ -1,0 +1,9 @@
+export const suitClass = className => ({children} = {}) => ({
+  element,
+  modifier
+} = {}) => {
+  if (children) className += `-${children}`
+  if (element) className += `-${element}`
+  if (modifier) className += `--${modifier}`
+  return className
+}

--- a/packages/sui-js/test/classesSpec.js
+++ b/packages/sui-js/test/classesSpec.js
@@ -1,0 +1,34 @@
+/* eslint-env mocha */
+import {expect} from 'chai'
+import {suitClass} from '../src/classes/index'
+
+describe('@s-ui/js', () => {
+  describe('classes:suitClass', () => {
+    it('should create a valid class name with children following convention', () => {
+      const baseComponent = suitClass('baseComponent')
+      const childrenComponent = baseComponent({children: 'childrenComponent'})
+      expect(
+        childrenComponent({element: 'element', modifier: 'modifier'})
+      ).to.be.equal('baseComponent-childrenComponent-element--modifier')
+    })
+
+    it('should create a valid class name without children following convention', () => {
+      const baseComponent = suitClass('baseComponent')()
+      expect(
+        baseComponent({element: 'element', modifier: 'modifier'})
+      ).to.be.equal('baseComponent-element--modifier')
+    })
+
+    it('should create a valid class name without children nor element following convention', () => {
+      const baseComponent = suitClass('baseComponent')()
+      expect(baseComponent()).to.be.equal('baseComponent')
+    })
+
+    it('should create a valid class name with element', () => {
+      const baseComponent = suitClass('baseComponent')()
+      expect(baseComponent({element: 'element'})).to.be.equal(
+        'baseComponent-element'
+      )
+    })
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a new util function to be able to easily suit a class name following the convention for baseComponent{-children}-element--modifier

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
`
const baseComponent = suitClass('baseComponent')
<div className={baseComponent({element: 'element'})}/>
`

