### PR TITLE
Add "sui-changelog" package

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ $ export PATH="$PATH:./node_modules/.bin"
 | -- | -- |
 | [babel-preset-sui](./packages/babel-preset-sui) | A babel preset for SUI components common syntax |
 | [sui-bundler](./packages/sui-bundler) | Config-free bundler for ES6 React apps |
+| [sui-changelog](./packages/sui-changelog) | CLI to retrieve a changelog from a set of dependencies |
 | [sui-component-dependencies](./packages/sui-component-dependencies) | A set of common dependencies for all SUI components |
 | [sui-component-peer-dependencies](./packages/sui-component-peer-dependencies) | A set of peer dependencies for all SUI components. |
 | [sui-cz](./packages/sui-cz) | A commitizen adapter for semantic commits |

--- a/packages/sui-changelog/README.md
+++ b/packages/sui-changelog/README.md
@@ -34,7 +34,7 @@ By default, `sui-changelog` works only with `@s-ui` scoped packages, so if you w
 
 ### Retrieving data from private repositories
 
-If you know you have some private respositories inside your set of dependencies, you might add a GitHub access token in order to make it work. Such token has to be added like the following example:
+If you know you have some private respositories inside your set of dependencies, you should add a GitHub access token in order to make it work. Such token has to be added like the following example:
 
 ```js
 {
@@ -45,3 +45,19 @@ If you know you have some private respositories inside your set of dependencies,
 ```
 
 You can get more information in this link to get the token: https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line. If it's not provided, the changelog data for such package will be ignored.
+
+## Output
+
+After triggering the CLI command `sui-changelog` we'll get new changes in our project. Firstly, current package version (`package.json` file) will be updated. Then, if it's the first time a new file named `CHANGELOG.md` will be added to your project, but if you already got it, a new hunk of changes will be added at the top of your file.
+
+```cs
+├── node_modules
+    ├── @my-awesome-scope
+    │   └── my-awesome-package // Package last changes will be retrieved from.
+    ├── @another-scope
+    │   └── another-scope-package // Other package last changes will be retrieved from.
+    ├── eslint
+    └── react
+├── package.json // Modified with the new package version.
+└── CHANGELOG.md // New or modified with the last changes.
+```

--- a/packages/sui-changelog/README.md
+++ b/packages/sui-changelog/README.md
@@ -6,7 +6,11 @@
 
 The main aim of this package is to build a changelog file with all the last changes you get in your last installation within your project. Dependencies are retrieved by its scope in the `node_modules` folder, so you can customize the scopes to get the changelog data from.
 
+Moreover, `sui-changelog` package runs a `npm shrinkwrap` in order to get the differences in the dependencies, and you can optionally run a `phoenix` command if you want to have a clean install before building your changelog.
+
 ## Usage
+
+### Basic usage
 
 Install `node@11` with `npm@6` in your env and run the following CLI command:
 
@@ -19,6 +23,14 @@ Or, if you want to save it in your project development dependencies:
 ```sh
 $ npm install @s-ui/changelog --save-dev
 $ sui-changelog
+```
+
+### Optionally running a phoenix
+
+If you feel more confortable having a clean install of your dependencies before retrieving the changelog, just set the `-p, --phoenix` option:
+
+```sh
+$ sui-changelog -p
 ```
 
 ### Adding more scopes

--- a/packages/sui-changelog/README.md
+++ b/packages/sui-changelog/README.md
@@ -14,9 +14,10 @@ Install `node@11` with `npm@6` in your env and run the following CLI command:
 $ npx @s-ui/changelog
 ```
 
-Or, if you already have it installed:
+Or, if you want to save it in your project development dependencies:
 
 ```sh
