### PR TITLE
fix(sui-hoc): use same version of the package as other libraries to avoid having twice the same

### DIFF
--- a/packages/sui-hoc/package.json
+++ b/packages/sui-hoc/package.json
@@ -15,7 +15,7 @@
     "react": "16"
   },
   "dependencies": {
-    "intersection-observer": "0.5.0"
+    "intersection-observer": "0.5.1"
   },
   "devDependencies": {
     "@s-ui/component-peer-dependencies": "1",


### PR DESCRIPTION
Bump Intersection Observer to latest version.