### PR TITLE
feat(sui-i18n): (backwards compatible) add an option to allow query p…

### DIFF
--- a/packages/sui-i18n/README.md
+++ b/packages/sui-i18n/README.md
@@ -65,7 +65,7 @@ import Polyglot from '@s-ui/i18n/lib/adapters/polyglot';
 const i18n = new I18n({adapter: new Polyglot()});
 i18n.languages = {
     'es-ES': {
-        'HELLO_WORLD': '¡Hola mundo!'
+        'HELLO_WORLD': '¡Hola mundo!',
     },
     'ca-ES': {
         'HELLO_WORLD': 'Hola món!'
@@ -147,6 +147,30 @@ i18n.c(1000000) //=> £1,000,000
 i18n.f('phone', '123123123') //=> '123 123 123'
 i18n.f('phone', '1 23 12312 3') //=> '123 123 123'
 i18n.f('phone', '123123123', {separator: '-'}) //=> '123-123-123'
+```
+
+### URLs
+
+`i18n.url` provides some funcionality for creating urls
+
+```js
+i18n.languages = {
+    'es-ES': {
+        "HOME": "home"
+        "REDIRECT_TRUE": "?redirect=true",
+
+    }
+}
+```
+
+```js
+i18n.url('/HOME') //=> 'www.example.com/home'
+i18n.url('/HOME') //=> 'www.example.com/home'
+i18n.url('/HOME') //=> 'www.example.com/home'
+i18n.url('/HOME/REDIRECT_TRUE', true) //=> ''www.example.com/home/?redirect=true'
+i18n.url('/HOME/REDIRECT_TRUE') //=> 'www.example.com/home/redirecttrue'
+i18n.url('/HOME/REDIRECT_TRUE', false) //=> 'www.example.com/home/redirecttrue'
+
 ```
 
 ### Use with ReactJS

--- a/packages/sui-i18n/src/i18n.js
+++ b/packages/sui-i18n/src/i18n.js
@@ -96,10 +96,10 @@ export default class Rosetta {
     throw new Error(`Invalid type '${type}' passed to i18n.f`)
   }
 
-  url(urlPattern) {
+  url(urlPattern, allowQueryParams) {
     return urlPattern
       .split('/')
-      .map(token => slugify(this.t(token)))
+      .map(token => slugify(this.t(token), allowQueryParams))
       .join('/')
   }
 }

--- a/packages/sui-i18n/src/slugify.js
+++ b/packages/sui-i18n/src/slugify.js
@@ -7,11 +7,14 @@ function replaceCharIfNeeded(char) {
   return index === -1 ? char : to[index]
 }
 
-export function slugify(str) {
+export function slugify(str, allowQueryParams) {
+  const validCharsRegEx = allowQueryParams
+    ? /[^a-z0-9\\. - ? =]/g // only letters numbers, dashes, dots, equals and question marks
+    : /[^a-z0-9\\. -]/g // only letters numbers, dashes and dots
   return str
     .toLowerCase()
     .replace(/.{1}/g, replaceCharIfNeeded)
-    .replace(/[^a-z0-9\\. -]/g, '') // remove invalid chars only letters numbers, dashes and dots
+    .replace(validCharsRegEx, '') // remove invalid chars
     .replace(/\s+/g, '-') // collapse whitespace and replace by -
     .replace(/-+/g, '-') // collapse dashes
 }

--- a/packages/sui-i18n/src/slugify.js
+++ b/packages/sui-i18n/src/slugify.js
@@ -9,7 +9,7 @@ function replaceCharIfNeeded(char) {
 
 export function slugify(str, allowQueryParams) {
   const validCharsRegEx = allowQueryParams
-    ? /[^a-z0-9\\. - ? =]/g // only letters numbers, dashes, dots, equals and question marks
+    ? /[^a-z0-9\\. \- ? =]/g // only letters numbers, dashes, dots, equals and question marks
     : /[^a-z0-9\\. -]/g // only letters numbers, dashes and dots
   return str
     .toLowerCase()


### PR DESCRIPTION
## Description
Add an option to the url method in order to allow ? and = signs (query paramters)  (backwards compatible).

## Related Issue
Before this PR, if you add a query parameter in the url, the chars: `?` and `=` are removed from the url

## Example
Before: https://milanuncios.com/mis-anuncios/?recargar=1 is converted to https://milanuncios.com/mis-anuncios/recargar1
After: https://milanuncios.com/mis-anuncios/?recargar=1 is converted to https://milanuncios.com/mis-anuncios/?recargar=1
