### PR TITLE
Feat/limit sui mono release commit

### DIFF
--- a/packages/sui-mono/bin/sui-mono-changelog.js
+++ b/packages/sui-mono/bin/sui-mono-changelog.js
@@ -24,7 +24,7 @@ program
   })
   .parse(process.argv)
 
-const CHANGELOG_NAME = 'CHANGELOG.md'
+const CHANGELOG_NAME = config.getChangelogFilename()
 const cwd = path.join(process.cwd(), getPackagesFolder())
 const getRepoFolders = () =>
   !isMonoPackage() ? getPackagesPaths(cwd)(getScopes()) : ['.']

--- a/packages/sui-mono/bin/sui-mono-changelog.js
+++ b/packages/sui-mono/bin/sui-mono-changelog.js
@@ -3,7 +3,7 @@ const program = require('commander')
 const fs = require('fs')
 const path = require('path')
 const conventionalChangelog = require('conventional-changelog')
-const {getScopes, getPackagesFolder, isMonoPackage} = require('../src/config')
+const {getScopes, getPackagesFolder, isMonoPackage, getChangelogFilename} = require('../src/config')
 const {getPackagesPaths} = require('@s-ui/helpers/packages')
 
 program
@@ -24,7 +24,7 @@ program
   })
   .parse(process.argv)
 
-const CHANGELOG_NAME = config.getChangelogFilename()
+const CHANGELOG_NAME = getChangelogFilename()
 const cwd = path.join(process.cwd(), getPackagesFolder())
 const getRepoFolders = () =>
   !isMonoPackage() ? getPackagesPaths(cwd)(getScopes()) : ['.']

--- a/packages/sui-mono/bin/sui-mono-release.js
+++ b/packages/sui-mono/bin/sui-mono-release.js
@@ -40,6 +40,7 @@ const BASE_DIR = process.cwd()
 const packagesFolder = config.getPackagesFolder()
 const publishAccess = config.getPublishAccess()
 const suiMonoBinPath = require.resolve('@s-ui/mono/bin/sui-mono')
+const changelogFilename = config.getChangelogFilename()
 
 const RELEASE_CODES = {
   0: 'clean',
@@ -81,11 +82,11 @@ const releaseEachPkg = ({pkg, code} = {}) => {
 
     let releaseCommands = [
       ['npm', ['--no-git-tag-version', 'version', `${RELEASE_CODES[code]}`]],
-      ['git', ['add', cwd]]
+      ['git', ['add', path.join(cwd, 'package.json')]]
     ]
     let docCommands = [
       [suiMonoBinPath, ['changelog', cwd]],
-      ['git', ['add', cwd]],
+      ['git', ['add', path.join(cwd, changelogFilename)]],
       ['git', ['commit --amend --no-verify --no-edit']]
     ]
     let publishCommands = [

--- a/packages/sui-mono/src/config.js
+++ b/packages/sui-mono/src/config.js
@@ -21,6 +21,7 @@ const rootPath = path.join(basePath, packagesFolder)
 const deepLevel = getOrDefault('deepLevel', 1)
 const configCustomScopes = getOrDefault('customScopes', [])
 const publishAccess = getOrDefault('access', 'restricted')
+const changelogFilename = getOrDefault('changeLogFilename', 'CHANGELOG.md')
 
 module.exports = {
   getScopes: function() {
@@ -58,6 +59,9 @@ module.exports = {
   },
   getProjectName: function() {
     return projectPackage.name
+  },
+  getChangelogFilename: function() {
+    return changelogFilename
   },
   isMonoPackage: function() {
     const folders = cwds(rootPath, deepLevel)


### PR DESCRIPTION
## Description
Right now `sui-mono release` command adds the entire package directory to the release commit, which can cause problems when the user has other modified files in that component folder that have not been commited yet.

The changes in this PR limit the files added when `releaseCommands` and `docCommands` are run to the `package.json` and `changelog.md` files, respectively. 

The changelog file name is retrieved from the config, the default value is `CHANGELOG.md` but can be set with the `changeLogFilename` key.

