### PR TITLE
feat(sui-bundler): support react-router-dom link-package

### DIFF
--- a/packages/sui-bundler/webpack.config.dev.js
+++ b/packages/sui-bundler/webpack.config.dev.js
@@ -27,6 +27,9 @@ let webpackConfig = {
       react: path.resolve(path.join(process.env.PWD, './node_modules/react')),
       '@s-ui/react-context': path.resolve(
         path.join(process.env.PWD, './node_modules/@s-ui/react-context')
+      ),
+      'react-router-dom': path.resolve(
+        path.join(process.env.PWD, './node_modules/react-router-dom')
       )
     },
     extensions: ['*', '.js', '.jsx', '.json']


### PR DESCRIPTION
Add support to `react-router-dom` package when linking packages as it's using React.Context and we cannot load two different libraries for it.