### PR TITLE
fix(sui-mono): Avoid creating root path Scope because it doesnt' exist

### DIFF
--- a/packages/sui-mono/src/config.js
+++ b/packages/sui-mono/src/config.js
@@ -7,12 +7,11 @@ const projectPackage = require(path.join(basePath, 'package.json'))
 const packageConfig = projectPackage.config
 
 function getOrDefault(key, defaultValue) {
-  return (
-    (packageConfig &&
-      packageConfig['sui-mono'] &&
-      packageConfig['sui-mono'][key]) ||
-    defaultValue
-  )
+  return packageConfig &&
+    packageConfig['sui-mono'] &&
+    typeof packageConfig['sui-mono'][key] !== 'undefined'
+    ? packageConfig['sui-mono'][key]
+    : defaultValue
 }
 
 const packagesFolder = getOrDefault('packagesFolder', 'src')
@@ -20,6 +19,7 @@ const rootPath = path.join(basePath, packagesFolder)
 const deepLevel = getOrDefault('deepLevel', 1)
 const configCustomScopes = getOrDefault('customScopes', [])
 const publishAccess = getOrDefault('access', 'restricted')
+const addRootScope = getOrDefault('addRootScope', true)
 
 module.exports = {
   getScopes: function() {
@@ -38,7 +38,7 @@ module.exports = {
     })
 
     const customScopes =
-      hasRootFiles() && this.isMonoPackage()
+      addRootScope && hasRootFiles() && this.isMonoPackage()
         ? [...configCustomScopes, 'Root']
         : configCustomScopes
     return flatten(scopes, customScopes)

--- a/packages/sui-mono/src/config.js
+++ b/packages/sui-mono/src/config.js
@@ -5,13 +5,15 @@ const statSync = require('fs').statSync
 const basePath = process.cwd()
 const projectPackage = require(path.join(basePath, 'package.json'))
 const packageConfig = projectPackage.config
+const ROOT_SCOPE = 'Root'
 
 function getOrDefault(key, defaultValue) {
-  return packageConfig &&
-    packageConfig['sui-mono'] &&
-    typeof packageConfig['sui-mono'][key] !== 'undefined'
-    ? packageConfig['sui-mono'][key]
-    : defaultValue
+  return (
+    (packageConfig &&
+      packageConfig['sui-mono'] &&
+      packageConfig['sui-mono'][key]) ||
+    defaultValue
+  )
 }
 
 const packagesFolder = getOrDefault('packagesFolder', 'src')
@@ -19,7 +21,6 @@ const rootPath = path.join(basePath, packagesFolder)
 const deepLevel = getOrDefault('deepLevel', 1)
 const configCustomScopes = getOrDefault('customScopes', [])
 const publishAccess = getOrDefault('access', 'restricted')
-const addRootScope = getOrDefault('addRootScope', true)
 
 module.exports = {
   getScopes: function() {
@@ -38,14 +39,16 @@ module.exports = {
     })
 
     const customScopes =
-      addRootScope && hasRootFiles() && this.isMonoPackage()
-        ? [...configCustomScopes, 'Root']
+      hasRootFiles() && this.isMonoPackage()
+        ? [...configCustomScopes, ROOT_SCOPE]
         : configCustomScopes
     return flatten(scopes, customScopes)
   },
   getScopesPaths: function() {
     const packagesDir = path.join(process.cwd(), this.getPackagesFolder())
-    return this.getScopes().map(pkg => path.join(packagesDir, pkg))
+    return this.getScopes()
+      .filter(scope => scope !== ROOT_SCOPE)
+      .map(pkg => path.join(packagesDir, pkg))
   },
   getPackagesFolder: function() {
     return packagesFolder


### PR DESCRIPTION
Avoid creating the Root scope path as it doesn't exist when we try performing a phoenix or running an npm install in parallel.
```
→ cd demo && ../node_modules/.bin/sui-mono run-parallel npm install --no-progress
{ 'sui-mono': { packagesFolder: '.', deepLevel: 3, addRootScope: false } }
true
❯❯ Running 6 commands in parallel.
 ⠙ npm install --no-progress @profile/themes
 ⠙ npm install --no-progress @banner/themes
 ⠙ npm install --no-progress @appBoundary/themes
 ⠙ npm install --no-progress @gallery/themes
 ⠙ npm install --no-progress @icons/themes
 ✖ npm install --no-progress @demo/Root
   → spawn npm ENOENT

✖ An error occurred during command execution. Info:

Error: spawn npm ENOENT
```