### PR TITLE
Feature/force create always gz and br files

### DIFF
--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -156,7 +156,7 @@ module.exports = {
         new CompressionPlugin({
           filename: '[path].gz',
           threshold: 0,
-          minRatio: 0,
+          minRatio: 2,
           test: /\.(js|css)$/i
         })
     ),
@@ -167,7 +167,7 @@ module.exports = {
           filename: '[path].br',
           algorithm: 'brotliCompress',
           threshold: 0,
-          minRatio: 0,
+          minRatio: 2,
           test: /\.(js|css)$/i,
           compressionOptions: {level: 11}
         })

--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -155,8 +155,9 @@ module.exports = {
       () =>
         new CompressionPlugin({
           filename: '[path].gz',
-          test: /\.(js|css)$/i,
-          minRatio: 1
+          threshold: 0,
+          minRatio: 0,
+          test: /\.(js|css)$/i
         })
     ),
     when(
@@ -165,8 +166,9 @@ module.exports = {
         new CompressionPlugin({
           filename: '[path].br',
           algorithm: 'brotliCompress',
+          threshold: 0,
+          minRatio: 0,
           test: /\.(js|css)$/i,
-          minRatio: 1,
           compressionOptions: {level: 11}
         })
     )


### PR DESCRIPTION
Compress always files no matter how small they are and if the compressed file is not better than the original one (it's weird but could happen and minRatio should be 2 in order to be sure ALL files are compressed).