### PR TITLE
feat(sui-test): add support for some proposal export babel plugins

### DIFF
--- a/packages/sui-test/bin/karma/config.js
+++ b/packages/sui-test/bin/karma/config.js
@@ -41,7 +41,10 @@ const config = {
                 ],
                 plugins: [
                   require.resolve('babel-plugin-dynamic-import-node'),
-                  require.resolve('@babel/plugin-proposal-export-default-from')
+                  require.resolve('@babel/plugin-proposal-export-default-from'),
+                  require.resolve(
+                    '@babel/plugin-proposal-export-namespace-from'
+                  )
                 ]
               }
             }

--- a/packages/sui-test/bin/mocha/register.js
+++ b/packages/sui-test/bin/mocha/register.js
@@ -3,6 +3,8 @@ require('@babel/register')({
   presets: ['babel-preset-sui'],
   plugins: [
     'babel-plugin-dynamic-import-node',
+    '@babel/plugin-proposal-export-default-from',
+    '@babel/plugin-proposal-export-namespace-from',
     '@babel/plugin-transform-modules-commonjs'
   ]
 })

--- a/packages/sui-test/package.json
+++ b/packages/sui-test/package.json
@@ -17,6 +17,7 @@
     "@babel/cli": "7.2.3",
     "@babel/core": "7.2.2",
     "@babel/plugin-proposal-export-default-from": "7.2.0",
+    "@babel/plugin-proposal-export-namespace-from": "7.2.0",
     "@babel/plugin-transform-modules-commonjs": "7.2.0",
     "@babel/polyfill": "7.2.3",
     "@babel/register": "7.0.0",


### PR DESCRIPTION
### Description
Give support for some proposal export plugins as `plugin-proposal-export-default-from` and `plugin-proposal-export-namespace-from` in unit tests execution (both client and server).

### Example
Some of code examples that will be supported with this change will be:
```js
// @babel/plugin-proposal-export-default-from
export test from 'sui-test';
// @babel/plugin-proposal-export-namespace-from
export * as ads from 'ads';
``` 
