### PR TITLE
feat(sui-widget-embedder): add support for the new react context

### DIFF
--- a/packages/sui-widget-embedder/package.json
+++ b/packages/sui-widget-embedder/package.json
@@ -19,6 +19,7 @@
     "@s-ui/bundler": "3",
     "@s-ui/component-peer-dependencies": "1",
     "@s-ui/helpers": "1",
+    "@s-ui/react-context": "1",
     "@s-ui/react-domain-connector": "1",
     "commander": "2.11.0",
     "copy-paste": "1.3.0",

--- a/packages/sui-widget-embedder/src-react/Widget.js
+++ b/packages/sui-widget-embedder/src-react/Widget.js
@@ -1,8 +1,8 @@
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import ReactDOM from 'react-dom'
-
-import {Provider} from '@s-ui/react-domain-connector'
+import Context from '@s-ui/react-context'
+import {Provider as ProviderLegacy} from '@s-ui/react-domain-connector'
 
 export default class Widget extends Component {
   static propTypes = {
@@ -21,9 +21,16 @@ export default class Widget extends Component {
     }
 
     ReactDOM.render(
-      <Provider i18n={i18n} domain={domain}>
-        {children}
-      </Provider>,
+      <Context.Provider
+        value={{
+          i18n,
+          domain
+        }}
+      >
+        <ProviderLegacy i18n={i18n} domain={domain}>
+          {children}
+        </ProviderLegacy>
+      </Context.Provider>,
       node
     )
   }


### PR DESCRIPTION
# add support for the new react context

## Description
Since we're trying to migrate all our vertical components to the new React Context API, we need to have the Context Provider wrapping our widgets apps.
