### PR TITLE
feat(sui-analytics): add userId and anonymousId trait into message context

### DIFF
--- a/packages/sui-analytics/README.md
+++ b/packages/sui-analytics/README.md
@@ -24,7 +24,7 @@ sui-analytics will be an object with the methods described [here](#events)
 ### In your javascript
 
 ```js
-import suiAnalytics from '@s-ui/sui-analytics'
+import suiAnalytics from '@s-ui/analytics'
 ```
 
 ## Events

--- a/packages/sui-analytics/package.json
+++ b/packages/sui-analytics/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "devDependencies": {
     "@babel/cli": "7",
-    "babel-preset-sui": "3"
+    "babel-preset-sui": "3",
+    "sinon": "7.3.2"
   }
 }

--- a/packages/sui-analytics/src/index.js
+++ b/packages/sui-analytics/src/index.js
@@ -9,7 +9,8 @@ export default {
     window.analytics.ready(function() {
       const [event, properties, options = {}, fn] = args
       options.traits = {
-        anonymousId: window.analytics.user().anonymousId()
+        anonymousId: window.analytics.user().anonymousId(),
+        userId: window.analytics.user().id()
       }
       window.analytics.track(event, properties, options, fn)
     })

--- a/packages/sui-analytics/src/index.js
+++ b/packages/sui-analytics/src/index.js
@@ -6,6 +6,12 @@ export default {
     window.analytics.reset(...args)
   },
   track: (...args) => {
-    window.analytics.track(...args)
+    window.analytics.ready(function() {
+      const [event, properties, options = {}, fn] = args
+      options.traits = {
+        anonymousId: window.analytics.user().anonymousId()
+      }
+      window.analytics.track(event, properties, options, fn)
+    })
   }
 }

--- a/packages/sui-analytics/test/suiAnalyticsSpec.js
+++ b/packages/sui-analytics/test/suiAnalyticsSpec.js
@@ -1,0 +1,37 @@
+import suiAnalytics from '../src/'
+import {expect} from 'chai'
+import sinon from 'sinon'
+
+describe('#suiAnalytics', () => {
+  describe('when the track event is called', () => {
+    beforeEach(() => {
+      window.analytics = {}
+      window.analytics = {
+        ready: function(cb) {
+          cb()
+        },
+        user: function() {
+          return {
+            anonymousId: function() {
+              return 'fakeAnonymousId'
+            }
+          }
+        },
+        track: sinon.stub()
+      }
+    })
+
+    afterEach(() => {
+      delete window.analytics
+    })
+
+    it('should add anonymousId as options trait', () => {
+      suiAnalytics.track('fakeEvent', {fakePropKey: 'fakePropValue'})
+
+      sinon.assert.callCount(window.analytics.track, 1)
+      expect(window.analytics.track.getCall(0).args[2]).to.deep.equal({
+        traits: {anonymousId: 'fakeAnonymousId'}
+      })
+    })
+  })
+})

--- a/packages/sui-analytics/test/suiAnalyticsSpec.js
+++ b/packages/sui-analytics/test/suiAnalyticsSpec.js
@@ -10,13 +10,10 @@ describe('#suiAnalytics', () => {
         ready: function(cb) {
           cb()
         },
-        user: function() {
-          return {
-            anonymousId: function() {
-              return 'fakeAnonymousId'
-            }
-          }
-        },
+        user: () => ({
+          anonymousId: () => 'fakeAnonymousId',
+          id: () => 'fakeId'
+        }),
         track: sinon.stub()
       }
     })
@@ -30,7 +27,7 @@ describe('#suiAnalytics', () => {
 
       sinon.assert.callCount(window.analytics.track, 1)
       expect(window.analytics.track.getCall(0).args[2]).to.deep.equal({
-        traits: {anonymousId: 'fakeAnonymousId'}
+        traits: {anonymousId: 'fakeAnonymousId', userId: 'fakeId'}
       })
     })
   })


### PR DESCRIPTION
In order to be able to track the user and anonymous id in adobe, we need segment to sent in its message's context the anonymousId as a trait, a message example would be:

```json
{
  "anonymousId": "e1f5e097-dd7b-456b-bfc9-0d0273017cc1",
  "context": {
    "traits": {
      "anonymousId": "e1f5e097-dd7b-456b-bfc9-0d0273017cc1",
      "userId": "d2g5s9vu-ds7b-456b-bfc9-7d8592734kd3"
    },
  },
  "userId": "d2g5s9vu-ds7b-456b-bfc9-7d8592734kd3"
}
```

track event in which we can see that it normalizes the options https://github.com/segmentio/analytics.js-core/blob/master/lib/analytics.js#L337
normalize function in which we can see that the unknown keys are added into the context https://github.com/segmentio/analytics.js-core/blob/master/lib/normalize.js#L77