### PR TITLE
fix(sui-bundler): fix linking packages not working with the react context package

### DIFF
--- a/packages/sui-bundler/webpack.config.dev.js
+++ b/packages/sui-bundler/webpack.config.dev.js
@@ -23,7 +23,10 @@ let webpackConfig = {
       // Why? The reason is that as hooks stores references of components
       // you should use the exact same imported file from node_modules, and the linked package
       // was trying to use another diferent from its own node_modules
-      react: path.resolve(path.join(process.env.PWD, './node_modules/react'))
+      react: path.resolve(path.join(process.env.PWD, './node_modules/react')),
+      '@s-ui/react-context': path.resolve(
+        path.join(process.env.PWD, './node_modules/@s-ui/react-context')
+      )
     },
     extensions: ['*', '.js', '.jsx', '.json']
   },


### PR DESCRIPTION
### Description
Since in Motor we're working with new React Context package, we've notice linking components that import `@s-ui/react-context` in our app breaks the loaded page.