### PR TITLE
feat(sui-js): arrayToCommaQueryString method

### DIFF
--- a/packages/sui-js/README.md
+++ b/packages/sui-js/README.md
@@ -96,9 +96,9 @@ import {parseQueryString} from '@s-ui/js/lib/string'
 console.log(parseQueryString('?targetPage=pta')) // {targetPage: "pta"}
 
 
-import {arrayToCommaQueryString} from '@s-ui/js/lib/string'
+import {fromArrayToCommaQueryString} from '@s-ui/js/lib/string'
 
-console.log(arrayToCommaQueryString({userId: 1, adId: 2, products: [3, 4, 5]})) // 'userId=1&adId=2&products=3,4,5'
+console.log(fromArrayToCommaQueryString({userId: 1, adId: 2, products: [3, 4, 5]})) // 'userId=1&adId=2&products=3,4,5'
 
 
 import {htmlStringToReactElement} from '@s-ui/js/lib/string'

--- a/packages/sui-js/README.md
+++ b/packages/sui-js/README.md
@@ -96,6 +96,11 @@ import {parseQueryString} from '@s-ui/js/lib/string'
 console.log(parseQueryString('?targetPage=pta')) // {targetPage: "pta"}
 
 
+import {arrayToCommaQueryString} from '@s-ui/js/lib/string'
+
+console.log(arrayToCommaQueryString({userId: 1, adId: 2, products: [3, 4, 5]})) // 'a=1&b=2,c=3,4,5'
+
+
 import {htmlStringToReactElement} from '@s-ui/js/lib/string'
 
 htmlStringToReactElement('<p>No more dangerouslySetInnerHTML</p>')

--- a/packages/sui-js/README.md
+++ b/packages/sui-js/README.md
@@ -98,7 +98,7 @@ console.log(parseQueryString('?targetPage=pta')) // {targetPage: "pta"}
 
 import {arrayToCommaQueryString} from '@s-ui/js/lib/string'
 
-console.log(arrayToCommaQueryString({userId: 1, adId: 2, products: [3, 4, 5]})) // 'a=1&b=2,c=3,4,5'
+console.log(arrayToCommaQueryString({userId: 1, adId: 2, products: [3, 4, 5]})) // 'a=1&b=2&c=3,4,5'
 
 
 import {htmlStringToReactElement} from '@s-ui/js/lib/string'

--- a/packages/sui-js/README.md
+++ b/packages/sui-js/README.md
@@ -98,7 +98,7 @@ console.log(parseQueryString('?targetPage=pta')) // {targetPage: "pta"}
 
 import {arrayToCommaQueryString} from '@s-ui/js/lib/string'
 
-console.log(arrayToCommaQueryString({userId: 1, adId: 2, products: [3, 4, 5]})) // 'a=1&b=2&c=3,4,5'
+console.log(arrayToCommaQueryString({userId: 1, adId: 2, products: [3, 4, 5]})) // 'userId=1&adId=2&products=3,4,5'
 
 
 import {htmlStringToReactElement} from '@s-ui/js/lib/string'

--- a/packages/sui-js/package.json
+++ b/packages/sui-js/package.json
@@ -16,7 +16,7 @@
     "lodash.camelcase": "4.3.0",
     "lodash.capitalize": "4.2.1",
     "lodash.kebabcase": "4.1.1",
-    "qs": "6.6.0",
+    "qs": "6.7.0",
     "remove-accents": "0.4.2"
   },
   "license": "MIT",

--- a/packages/sui-js/src/string/index.js
+++ b/packages/sui-js/src/string/index.js
@@ -1,9 +1,13 @@
-import {parse} from 'qs'
+import {parse, stringify} from 'qs'
 
 export const parseQueryString = query => parse(query, {ignoreQueryPrefix: true})
+export const arrayToCommaQueryString = query =>
+  stringify(query, {arrayFormat: 'comma'})
+
 export {stringify as toQueryString} from 'qs'
 export {fromSnakeToCamelCase, fromCamelToSnakeCase} from './snake-case'
+export {has as hasAccents, remove as removeAccents} from 'remove-accents'
+
 export {default as toCamelCase} from 'lodash.camelcase'
 export {default as toCapitalCase} from 'lodash.capitalize'
 export {default as toKebabCase} from 'lodash.kebabcase'
-export {has as hasAccents, remove as removeAccents} from 'remove-accents'

--- a/packages/sui-js/src/string/index.js
+++ b/packages/sui-js/src/string/index.js
@@ -1,7 +1,7 @@
 import {parse, stringify} from 'qs'
 
 export const parseQueryString = query => parse(query, {ignoreQueryPrefix: true})
-export const arrayToCommaQueryString = query =>
+export const fromArrayToCommaQueryString = query =>
   decodeURIComponent(stringify(query, {arrayFormat: 'comma'}))
 
 export {stringify as toQueryString} from 'qs'

--- a/packages/sui-js/src/string/index.js
+++ b/packages/sui-js/src/string/index.js
@@ -2,7 +2,7 @@ import {parse, stringify} from 'qs'
 
 export const parseQueryString = query => parse(query, {ignoreQueryPrefix: true})
 export const arrayToCommaQueryString = query =>