+$ npm install @s-ui/changelog --save-dev
 $ sui-changelog
 ```
 
@@ -26,22 +27,20 @@ By default, `sui-changelog` works only with `@s-ui` scoped packages, so if you w
 
 ```js
 {
-  "sui-changelog": {
-    "scopes": ["@my-awesome-scope", "@another-scope"]
+  "config": {
+    "sui-changelog": {
+      "scopes": ["@my-awesome-scope", "@another-scope"]
+    }
   }
 }
 ```
 
 ### Retrieving data from private repositories
 
-If you know you have some private respositories inside your set of dependencies, you should add a GitHub access token in order to make it work. Such token has to be added like the following example:
+If you know you have some private respositories inside your set of dependencies, you should add a GitHub access token as an environment variable (as `GITHUB_TOKEN`) to make it work. Such token has to be added into your `~/.bash_profile` file (or `~/.profile`, or `~/.bashrc`) like the following example:
 
-```js
-{
-  "sui-changelog": {
-    "githubToken": "MY_AWESOME_GITHUB_PERSONAL_ACCESS_TOKEN"
-  }
-}
+```cs
+export GITHUB_TOKEN="MY_AWESOME_GITHUB_PERSONAL_ACCESS_TOKEN"
 ```
 
 You can get more information in this link to get the token: https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line. If it's not provided, the changelog data for such package will be ignored.

--- a/packages/sui-changelog/README.md
+++ b/packages/sui-changelog/README.md
@@ -1,0 +1,47 @@
+# sui-changelog
+
+> CLI to retrieve a changelog from a set of dependencies.
+
+## Description
+
+The main aim of this package is to build a changelog file with all the last changes you get in your last installation within your project. Dependencies are retrieved by its scope in the `node_modules` folder, so you can customize the scopes to get the changelog data from.
+
+## Usage
+
+Install `node@11` with `npm@6` in your env and run the following CLI command:
+
+```sh
+$ npx @s-ui/changelog
+```
+
+Or, if you already have it installed:
+
+```sh
+$ sui-changelog
+```
+
+### Adding more scopes
+
+By default, `sui-changelog` works only with `@s-ui` scoped packages, so if you want to add more scopes to your changelog, just add them in your project `package.json` file, the same way as the example below:
+
+```js
+{
+  "sui-changelog": {
+    "scopes": ["@my-awesome-scope", "@another-scope"]
+  }
+}
+```
+
+### Retrieving data from private repositories
+
+If you know you have some private respositories inside your set of dependencies, you might add a GitHub access token in order to make it work. Such token has to be added like the following example:
+
+```js
+{
+  "sui-changelog": {
+    "githubToken": "MY_AWESOME_GITHUB_PERSONAL_ACCESS_TOKEN"
+  }
+}
+```
+
+You can get more information in this link to get the token: https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line. If it's not provided, the changelog data for such package will be ignored.

--- a/packages/sui-changelog/bin/index.js
+++ b/packages/sui-changelog/bin/index.js
@@ -146,7 +146,7 @@ if (phoenix) {
   execSync(`npx rimraf ${LOCK_FILE_NAME} && npm shrinkwrap`)
 }
 // Retrieve modified packages info from npm shrinkwrap.
-exec('git diff npm-shrinkwrap.json', {maxBuffer: MAX_BUFFER}, (err, stdout) => {
+exec(`git diff ${LOCK_FILE_NAME}`, {maxBuffer: MAX_BUFFER}, (err, stdout) => {
   if (err) error(err)
   const [diff = {}] = parseDiff(stdout)
   const {hunks} = diff

--- a/packages/sui-changelog/bin/index.js
+++ b/packages/sui-changelog/bin/index.js
@@ -12,6 +12,7 @@ const exit = process.exit
 const date = new Date()
 const {
   DEFAULT_SCOPES,
+  LOCK_FILE_NAME,
   PACKAGE_FILES,
   MAX_BUFFER,
   version,
@@ -32,8 +33,6 @@ const {
 let newPackageVersion = version
 let modifiedPackages = []
 let changelogData = []
-
-program.version(version).parse(process.argv)
 
 const pushModifiedPackage = lines => oldVersionLine => {
   const oldVersionIndex = lines.indexOf(oldVersionLine)
@@ -131,6 +130,21 @@ const writeChangelogFile = repositories => {
   })
 }
 
+// Set bin version and parse options.
+program
+  .version(version)
+  .option('-p, --phoenix', 'Run a phoenix before building the changelog.')
+  .parse(process.argv)
+
+const {phoenix} = program
+
+if (phoenix) {
+  execSync(
+    `npx rimraf node_modules && npx rimraf ${LOCK_FILE_NAME} && npm install --prefer-online && npm shrinkwrap`
+  )
+} else {
+  execSync(`npx rimraf ${LOCK_FILE_NAME} && npm shrinkwrap`)
+}
 // Retrieve modified packages info from npm shrinkwrap.
 exec('git diff npm-shrinkwrap.json', {maxBuffer: MAX_BUFFER}, (err, stdout) => {
   if (err) error(err)

--- a/packages/sui-changelog/bin/index.js
+++ b/packages/sui-changelog/bin/index.js
@@ -35,6 +35,102 @@ let changelogData = []
 
 program.version(version).parse(process.argv)
 
+const pushModifiedPackage = lines => oldVersionLine => {
+  const oldVersionIndex = lines.indexOf(oldVersionLine)
+  const newVersionLine = lines[oldVersionIndex + 1]
+  const newMajorVersionLine = lines[oldVersionIndex + 3]
+  const newMajorVersionLineParts = newMajorVersionLine.match(versionRegExp)
+  const newVersionParts = newVersionLine.match(versionRegExp)
+  const scopes = [...DEFAULT_SCOPES, ...customScopes].join('|')
+  const packageRegExp = new RegExp(`"(${scopes})/(.*)":`)
+  const packageParts = lines[oldVersionIndex - 1].match(packageRegExp)
+  if (!packageParts) return
+  const packageScope = packageParts[1]
+  const packageName = packageParts[2]
+  const from = oldVersionLine.match(versionRegExp)[1]
+  const to = newVersionParts
+    ? newVersionParts[1]
+    : newMajorVersionLineParts && newMajorVersionLineParts[1]
+  if (!to) return
+
+  log(`${packageScope}/${packageName}: ${from} => ${to}`)
+
+  modifiedPackages.push({
+    packageScope,
+    packageName,
+    from,
+    to
+  })
+}
+
+const pushChangelogData = (commits, index) => {
+  const {packageScope, packageName, from, to} = modifiedPackages[index]
+  const gitUrl = getRepositoryUrl({packageScope, packageName})
+
+  changelogData.push({h4: `${packageName} ${to}`})
+
+  // Maybe there is no GitHub URL for this package or it's
+  // invalid so we cannot get its changelog data.
+  // So that we print an special message.
+  if (typeof commits === 'undefined' || hasApiError(commits)) {
+    changelogData.push({
+      p: 'There is no changelog data for this package.'
+    })
+
+    return
+  }
+
+  // Retrieve the commits list.
+  let isNewVersionCommit = false
+  let isOldVersionCommit = false
+  let commitsList = []
+
+  commits.forEach(({commit: {message}, html_url: url}) => {
+    isOldVersionCommit = message.includes(from) || !isNewVersionCommit
+    isNewVersionCommit = message.includes(to) || !isOldVersionCommit
+
+    if (
+      isNewVersionCommit &&
+      !message.match(forbiddenExpressionsInCommitRegExp)
+    ) {
+      commitsList.push(`[${message.trim()}](${url})`)
+    }
+  })
+
+  // Only write the needed changes from monorepo commits.
+  if (isMonoRepo(gitUrl)) {
+    commitsList = commitsList.filter(commit => {
+      const packageNameRegExp = new RegExp(`((.*)-${packageName})`)
+
+      return commit.match(packageNameRegExp)
+    })
+  }
+
+  changelogData.push({ul: commitsList})
+}
+
+const writeChangelogFile = repositories => {
+  repositories.forEach(pushChangelogData)
+
+  // Write changelog file.
+  const changelogFile = './CHANGELOG.md'
+  let changelogTemplate = json2md(changelogData)
+  if (fs.existsSync(changelogFile)) {
+    execSync(`git checkout -- ${changelogFile}`)
+    const currentChangelogData = fs.readFileSync(changelogFile, 'utf-8')
+    if (currentChangelogData.includes(changelogTemplate.trim())) {
+      log('Your CHANGELOG.md is already updated.')
+      exit()
+    }
+    changelogTemplate = `${json2md(changelogData)}\n${currentChangelogData}`
+  }
+
+  fs.writeFile(changelogFile, changelogTemplate.trim(), 'utf-8', err => {
+    if (err) error(err)
+    log('Wrote CHANGELOG.md sucessfully.')
+  })
+}
+
 // Retrieve modified packages info from npm shrinkwrap.
 exec('git diff npm-shrinkwrap.json', {maxBuffer: MAX_BUFFER}, (err, stdout) => {
   if (err) error(err)
@@ -72,33 +168,7 @@ exec('git diff npm-shrinkwrap.json', {maxBuffer: MAX_BUFFER}, (err, stdout) => {
     const linesWithModifiedPackages = lines.filter(line =>
       line.match(oldVersionRegExp)
     )
-    linesWithModifiedPackages.forEach(oldVersionLine => {
-      const oldVersionIndex = lines.indexOf(oldVersionLine)
-      const newVersionLine = lines[oldVersionIndex + 1]
-      const newMajorVersionLine = lines[oldVersionIndex + 3]
-      const newMajorVersionLineParts = newMajorVersionLine.match(versionRegExp)
-      const newVersionParts = newVersionLine.match(versionRegExp)
-      const scopes = [...DEFAULT_SCOPES, ...customScopes].join('|')
-      const packageRegExp = new RegExp(`"(${scopes})/(.*)":`)
-      const packageParts = lines[oldVersionIndex - 1].match(packageRegExp)
-      if (!packageParts) return
-      const packageScope = packageParts[1]
-      const packageName = packageParts[2]
-      const from = oldVersionLine.match(versionRegExp)[1]
-      const to = newVersionParts
-        ? newVersionParts[1]
-        : newMajorVersionLineParts && newMajorVersionLineParts[1]
-      if (!to) return
-
-      log(`${packageScope}/${packageName}: ${from} => ${to}`)
-
-      modifiedPackages.push({
-        packageScope,
-        packageName,
-        from,
-        to
-      })
-    })
+    linesWithModifiedPackages.forEach(pushModifiedPackage(lines))
   })
 
   const modifiedRepositories = modifiedPackages.map(getModifiedRepository)
@@ -106,73 +176,7 @@ exec('git diff npm-shrinkwrap.json', {maxBuffer: MAX_BUFFER}, (err, stdout) => {
   Promise.all(modifiedRepositories)
     .then(responses => responses.map(response => response && response.json()))
     .then(responses => {
-      Promise.all(responses).then(repositories => {
-        repositories.forEach((commits, index) => {
-          const {packageScope, packageName, from, to} = modifiedPackages[index]
-          const gitUrl = getRepositoryUrl({packageScope, packageName})
-
-          changelogData.push({h4: `${packageName} ${to}`})
-
-          // Maybe there is no GitHub URL for this package or it's
-          // invalid so we cannot get its changelog data.
-          // So that we print an special message.
-          if (typeof commits === 'undefined' || hasApiError(commits)) {
-            changelogData.push({
-              p: 'There is no changelog data for this package.'
-            })
-
-            return
-          }
-
-          // Retrieve the commits list.
-          let isNewVersionCommit = false
-          let isOldVersionCommit = false
-          let commitsList = []
-
-          commits.forEach(({commit: {message}, html_url: url}) => {
-            isOldVersionCommit = message.includes(from) || !isNewVersionCommit
-            isNewVersionCommit = message.includes(to) || !isOldVersionCommit
-
-            if (
-              isNewVersionCommit &&
-              !message.match(forbiddenExpressionsInCommitRegExp)
-            ) {
-              commitsList.push(`[${message.trim()}](${url})`)
-            }
-          })
-
-          // Only write the needed changes from monorepo commits.
-          if (isMonoRepo(gitUrl)) {
-            commitsList = commitsList.filter(commit => {
-              const packageNameRegExp = new RegExp(`((.*)-${packageName})`)
-
-              return commit.match(packageNameRegExp)
-            })
-          }
-
-          changelogData.push({ul: commitsList})
-        })
-
-        // Write changelog file.
-        const changelogFile = './CHANGELOG.md'
-        let changelogTemplate = json2md(changelogData)
-        if (fs.existsSync(changelogFile)) {
-          execSync(`git checkout -- ${changelogFile}`)
-          const currentChangelogData = fs.readFileSync(changelogFile, 'utf-8')
-          if (currentChangelogData.includes(changelogTemplate.trim())) {
-            log('Your CHANGELOG.md is already updated.')
-            exit()
-          }
-          changelogTemplate = `${json2md(
-            changelogData
-          )}\n${currentChangelogData}`
-        }
-
-        fs.writeFile(changelogFile, changelogTemplate.trim(), 'utf-8', err => {
-          if (err) error(err)
-          log('Wrote CHANGELOG.md sucessfully.')
-        })
-      })
+      Promise.all(responses).then(writeChangelogFile)
     })
     .catch(err => error(err))
 })

--- a/packages/sui-changelog/bin/index.js
+++ b/packages/sui-changelog/bin/index.js
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+/* eslint no-console:0 */
+const program = require('commander')
+const parseDiff = require('what-the-diff').parse
+const exec = require('child_process').exec
+const execSync = require('child_process').execSync
+const json2md = require('json2md')
+const fs = require('fs')
+const log = console.log
+const error = console.error
+const exit = process.exit
+const date = new Date()
+const {
+  DEFAULT_SCOPES,
+  PACKAGE_FILES,
+  MAX_BUFFER,
+  version,
+  scopes: customScopes = [],
+  versionRegExp,
+  oldVersionRegExp,
+  oldPackageVersionRegExp,
+  forbiddenExpressionsInCommitRegExp
+} = require('../src/config')
+const {
+  updateFileVersion,
+  getModifiedRepository,
+  getRepositoryUrl,
+  isMonoRepo,
+  hasApiError
+} = require('../src/helpers')
+
+let newPackageVersion = version
+let modifiedPackages = []
+let changelogData = []
+
+program.version(version).parse(process.argv)
+
+// Retrieve modified packages info from npm shrinkwrap.
+exec('git diff npm-shrinkwrap.json', {maxBuffer: MAX_BUFFER}, (err, stdout) => {
+  if (err) error(err)
+  const [diff = {}] = parseDiff(stdout)
+  const {hunks} = diff
+
+  if (!hunks) {
+    log('There are no changes in your shrinkwrap.')
+    exit()
+  }
+
+  // Update package versions.
+  let oldPackageVersionParts
+  hunks.find(({lines}) => {
+    return lines.find(line => {
+      oldPackageVersionParts = line.match(oldPackageVersionRegExp)
+      return oldPackageVersionParts
+    })
+  })
+
+  if (!oldPackageVersionParts)
+    PACKAGE_FILES.forEach(filePath =>
+      updateFileVersion({filePath, newPackageVersion})
+    )
+
+  changelogData.push({
+    h2: `${newPackageVersion} (${date.getDate()}/${date.getMonth() +
+      1}/${date.getFullYear()})`
+  })
+
+  log('MODIFIED PACKAGES:')
+  hunks.forEach(({lines}) => {
+    // Get modified packages by filtering lines with git removal syntax from
+    // diff.
+    const linesWithModifiedPackages = lines.filter(line =>
+      line.match(oldVersionRegExp)
+    )
+    linesWithModifiedPackages.forEach(oldVersionLine => {
+      const oldVersionIndex = lines.indexOf(oldVersionLine)
+      const newVersionLine = lines[oldVersionIndex + 1]
+      const newMajorVersionLine = lines[oldVersionIndex + 3]
+      const newMajorVersionLineParts = newMajorVersionLine.match(versionRegExp)
+      const newVersionParts = newVersionLine.match(versionRegExp)
+      const scopes = [...DEFAULT_SCOPES, ...customScopes].join('|')
+      const packageRegExp = new RegExp(`"(${scopes})/(.*)":`)
+      const packageParts = lines[oldVersionIndex - 1].match(packageRegExp)
+      if (!packageParts) return
+      const packageScope = packageParts[1]
+      const packageName = packageParts[2]
+      const from = oldVersionLine.match(versionRegExp)[1]
+      const to = newVersionParts
+        ? newVersionParts[1]
+        : newMajorVersionLineParts && newMajorVersionLineParts[1]
+      if (!to) return
+
+      log(`${packageScope}/${packageName}: ${from} => ${to}`)
+
+      modifiedPackages.push({
+        packageScope,
+        packageName,
+        from,
+        to
+      })
+    })
+  })
+
+  const modifiedRepositories = modifiedPackages.map(getModifiedRepository)
+
+  Promise.all(modifiedRepositories)
+    .then(responses => responses.map(response => response && response.json()))
+    .then(responses => {
+      Promise.all(responses).then(repositories => {
+        repositories.forEach((commits, index) => {
+          const {packageScope, packageName, from, to} = modifiedPackages[index]
+          const gitUrl = getRepositoryUrl({packageScope, packageName})
+
+          changelogData.push({h4: `${packageName} ${to}`})
+
+          // Maybe there is no GitHub URL for this package or it's
+          // invalid so we cannot get its changelog data.
+          // So that we print an special message.
+          if (typeof commits === 'undefined' || hasApiError(commits)) {
+            changelogData.push({
+              p: 'There is no changelog data for this package.'
+            })
+
+            return
+          }
+
+          // Retrieve the commits list.
+          let isNewVersionCommit = false
+          let isOldVersionCommit = false
+          let commitsList = []
+
+          commits.forEach(({commit: {message}, html_url: url}) => {
+            isOldVersionCommit = message.includes(from) || !isNewVersionCommit
+            isNewVersionCommit = message.includes(to) || !isOldVersionCommit
+
+            if (
+              isNewVersionCommit &&
+              !message.match(forbiddenExpressionsInCommitRegExp)
+            ) {
+              commitsList.push(`[${message.trim()}](${url})`)
+            }
+          })
+
+          // Only write the needed changes from monorepo commits.
+          if (isMonoRepo(gitUrl)) {
+            commitsList = commitsList.filter(commit => {
+              const packageNameRegExp = new RegExp(`((.*)-${packageName})`)
+
+              return commit.match(packageNameRegExp)
+            })
+          }
+
+          changelogData.push({ul: commitsList})
+        })
+
+        // Write changelog file.
+        const changelogFile = './CHANGELOG.md'
+        let changelogTemplate = json2md(changelogData)
+        if (fs.existsSync(changelogFile)) {
+          execSync(`git checkout -- ${changelogFile}`)
+          const currentChangelogData = fs.readFileSync(changelogFile, 'utf-8')
+          if (currentChangelogData.includes(changelogTemplate.trim())) {
+            log('Your CHANGELOG.md is already updated.')
+            exit()
+          }
+          changelogTemplate = `${json2md(
+            changelogData
+          )}\n${currentChangelogData}`
+        }
+
+        fs.writeFile(changelogFile, changelogTemplate.trim(), 'utf-8', err => {
+          if (err) error(err)
+          log('Wrote CHANGELOG.md sucessfully.')
+        })
+      })
+    })
+    .catch(err => error(err))
+})

--- a/packages/sui-changelog/package.json
+++ b/packages/sui-changelog/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@s-ui/changelog",
+  "version": "1.0.0",
+  "description": "CLI to retrieve a changelog from a set of dependencies",
+  "main": "./bin/index.js",
+  "bin": {
+    "sui-changelog": "./bin/index.js"
+  },
+  "scripts": {
+    "phoenix": "npx @s-ui/mono phoenix",
+    "co": "sui-mono commit",
+    "lint": "sui-lint js"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/SUI-Components/sui.git"
+  },
+  "bugs": {
+    "url": "https://github.com/SUI-Components/sui/issues"
+  },
+  "homepage": "https://github.com/SUI-Components/sui/tree/master/packages/sui-changelog#readme",
+  "dependencies": {
+    "@s-ui/helpers": "1",
+    "commander": "2.19.0",
+    "edit-json-file": "1.2.1",
+    "git-url-parse": "11.1.2",
+    "json2md": "1.6.3",
+    "node-fetch": "2.3.0",
+    "what-the-diff": "0.6.0"
+  },
+  "devDependencies": {
+    "@s-ui/lint": "2",
+    "@s-ui/mono": "1",
+    "@s-ui/precommit": "2",
+    "husky": "0.13.4",
+    "validate-commit-msg": "2.14.0"
+  },
+  "eslintConfig": {
+    "extends": [
+      "./node_modules/@s-ui/lint/eslintrc.js"
+    ]
+  },
+  "config": {
+    "sui-mono": {
+      "packagesFolder": "bin"
+    },
+    "validate-commit-msg": {
+      "types": "@s-ui/mono/src/types"
+    }
+  }
+}

--- a/packages/sui-changelog/package.json
+++ b/packages/sui-changelog/package.json
@@ -27,6 +27,7 @@
     "git-url-parse": "11.1.2",
     "json2md": "1.6.3",
     "node-fetch": "2.3.0",
+    "rimraf": "2.6.3",
     "what-the-diff": "0.6.0"
   },
   "devDependencies": {

--- a/packages/sui-changelog/src/config.js
+++ b/packages/sui-changelog/src/config.js
@@ -2,7 +2,8 @@ const path = require('path')
 const basePath = process.cwd()
 const packageJson = require(path.join(basePath, 'package.json'))
 const version = packageJson.version
-const {scopes, githubToken} = packageJson['sui-changelog'] || {}
+const {scopes} =
+  (packageJson.config && packageJson.config['sui-changelog']) || {}
 
 const DEFAULT_SCOPES = ['@s-ui']
 
@@ -35,7 +36,6 @@ module.exports = {
   LIMIT_EXCEEDED_GITHUB_REPOSITORY_MESSAGE,
   version,
   scopes,
-  githubToken,
   monoRepoRegExp,
   versionRegExp,
   oldVersionRegExp,

--- a/packages/sui-changelog/src/config.js
+++ b/packages/sui-changelog/src/config.js
@@ -1,0 +1,44 @@
+const path = require('path')
+const basePath = process.cwd()
+const packageJson = require(path.join(basePath, 'package.json'))
+const version = packageJson.version
+const {scopes, githubToken} = packageJson['sui-changelog'] || {}
+
+const DEFAULT_SCOPES = ['@s-ui']
+
+const MAX_GITHUB_API_RESULTS = 100
+const PUBLIC_GITHUB_HOST = 'github.com'
+const PUBLIC_GITHUB_API_URL_PATTERN =
+  'https://api.github.com/repos/:org/:repo/commits?per_page=:results'
+const PRIVATE_GITHUB_API_URL_PATTERN =
+  'https://:host/api/v3/repos/:org/:repo/commits?access_token=:token'
+const PACKAGE_FILES = ['./package.json', './npm-shrinkwrap.json']
+const MAX_BUFFER = 1024 * 1024
+const INVALID_GITHUB_REPOSITORY_MESSAGE = 'Not Found'
+const LIMIT_EXCEEDED_GITHUB_REPOSITORY_MESSAGE = 'API rate limit exceeded'
+
+const monoRepoRegExp = /(sui|components).git/
+const versionRegExp = /"version": "(.*)",/
+const oldVersionRegExp = /-\s+"version": "(.*)",/
+const oldPackageVersionRegExp = /-\s\s"version": "(.*)",/
+const forbiddenExpressionsInCommitRegExp = /^Merge pull request|^Merge branch 'master'|^(feat\(META\): )?(R|r)elease|^Bumping to version/
+
+module.exports = {
+  DEFAULT_SCOPES,
+  MAX_GITHUB_API_RESULTS,
+  PUBLIC_GITHUB_HOST,
+  PUBLIC_GITHUB_API_URL_PATTERN,
+  PRIVATE_GITHUB_API_URL_PATTERN,
+  PACKAGE_FILES,
+  MAX_BUFFER,
+  INVALID_GITHUB_REPOSITORY_MESSAGE,
+  LIMIT_EXCEEDED_GITHUB_REPOSITORY_MESSAGE,
+  version,
+  scopes,
+  githubToken,
+  monoRepoRegExp,
+  versionRegExp,
+  oldVersionRegExp,
+  oldPackageVersionRegExp,
+  forbiddenExpressionsInCommitRegExp
+}

--- a/packages/sui-changelog/src/config.js
+++ b/packages/sui-changelog/src/config.js
@@ -6,7 +6,7 @@ const {scopes} =
   (packageJson.config && packageJson.config['sui-changelog']) || {}
 
 const DEFAULT_SCOPES = ['@s-ui']
-
+const LOCK_FILE_NAME = 'npm-shrinkwrap.json'
 const MAX_GITHUB_API_RESULTS = 100
 const PUBLIC_GITHUB_HOST = 'github.com'
 const PUBLIC_GITHUB_API_URL_PATTERN =
@@ -26,6 +26,7 @@ const forbiddenExpressionsInCommitRegExp = /^Merge pull request|^Merge branch 'm
 
 module.exports = {
   DEFAULT_SCOPES,
+  LOCK_FILE_NAME,
   MAX_GITHUB_API_RESULTS,
   PUBLIC_GITHUB_HOST,
   PUBLIC_GITHUB_API_URL_PATTERN,

--- a/packages/sui-changelog/src/helpers.js
+++ b/packages/sui-changelog/src/helpers.js
@@ -1,0 +1,92 @@
+/* eslint no-console:0 */
+const fetch = require('node-fetch')
+const editJsonFile = require('edit-json-file')
+const gitUrlParse = require('git-url-parse')
+const {
+  MAX_GITHUB_API_RESULTS,
+  PUBLIC_GITHUB_HOST,
+  PUBLIC_GITHUB_API_URL_PATTERN,
+  PRIVATE_GITHUB_API_URL_PATTERN,
+  INVALID_GITHUB_REPOSITORY_MESSAGE,
+  LIMIT_EXCEEDED_GITHUB_REPOSITORY_MESSAGE,
+  githubToken,
+  monoRepoRegExp
+} = require('./config')
+
+const buildPublicGithubApiUrl = gitUrl => {
+  const {organization, name} = gitUrlParse(gitUrl)
+
+  return PUBLIC_GITHUB_API_URL_PATTERN.replace(':org', organization)
+    .replace(':repo', name)
+    .replace(':results', MAX_GITHUB_API_RESULTS)
+}
+
+const buildPrivateGithubApiUrl = ({gitUrl, token}) => {
+  const {resource, organization, name} = gitUrlParse(gitUrl)
+
+  return PRIVATE_GITHUB_API_URL_PATTERN.replace(':host', resource)
+    .replace(':org', organization)
+    .replace(':repo', name)
+    .replace(':token', token)
+}
+
+const getRepositoryUrl = ({packageScope, packageName}) => {
+  const path = require('path')
+  const basePath = process.cwd()
+  const packageJson = require(path.join(
+    basePath,
+    'node_modules',
+    packageScope,
+    packageName,
+    'package.json'
+  ))
+
+  return packageJson.repository && packageJson.repository.url
+}
+
+const getModifiedRepository = ({packageScope, packageName}) => {
+  const gitUrl = getRepositoryUrl({packageScope, packageName})
+  if (!gitUrl) return
+  const isPublic = gitUrl.includes(PUBLIC_GITHUB_HOST)
+  let githubApiUrl
+  if (isPublic) {
+    githubApiUrl = buildPublicGithubApiUrl(gitUrl)
+  } else if (githubToken) {
+    githubApiUrl = buildPrivateGithubApiUrl({gitUrl, token: githubToken})
+  } else {
+    return
+  }
+
+  return fetch(githubApiUrl)
+}
+
+const isMonoRepo = url => url.match(monoRepoRegExp)
+
+const updateFileVersion = ({filePath, newPackageVersion}) => {
+  let file = editJsonFile(filePath)
+  const version = file.get('version')
+  newPackageVersion = version.replace(
+    /(\w+).(\w+).(\w+)/,
+    (version, major, minor, bugfix) => `${major}.${++minor}.${bugfix}`
+  )
+
+  file.set('version', newPackageVersion)
+  file.save()
+}
+
+const hasApiError = ({message} = {}) =>
+  Boolean(
+    message &&
+      [
+        INVALID_GITHUB_REPOSITORY_MESSAGE,
+        LIMIT_EXCEEDED_GITHUB_REPOSITORY_MESSAGE
+      ].find(errorMessage => message.includes(errorMessage))
+  )
+
+module.exports = {
+  getRepositoryUrl,
+  getModifiedRepository,
+  isMonoRepo,
+  updateFileVersion,
+  hasApiError
+}

--- a/packages/sui-changelog/src/helpers.js
+++ b/packages/sui-changelog/src/helpers.js
@@ -2,6 +2,7 @@
 const fetch = require('node-fetch')
 const editJsonFile = require('edit-json-file')
 const gitUrlParse = require('git-url-parse')
+const warn = console.warn
 const {
   MAX_GITHUB_API_RESULTS,
   PUBLIC_GITHUB_HOST,
@@ -9,7 +10,6 @@ const {
   PRIVATE_GITHUB_API_URL_PATTERN,
   INVALID_GITHUB_REPOSITORY_MESSAGE,
   LIMIT_EXCEEDED_GITHUB_REPOSITORY_MESSAGE,
-  githubToken,
   monoRepoRegExp
 } = require('./config')
 
@@ -48,12 +48,16 @@ const getModifiedRepository = ({packageScope, packageName}) => {
   const gitUrl = getRepositoryUrl({packageScope, packageName})
   if (!gitUrl) return
   const isPublic = gitUrl.includes(PUBLIC_GITHUB_HOST)
+  const {GITHUB_TOKEN} = process.env
   let githubApiUrl
   if (isPublic) {
     githubApiUrl = buildPublicGithubApiUrl(gitUrl)
-  } else if (githubToken) {
-    githubApiUrl = buildPrivateGithubApiUrl({gitUrl, token: githubToken})
+  } else if (GITHUB_TOKEN) {
+    githubApiUrl = buildPrivateGithubApiUrl({gitUrl, token: GITHUB_TOKEN})
   } else {
+    warn(
+      'You should set the environment variable `GITHUB_TOKEN` if you want to get the data from a private repository.'
+    )
     return
   }
 


### PR DESCRIPTION
# sui-changelog

> CLI to retrieve a changelog from a set of dependencies.

## Description

The main aim of this package is to build a changelog file with all the last changes you get in your last installation within your project. Dependencies are retrieved by its scope in the `node_modules` folder, so you can customize the scopes to get the changelog data from.

Moreover, `sui-changelog` package runs a `npm shrinkwrap` in order to get the differences in the dependencies, and you can optionally run a `phoenix` command if you want to have a clean install before building your changelog.

## Usage

### Basic usage

Install `node@11` with `npm@6` in your env and run the following CLI command:

```sh
$ npx @s-ui/changelog
```

Or, if you want to save it in your project development dependencies:

```sh
$ npm install @s-ui/changelog --save-dev
$ sui-changelog
```

### Optionally running a phoenix

If you feel more confortable having a clean install of your dependencies before retrieving the changelog, just set the `-p, --phoenix` option:

```sh
$ sui-changelog -p
```

### Adding more scopes

By default, `sui-changelog` works only with `@s-ui` scoped packages, so if you want to add more scopes to your changelog, just add them in your project `package.json` file, the same way as the example below:

```js
{
  "config": {
    "sui-changelog": {
      "scopes": ["@my-awesome-scope", "@another-scope"]
    }
  }
}
```

### Retrieving data from private repositories

If you know you have some private respositories inside your set of dependencies, you should add a GitHub access token as an environment variable (as `GITHUB_TOKEN`) to make it work. Such token has to be added into your `~/.bash_profile` file (or `~/.profile`, or `~/.bashrc`) like the following example:

```cs
export GITHUB_TOKEN="MY_AWESOME_GITHUB_PERSONAL_ACCESS_TOKEN"
```

You can get more information in this link to get the token: https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line. If it's not provided, the changelog data for such package will be ignored.

## Output

After triggering the CLI command `sui-changelog` we'll get new changes in our project. Firstly, current package version (`package.json` file) will be updated. Then, if it's the first time a new file named `CHANGELOG.md` will be added to your project, but if you already got it, a new hunk of changes will be added at the top of your file.

```cs
├── node_modules
    ├── @my-awesome-scope
    │   └── my-awesome-package // Package last changes will be retrieved from.
    ├── @another-scope
    │   └── another-scope-package // Other package last changes will be retrieved from.
    ├── eslint
    └── react
├── package.json // Modified with the new package version.
└── CHANGELOG.md // New or modified with the last changes.
```
