### PR TITLE
feat(sui-lint): exclude media queries from mixins-before-declarations sass lint rule

### DIFF
--- a/packages/sui-lint/sass-lint.yml
+++ b/packages/sui-lint/sass-lint.yml
@@ -48,7 +48,9 @@ rules:
     - 1
     - allow-leading-underscore: true
       convention: hyphenatedlowercase
-  mixins-before-declarations: 1
+  mixins-before-declarations:
+    - 1
+    - exclude: ['media-breakpoint-up', 'media-breakpoint-down', 'breakpoint', 'media', 'mq']
   nesting-depth:
     - 1
     - max-depth: 4


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Exclude media queries from `mixins-before-declarations` sass lint rule, in order to be able to declare css default properties before media queries and don't get an error.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