-  unescape(stringify(query, {arrayFormat: 'comma'}))
+  decodeURIComponent(stringify(query, {arrayFormat: 'comma'}))
 
 export {stringify as toQueryString} from 'qs'
 export {fromSnakeToCamelCase, fromCamelToSnakeCase} from './snake-case'

--- a/packages/sui-js/src/string/index.js
+++ b/packages/sui-js/src/string/index.js
@@ -2,7 +2,7 @@ import {parse, stringify} from 'qs'
 
 export const parseQueryString = query => parse(query, {ignoreQueryPrefix: true})
 export const arrayToCommaQueryString = query =>
-  stringify(query, {arrayFormat: 'comma'})
+  unescape(stringify(query, {arrayFormat: 'comma'}))
 
 export {stringify as toQueryString} from 'qs'
 export {fromSnakeToCamelCase, fromCamelToSnakeCase} from './snake-case'

--- a/packages/sui-js/test/stringSpec.js
+++ b/packages/sui-js/test/stringSpec.js
@@ -21,7 +21,7 @@ describe('@s-ui/js', () => {
       expect(parseQueryString(query)).to.deep.equal(params)
     })
   })
-  describe('string:arrayToCommaQueryString', () => {
+  describe('string:fromArrayToCommaQueryString', () => {
     it.only('should convert params array to comma separated object params', () => {
       const paramsArray = {a: 1, b: 2, c: [3, 4]}
       const params = 'a=1&b=2&c=3,4'

--- a/packages/sui-js/test/stringSpec.js
+++ b/packages/sui-js/test/stringSpec.js
@@ -25,9 +25,7 @@ describe('@s-ui/js', () => {
     it('should convert params array to comma separated object params', () => {
       const paramsArray = {a: 1, b: 2, c: [3, 4]}
       const params = 'a=1&b=2&c=3,4'
-      expect(unescape(arrayToCommaQueryString(paramsArray))).to.deep.equal(
-        params
-      )
+      expect(arrayToCommaQueryString(paramsArray)).to.deep.equal(params)
     })
   })
 })

--- a/packages/sui-js/test/stringSpec.js
+++ b/packages/sui-js/test/stringSpec.js
@@ -22,7 +22,7 @@ describe('@s-ui/js', () => {
     })
   })
   describe('string:arrayToCommaQueryString', () => {
-    it('should convert params array to comma separated object params', () => {
+    it.only('should convert params array to comma separated object params', () => {
       const paramsArray = {a: 1, b: 2, c: [3, 4]}
       const params = 'a=1&b=2&c=3,4'
       expect(arrayToCommaQueryString(paramsArray)).to.deep.equal(params)

--- a/packages/sui-js/test/stringSpec.js
+++ b/packages/sui-js/test/stringSpec.js
@@ -1,6 +1,10 @@
 /* eslint-env mocha */
 import {expect} from 'chai'
-import {parseQueryString, toQueryString} from '../src/string/index'
+import {
+  parseQueryString,
+  toQueryString,
+  arrayToCommaQueryString
+} from '../src/string/index'
 
 describe('@s-ui/js', () => {
   describe('string:toQueryString', () => {
@@ -15,6 +19,15 @@ describe('@s-ui/js', () => {
       const query = '?a=1&b=test'
       const params = {a: '1', b: 'test'}
       expect(parseQueryString(query)).to.deep.equal(params)
+    })
+  })
+  describe('string:arrayToCommaQueryString', () => {
+    it('should convert params array to comma separated object params', () => {
+      const paramsArray = {a: 1, b: 2, c: [3, 4]}
+      const params = 'a=1&b=2&c=3,4'
+      expect(unescape(arrayToCommaQueryString(paramsArray))).to.deep.equal(
+        params
+      )
     })
   })
 })

--- a/packages/sui-js/test/stringSpec.js
+++ b/packages/sui-js/test/stringSpec.js
@@ -3,7 +3,7 @@ import {expect} from 'chai'
 import {
   parseQueryString,
   toQueryString,
-  arrayToCommaQueryString
+  fromArrayToCommaQueryString
 } from '../src/string/index'
 
 describe('@s-ui/js', () => {
@@ -25,7 +25,7 @@ describe('@s-ui/js', () => {
     it.only('should convert params array to comma separated object params', () => {
       const paramsArray = {a: 1, b: 2, c: [3, 4]}
       const params = 'a=1&b=2&c=3,4'
-      expect(arrayToCommaQueryString(paramsArray)).to.deep.equal(params)
+      expect(fromArrayToCommaQueryString(paramsArray)).to.deep.equal(params)
     })
   })
 })


### PR DESCRIPTION
### `arrayToCommaQueryString sui-js method`

## Description
Method for transforming a parameter object into a query-string. If one of the parameters contains an array, it will construct it with a comma separation.

> Needs to upgrade `qs` package from `6.6.0` to `6.7.0`

## Example
```javascript
const params = {userId: 1, adId: 2, products: [3, 4, 5]}
console.log(arrayToCommaQueryString(params)) // 'a=1&b=2&c=3,4,5'
```
