### PR TITLE
fix(sui-domain): avoid using not supported export from webpack

### DIFF
--- a/packages/sui-domain/src/index.js
+++ b/packages/sui-domain/src/index.js
@@ -1,8 +1,19 @@
-export Entity from './Entity'
-export EntryPointFactory from './EntryPointFactory'
-export FetcherFactory from './fetcher/factory'
-export Mapper from './Mapper'
-export Repository from './Repository'
-export Service from './Service'
-export UseCase from './UseCase'
-export ValueObject from './ValueObject'
+import Entity from './Entity'
+import EntryPointFactory from './EntryPointFactory'
+import FetcherFactory from './fetcher/factory'
+import Mapper from './Mapper'
+import Repository from './Repository'
+import Service from './Service'
+import UseCase from './UseCase'
+import ValueObject from './ValueObject'
+
+export {
+  Entity,
+  EntryPointFactory,
+  FetcherFactory,
+  Mapper,
+  Repository,
+  Service,
+  UseCase,
+  ValueObject
+}


### PR DESCRIPTION
Stop using unsupported export proposal and use the native way of handling this (supported by webpack and native modules).