### PR TITLE
Feature/move to babel preset sui 3

### DIFF
--- a/packages/sui-bundler/example/src/app.js
+++ b/packages/sui-bundler/example/src/app.js
@@ -1,8 +1,6 @@
 /* eslint-disable no-console */
 import React from 'react'
 import ReactDOM from 'react-dom'
-import {AppContainer} from 'react-hot-loader'
-
 import Hello from './hello'
 
 // eslint-next-disable-line
@@ -10,16 +8,7 @@ import(/* webpackChunkName: "my-chunk-name" */ './foo').then(a =>
   console.log('loaded async chunk')
 )
 
-// https://webpack.js.org/guides/hmr-react/#components/sidebar/sidebar.jsx
 const render = Component =>
-  ReactDOM.render(
-    <AppContainer>
-      <Component />
-    </AppContainer>,
-    document.getElementById('root')
-  )
-render(Hello)
+  ReactDOM.render(<Component />, document.getElementById('root'))
 
-if (module.hot) {
-  module.hot.accept('./hello', () => render(require('./hello').default))
-}
+render(Hello)

--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -27,7 +27,7 @@
     "@s-ui/lint": "2",
     "autoprefixer": "9.4.3",
     "babel-loader": "8.0.4",
-    "babel-preset-sui": "2",
+    "babel-preset-sui": "3",
     "bundle-loader": "0.5.6",
     "chalk": "1.1.3",
     "commander": "2.19.0",

--- a/packages/sui-decorators/package.json
+++ b/packages/sui-decorators/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "devDependencies": {
     "@babel/cli": "7",
-    "babel-preset-sui": "2",
+    "babel-preset-sui": "3",
     "sinon": "2"
   },
   "dependencies": {

--- a/packages/sui-domain/package.json
+++ b/packages/sui-domain/package.json
@@ -14,8 +14,8 @@
     "axios": "0.17.1"
   },
   "devDependencies": {
-    "babel-cli": "6.24.1",
-    "babel-preset-sui": "1",
+    "@babel/cli": "7.2.3",
+    "babel-preset-sui": "3",
     "fs-extra": "4.0.2"
   }
 }

--- a/packages/sui-hoc/package.json
+++ b/packages/sui-hoc/package.json
@@ -20,6 +20,6 @@
   "devDependencies": {
     "@s-ui/component-peer-dependencies": "1",
     "@babel/cli": "7",
-    "babel-preset-sui": "2"
+    "babel-preset-sui": "3"
   }
 }

--- a/packages/sui-html-tagger/package.json
+++ b/packages/sui-html-tagger/package.json
@@ -16,7 +16,7 @@
   "license": "ISC",
   "devDependencies": {
     "babel-cli": "6.24.1",
-    "babel-preset-sui": "1"
+    "babel-preset-sui": "3"
   },
   "dependencies": {
     "just-debounce-it": "1.0.1"

--- a/packages/sui-i18n/package.json
+++ b/packages/sui-i18n/package.json
@@ -14,7 +14,7 @@
     "node-polyglot": "0.4.3"
   },
   "devDependencies": {
-    "babel-cli": "6.24.1",
-    "babel-preset-sui": "1"
+    "@babel/cli": "7.2.3",
+    "babel-preset-sui": "3"
   }
 }

--- a/packages/sui-js/package.json
+++ b/packages/sui-js/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@babel/cli": "7",
-    "babel-preset-sui": "2"
+    "babel-preset-sui": "3"
   },
   "homepage": "https://github.com/SUI-Components/sui/tree/master/packages/sui-js#readme"
 }

--- a/packages/sui-mockmock/package.json
+++ b/packages/sui-mockmock/package.json
@@ -25,7 +25,7 @@
     "@s-ui/test": "2",
     "axios": "0.18.0",
     "@babel/cli": "7",
-    "babel-preset-sui": "2"
+    "babel-preset-sui": "3"
   },
   "license": "MIT",
   "repository": {

--- a/packages/sui-perf/package.json
+++ b/packages/sui-perf/package.json
@@ -24,8 +24,8 @@
   },
   "homepage": "https://github.com/SUI-Components/sui/tree/master/packages/sui-perf#readme",
   "devDependencies": {
-    "babel-cli": "6.18.0",
-    "babel-preset-sui": "1"
+    "@babel/cli": "7.2.3",
+    "babel-preset-sui": "3"
   },
   "peerDependencies": {
     "react": "15",

--- a/packages/sui-react-context/package.json
+++ b/packages/sui-react-context/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "@babel/cli": "7.2.3",
-    "babel-preset-sui": "2"
+    "babel-preset-sui": "3"
   }
 }

--- a/packages/sui-react-initial-props/package.json
+++ b/packages/sui-react-initial-props/package.json
@@ -16,8 +16,8 @@
   },
   "devDependencies": {
     "@s-ui/component-peer-dependencies": "1",
-    "babel-cli": "6.24.1",
-    "babel-preset-sui": "1"
+    "@babel/cli": "7.2.3",
+    "babel-preset-sui": "3"
   },
   "dependencies": {
     "@s-ui/hoc": "1"

--- a/packages/sui-studio-utils/package.json
+++ b/packages/sui-studio-utils/package.json
@@ -11,8 +11,8 @@
   "author": "Enablers Frontend",
   "license": "ISC",
   "devDependencies": {
-    "babel-cli": "6.26.0",
-    "babel-preset-sui": "1"
+    "@babel/cli": "7.2.3",
+    "babel-preset-sui": "3"
   },
   "dependencies": {
     "@s-ui/i18n": "1"

--- a/packages/sui-test/package.json
+++ b/packages/sui-test/package.json
@@ -25,7 +25,7 @@
     "babel-loader": "8.0.5",
     "babel-plugin-dynamic-import-node": "2.2.0",
     "babel-plugin-istanbul": "5.1.0",
-    "babel-preset-sui": "2",
+    "babel-preset-sui": "3",
     "chalk": "2.4.1",
     "commander": "2.19.0",
     "karma": "4.0.0",


### PR DESCRIPTION
Move packages from babel-preset-sui 2 to 3.
Update sui-bundler example to remove react-hot-loader references.