### PR TITLE
Feat/add gzip and brotli compression

### DIFF
--- a/packages/sui-bundler/README.md
+++ b/packages/sui-bundler/README.md
@@ -134,6 +134,8 @@ This tool works with zero configuration out the box but you could use some confi
 
 `scripts` property accept ScriptExtHtmlWebpackPlugin config: https://github.com/numical/script-ext-html-webpack-plugin#configuration
 
+`manualCompression`: Compress files manually to gzip and brotli (if supported). Useful to use along with a S3 and Lambda@Edge in order to send the best content for the userAgent. (default: `false`)
+
 ```json
 {
   "sui-bundler": {
@@ -142,6 +144,7 @@ This tool works with zero configuration out the box but you could use some confi
     "cdn": "https://url_to_me_cdn.com/",
     "alias": {"react": "preact"},
     "offline": true,
+    "manualCompression": true,
     "externals": {
       "jquery": "./node_modules/jquery/jquery.min.js"
     },

--- a/packages/sui-bundler/bin/sui-bundler-build.js
+++ b/packages/sui-bundler/bin/sui-bundler-build.js
@@ -19,6 +19,10 @@ const chalkProcessing = chalk.blue
 program
   .option('-C, --clean', 'Remove public folder before create a new one')
   .option('-c, --context [folder]', 'Context folder (cwd by default)')
+  .option(
+    '-M, --manual-compression',
+    'Compress files with gzip and brotli (if available) manually'
+  )
   .on('--help', () => {
     console.log('  Examples:')
     console.log('')
@@ -29,8 +33,9 @@ program
   })
   .parse(process.argv)
 
-const {clean = false, context} = program
+const {clean = false, context, manualCompression} = program
 config.context = context || config.context
+config.manualCompression = manualCompression || config.manualCompression
 
 process.env.NODE_ENV = process.env.NODE_ENV
   ? process.env.NODE_ENV

--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -21,8 +21,8 @@
   },
   "homepage": "https://github.com/SUI-Components/sui/tree/master/packages/sui-bundler#readme",
   "dependencies": {
-    "@babel/core": "7.2.2",
     "@babel/cli": "7.2.3",
+    "@babel/core": "7.2.2",
     "@s-ui/helpers": "1",
     "@s-ui/lint": "2",
     "autoprefixer": "9.4.3",
@@ -31,6 +31,7 @@
     "bundle-loader": "0.5.6",
     "chalk": "1.1.3",
     "commander": "2.19.0",
+    "compression-webpack-plugin": "2.0.0",
     "copy-paste": "1.3.0",
     "css-content-loader": "1.0.0",
     "css-loader": "1.0.0",

--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+const CompressionPlugin = require('compression-webpack-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const ManifestPlugin = require('webpack-manifest-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
@@ -10,6 +11,9 @@ const uglifyJsPlugin = require('./shared/uglify')
 const webpack = require('webpack')
 const definePlugin = require('./shared/define')
 const babelRules = require('./shared/module-rules-babel')
+
+const zlib = require('zlib')
+const hasBrotliSupport = Boolean(zlib.brotliCompress)
 
 const {
   navigateFallbackWhitelist,
@@ -145,7 +149,23 @@ module.exports = {
         })
     ),
     when(config.externals, () => new Externals({files: config.externals})),
-    new LoaderUniversalOptionsPlugin(require('./shared/loader-options'))
+    new LoaderUniversalOptionsPlugin(require('./shared/loader-options')),
+    new CompressionPlugin({
+      filename: '[path].gzip',
+      test: /\.(js|css)$/i,
+      minRatio: 1
+    }),
+    when(
+      hasBrotliSupport,
+      () =>
+        new CompressionPlugin({
+          filename: '[path].br',
+          algorithm: 'brotliCompress',
+          test: /\.(js|css)$/i,
+          minRatio: 1,
+          compressionOptions: {level: 11}
+        })
+    )
   ]),
   module: {
     rules: [

--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -150,13 +150,17 @@ module.exports = {
     ),
     when(config.externals, () => new Externals({files: config.externals})),
     new LoaderUniversalOptionsPlugin(require('./shared/loader-options')),
-    new CompressionPlugin({
-      filename: '[path].gzip',
-      test: /\.(js|css)$/i,
-      minRatio: 1
-    }),
     when(
-      hasBrotliSupport,
+      config.manualCompression,
+      () =>
+        new CompressionPlugin({
+          filename: '[path].gzip',
+          test: /\.(js|css)$/i,
+          minRatio: 1
+        })
+    ),
+    when(
+      config.manualCompression && hasBrotliSupport,
       () =>
         new CompressionPlugin({
           filename: '[path].br',


### PR DESCRIPTION
- [x] Add Gzip and Brotli manual option compression.
- [x] Support Brotli only if node version supports it.
- [x] Add config for activating manual compression and create compressed files for you.
- [x] Add -M flag to the sui-bundler build command for manualCompression.

Image of the output:
![image](https://user-images.githubusercontent.com/1561955/55942749-5defb480-5c45-11e9-9867-99a2daf1d80f.png)
