### PR TITLE
feat(sui-mono): resolve promise on writeStream end event

### DIFF
--- a/packages/sui-mono/bin/sui-mono-changelog.js
+++ b/packages/sui-mono/bin/sui-mono-changelog.js
@@ -71,8 +71,11 @@ function generateChangelog(folder) {
         }
         output.write(chunk)
       })
-      .on('end', () => resolve(outputFile))
-      .on('error', reject)
+      .on('end', () => output.end(() => resolve(outputFile)))
+      .on('error', error => {
+        output.destroy(error)
+        reject(error)
+      })
   })
 }
 


### PR DESCRIPTION
Sometimes race conditions can occur between reading git log and writing changes to CHANGELOG.MD.

## Description

Currently changelog.md generation process ends after the `end` event is emitted from `conventionalChangelog` reading stream. The proposal is to resolve the promise after the `end` event emitted from the writing stream.

## Related Issue

fix #581 

## Example

Currently the content of [CHANGELOG.md](https://github.com/SUI-Components/sui/blob/master/packages/babel-preset-sui/CHANGELOG.md) was wiped out after a release [release commit](https://github.com/SUI-Components/sui/commit/58791e7195388f43d7a3b9bd64e19bdb3da43b91)