### PR TITLE
feat(sui-bundler): add alias to keep same experiment context on linked packages

### DIFF
--- a/packages/sui-bundler/README.md
+++ b/packages/sui-bundler/README.md
@@ -180,7 +180,6 @@ This tool works with zero configuration out the box but you could use some confi
 }
 ```
 
-**advice:** the alias option will not work for dev environment
 > The URL to the CDN **MUST** end with a slash `/`
 
 ## OnlyHash

--- a/packages/sui-bundler/webpack.config.dev.js
+++ b/packages/sui-bundler/webpack.config.dev.js
@@ -30,6 +30,12 @@ let webpackConfig = {
       ),
       'react-router-dom': path.resolve(
         path.join(process.env.PWD, './node_modules/react-router-dom')
+      ),
+      '@s-ui/abtesting-optimizely-x': path.resolve(
+        path.join(
+          process.env.PWD,
+          './node_modules/@s-ui/abtesting-optimizely-x'
+        )
       )
     },
     extensions: ['*', '.js', '.jsx', '.json']

--- a/packages/sui-bundler/webpack.config.dev.js
+++ b/packages/sui-bundler/webpack.config.dev.js
@@ -15,6 +15,18 @@ const EXCLUDED_FOLDERS_REGEXP = new RegExp(
   }workbench)?${path.sep}src)`
 )
 
+const ALIAS_FROM_CONFIG = config.alias
+  ? Object.entries(config.alias).reduce(
+      (obj, [aliasName, aliasPath]) => ({
+        ...obj,
+        [aliasName]: aliasPath.startsWith('./')
+          ? path.join(process.env.PWD, aliasPath)
+          : aliasPath
+      }),
+      {}
+    )
+  : {}
+
 let webpackConfig = {
   mode: 'development',
   context: path.resolve(process.env.PWD, 'src'),
@@ -31,12 +43,8 @@ let webpackConfig = {
       'react-router-dom': path.resolve(
         path.join(process.env.PWD, './node_modules/react-router-dom')
       ),
-      '@s-ui/abtesting-optimizely-x': path.resolve(
-        path.join(
-          process.env.PWD,
-          './node_modules/@s-ui/abtesting-optimizely-x'
-        )
-      )
+      // add extra alias from the config
+      ...ALIAS_FROM_CONFIG
     },
     extensions: ['*', '.js', '.jsx', '.json']
   },


### PR DESCRIPTION
## ✍️ Description
The **Experiment Context** feature [which was introduced in this PR](https://github.com/SUI-Components/schibsted-spain-components/pull/94) and resides in the `@s-ui/abtesting-optimizely-x` package, needs an alias on sui-bundler in order to work with linked packages, so the `createContext` method is ran from a single place: the `node_modules` directory from the project in which sui-bundler is running.

This is the very same problem that is being solved for `@s-ui/react-context` package by adding an alias as well:

https://github.com/SUI-Components/sui/blob/3fd5a279e43e9aed038b48da41b3a4d5774bfe72/packages/sui-bundler/webpack.config.dev.js#L28-L30