### PR TITLE
fix(sui-bundler): move alias parse logic to shared for all environments

### DIFF
--- a/packages/sui-bundler/shared/parse-alias.js
+++ b/packages/sui-bundler/shared/parse-alias.js
@@ -1,0 +1,14 @@
+const path = require('path')
+
+module.exports = alias =>
+  alias
+    ? Object.entries(alias).reduce(
+        (obj, [aliasName, aliasPath]) => ({
+          ...obj,
+          [aliasName]: aliasPath.startsWith('./')
+            ? path.join(process.env.PWD, aliasPath)
+            : aliasPath
+        }),
+        {}
+      )
+    : {}

--- a/packages/sui-bundler/webpack.config.dev.js
+++ b/packages/sui-bundler/webpack.config.dev.js
@@ -5,6 +5,7 @@ const LoaderUniversalOptionsPlugin = require('./plugins/loader-options')
 const eslintFormatter = require('react-dev-utils/eslintFormatter')
 const definePlugin = require('./shared/define')
 const manifestLoaderRules = require('./shared/module-rules-manifest-loader')
+const parseAlias = require('./shared/parse-alias')
 require('./shared/shims')
 
 const {envVars, MAIN_ENTRY_POINT, config, cleanList, when} = require('./shared')
@@ -14,18 +15,6 @@ const EXCLUDED_FOLDERS_REGEXP = new RegExp(
     path.sep
   }workbench)?${path.sep}src)`
 )
-
-const ALIAS_FROM_CONFIG = config.alias
-  ? Object.entries(config.alias).reduce(
-      (obj, [aliasName, aliasPath]) => ({
-        ...obj,
-        [aliasName]: aliasPath.startsWith('./')
-          ? path.join(process.env.PWD, aliasPath)
-          : aliasPath
-      }),
-      {}
-    )
-  : {}
 
 let webpackConfig = {
   mode: 'development',
@@ -44,7 +33,7 @@ let webpackConfig = {
         path.join(process.env.PWD, './node_modules/react-router-dom')
       ),
       // add extra alias from the config
-      ...ALIAS_FROM_CONFIG
+      ...parseAlias(config.alias)
     },
     extensions: ['*', '.js', '.jsx', '.json']
   },

--- a/packages/sui-bundler/webpack.config.lib.js
+++ b/packages/sui-bundler/webpack.config.lib.js
@@ -4,12 +4,13 @@ const minifyJs = require('./shared/minify-js')
 const definePlugin = require('./shared/define')
 const babelRules = require('./shared/module-rules-babel')
 const {sourceMap} = require('./shared/config')
+const parseAlias = require('./shared/parse-alias')
 require('./shared/shims')
 
 module.exports = {
   mode: 'production',
   resolve: {
-    alias: config.alias,
+    alias: parseAlias(config.alias),
     extensions: ['*', '.js', '.jsx', '.json']
   },
   entry: config.vendor

--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -24,6 +24,7 @@ const {
 } = require('./shared/precache')
 const {when, cleanList, envVars, MAIN_ENTRY_POINT, config} = require('./shared')
 const {sourceMap} = require('./shared/config')
+const parseAlias = require('./shared/parse-alias')
 
 const Externals = require('./plugins/externals')
 const LoaderUniversalOptionsPlugin = require('./plugins/loader-options')
@@ -36,7 +37,7 @@ module.exports = {
   mode: 'production',
   context: path.resolve(process.cwd(), 'src'),
   resolve: {
-    alias: config.alias,
+    alias: parseAlias(config.alias),
     extensions: ['*', '.js', '.jsx', '.json']
   },
   entry: config.vendor

--- a/packages/sui-bundler/webpack.config.server.js
+++ b/packages/sui-bundler/webpack.config.server.js
@@ -3,13 +3,15 @@ const webpackNodeExternals = require('webpack-node-externals')
 const path = require('path')
 const babelRules = require('./shared/module-rules-babel')
 const manifestLoaderRules = require('./shared/module-rules-manifest-loader')
+const parseAlias = require('./shared/parse-alias')
+
 const {config, when, cleanList} = require('./shared')
 
 let webpackConfig = {
   context: path.resolve(process.cwd(), 'src'),
   mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
   resolve: {
-    alias: config.alias,
+    alias: parseAlias(config.alias),
     extensions: ['*', '.js', '.jsx', '.json']
   },
   entry: './server.js',


### PR DESCRIPTION
## Description

Alias parsing logic must be present on all the webpack configs.

Fixes #625