### PR TITLE
feat(sui-domain): accept multiple params for usecase.execute method

### DIFF
--- a/packages/sui-domain/src/EntryPointFactory.js
+++ b/packages/sui-domain/src/EntryPointFactory.js
@@ -40,10 +40,12 @@ export default ({useCases, config}) =>
       return loader === undefined
         ? new NotImplementedUseCase(key)
         : {
-            execute: params => {
+            execute: (...params) => {
               // load async the factory, execute use case and return the promise
               return loader().then(factory =>
-                factory.default[method]({config: this._config}).execute(params)
+                factory.default[method]({config: this._config}).execute(
+                  ...params
+                )
               )
             },
             $: {


### PR DESCRIPTION
## Description
Allows passing by multiple args to the useCase's execute method

## Related Issue
I would like to follow [Segment's track spec](https://segment.com/docs/spec/track/) in order to have the same API everywhere and be able to execute something like:

```js
domain.get('myTrackingEventUseCase').execute('Event Name', {eventProp1: ''})
```
