### PR TITLE
Fix/add babel plugin dynamic import node for karma webpack

### DIFF
--- a/packages/sui-test/bin/karma/config.js
+++ b/packages/sui-test/bin/karma/config.js
@@ -35,7 +35,8 @@ const config = {
                       isDevelopment: true
                     }
                   ]
-                ]
+                ],
+                plugins: [require.resolve('babel-plugin-dynamic-import-node')]
               }
             }
           ]

--- a/packages/sui-test/bin/karma/config.js
+++ b/packages/sui-test/bin/karma/config.js
@@ -1,3 +1,5 @@
+const webpack = require('webpack')
+
 const TARGET = process.env.npm_lifecycle_event
 const CWD = process.cwd()
 
@@ -17,6 +19,7 @@ const config = {
     node: {
       fs: 'empty'
     },
+    plugins: [new webpack.EnvironmentPlugin(['NODE_ENV'])],
     module: {
       rules: [
         {


### PR DESCRIPTION
Fix problems with sui-test for some products as karma-webpack doesn't support yet dynamic imports.

Also define NODE_ENV in order to fix the problems with it.