### PR TITLE
fix(sui-widget-embedder): fix wrong context on using pathname.match

### DIFF
--- a/packages/sui-widget-embedder/downloader/index.js
+++ b/packages/sui-widget-embedder/downloader/index.js
@@ -108,14 +108,14 @@
   }
 
   function matchPathnameWithRegExp(regExp) {
-    var match = window.location.pathname.match
+    var pathname = window.location.pathname
     if (Array.isArray(regExp)) {
       return regExp.some(function(re) {
-        match(new RegExp(re))
+        pathname.match(new RegExp(re))
       })
     }
 
-    return match(new RegExp(regExp))
+    return pathname.match(new RegExp(regExp))
   }
 
   var pages = []


### PR DESCRIPTION
Storing in a variable the whole pathname.match is causing problems when using widgets.

![image](https://user-images.githubusercontent.com/1561955/55471867-00d37d80-560b-11e9-85a3-1d5eca89f220.png)

For avoiding that, we should store the `pathname` and use the method match instead, in order to avoid losing the reference of the string we want to match.