### PR TITLE
Fix/sui studio supported exported react memo components

### DIFF
--- a/packages/sui-studio/src/components/demo/index.js
+++ b/packages/sui-studio/src/components/demo/index.js
@@ -157,9 +157,13 @@ export default class Demo extends Component {
     } = this.state
 
     const Base = exports.default
+
     if (!Base) {
       return <h1>Loading...</h1>
     }
+
+    // check if is a normal component or it's wrapped with a React.memo method
+    const ComponentToRender = Base.type ? Base.type : Base
 
     const nonDefaultExports = removeDefaultContext(exports)
     const context =
@@ -171,7 +175,7 @@ export default class Demo extends Component {
     const Enhance = pipe(
       withContext(context, context),
       withProvider(hasProvider, store)
-    )(Base)
+    )(ComponentToRender)
 
     const EnhanceDemoComponent =
       DemoComponent &&

--- a/packages/sui-studio/src/components/root/index.js
+++ b/packages/sui-studio/src/components/root/index.js
@@ -1,13 +1,7 @@
-import React, {Component} from 'react'
-import {hot} from 'react-hot-loader'
+import React from 'react'
 import {Router, browserHistory} from 'react-router'
 import routes from '../../routes'
 import '../../index.scss'
 
-class Root extends Component {
-  render() {
-    return <Router routes={routes} history={browserHistory} />
-  }
-}
-
-export default hot(module)(Root)
+const Root = () => <Router routes={routes} history={browserHistory} />
+export default Root

--- a/packages/sui-studio/workbench/src/components/Raw/index.js
+++ b/packages/sui-studio/workbench/src/components/Raw/index.js
@@ -1,7 +1,6 @@
 /* eslint import/no-webpack-loader-syntax:0 */
 import React from 'react'
 import PropTypes from 'prop-types'
-import {hot} from 'react-hot-loader'
 
 import Preview from '../../../../src/components/preview'
 
@@ -109,4 +108,4 @@ class Raw extends React.PureComponent {
   handleChangeCodeMirror = playground => this.setState({playground})
 }
 
-export default hot(module)(Raw)
+export default Raw

--- a/packages/sui-studio/workbench/src/components/Raw/index.js
+++ b/packages/sui-studio/workbench/src/components/Raw/index.js
@@ -59,10 +59,12 @@ class Raw extends React.PureComponent {
     const {domain} = context || {}
     const store = domain && hasProvider && createStore(domain)
 
+    // check if is a normal component or it's wrapped with a React.memo method
+    const ComponentToRender = Component.type ? Component.type : Component
     const Enhance = pipe(
       withContext(context, context),
       withProvider(hasProvider, store)
-    )(Component)
+    )(ComponentToRender)
 
     const EnhanceDemoComponent =
       DemoComponent &&
@@ -70,6 +72,7 @@ class Raw extends React.PureComponent {
         withContext(context, context),
         withProvider(hasProvider, store)
       )(DemoComponent)
+
     return (
       <div className="Raw">
         <Style>{themes[actualStyle]}</Style>

--- a/packages/sui-studio/workbench/src/components/Root/index.js
+++ b/packages/sui-studio/workbench/src/components/Root/index.js
@@ -1,7 +1,6 @@
 /* eslint import/no-webpack-loader-syntax:0 */
 import React from 'react'
 import PropTypes from 'prop-types'
-import {hot} from 'react-hot-loader'
 
 import Header from '../Header'
 import Select from '../Select'
@@ -94,4 +93,4 @@ class Root extends React.PureComponent {
   }
 }
 
-export default hot(module)(Root)
+export default Root


### PR DESCRIPTION
Issue: https://github.com/SUI-Components/sui/issues/532

- [x] Make exported React.memo components compatible with sui-studio catalogue and development mode.
- [x] Remove react-hot-loader stuff from sui-studio.

Screenshot with the error to be fixed:
![image](https://user-images.githubusercontent.com/1561955/54261175-5b793c80-456b-11e9-98a6-ab5cdf01730d.png)
