### PR TITLE
fix(sui-bundler): add alias to get linked packages with react hooks working

### DIFF
--- a/packages/sui-bundler/webpack.config.dev.js
+++ b/packages/sui-bundler/webpack.config.dev.js
@@ -25,7 +25,13 @@ let webpackConfig = {
       // this alias is needed so react-hot-loader works with linked packages on dev mode
       'react-hot-loader': path.resolve(
         path.join(process.env.PWD, './node_modules/react-hot-loader')
-      )
+      ),
+
+      // this alias is needed so react hooks work as expected with linked packages
+      // Why? The reason is that as hooks stores references of components
+      // you should use the exact same imported file from node_modules, and the linked package
+      // was trying to use another diferent from its own node_modules
+      react: path.resolve(path.join(process.env.PWD, './node_modules/react'))
     },
     extensions: ['*', '.js', '.jsx', '.json']
   },


### PR DESCRIPTION
Alias `react` package so when linking components we make sure we're only using only one React library and we're not loading different React instances.