### PR TITLE
feat(sui-bundler): patch in development mode react-dom for get working with hooks and other features

### DIFF
--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@babel/core": "7.2.2",
     "@babel/cli": "7.2.3",
+    "@hot-loader/react-dom": "16",
     "@s-ui/helpers": "1",
     "@s-ui/lint": "2",
     "autoprefixer": "9.4.3",

--- a/packages/sui-bundler/webpack.config.dev.js
+++ b/packages/sui-bundler/webpack.config.dev.js
@@ -19,6 +19,9 @@ let webpackConfig = {
   context: path.resolve(process.env.PWD, 'src'),
   resolve: {
     alias: {
+      // this alias is needed so react-hot-loader works with all the React 16.6+ features
+      'react-dom': '@hot-loader/react-dom',
+
       // this alias is needed so react-hot-loader works with linked packages on dev mode
       'react-hot-loader': path.resolve(
         path.join(process.env.PWD, './node_modules/react-hot-loader')


### PR DESCRIPTION
Use `@hot-loader/react-dom` to patch react-dom in dev mode.