### PR TITLE
feat(sui-js): added htmr package

### DIFF
--- a/packages/sui-js/README.md
+++ b/packages/sui-js/README.md
@@ -94,6 +94,11 @@ console.log(hasAccents('Árbol')) // true
 import {parseQueryString} from '@s-ui/js/lib/string'
 
 console.log(parseQueryString('?targetPage=pta')) // {targetPage: "pta"}
+
+
+import {htmlStringToReactElement} from '@s-ui/js/lib/string'
+
+htmlStringToReactElement('<p>No more dangerouslySetInnerHTML</p>')
 ```
 
 ## ua-parser


### PR DESCRIPTION
## Description

Added a new package `htmr` to have the option to convert html strings to React element.
`No more dangerouslySetInnerHTML`

## More info

👉🏼 [htmr](https://github.com/pveyes/htmr)

## Example

```
const HtmlContent = (html) => {
  return (
    htmlStringToReactElement(html)
  )
}
```