### PR TITLE
feat(sui-analytics): add adobe marketing cloud id tracking

### DIFF
--- a/packages/sui-analytics/README.md
+++ b/packages/sui-analytics/README.md
@@ -54,3 +54,11 @@ suiAnalytics.track('Registered', {
 ```js
 suiAnalytics.reset()
 ```
+
+## Adobe Analytics Integration - marketingCloudVisitorId
+
+Make sure to call the `setAdobeOrganizationId` function before your first track. It is needed in order to sent the marketingCloudVisitorId within your track events
+
+```js
+suiAnalytics.setAdobeOrganizationId('YOUR_ORGANIZATION_ID')
+```

--- a/packages/sui-analytics/src/index.js
+++ b/packages/sui-analytics/src/index.js
@@ -1,3 +1,5 @@
+let adobeOrgId
+
 export default {
   identify: (...args) => {
     window.analytics.identify(...args)
@@ -12,7 +14,17 @@ export default {
         anonymousId: window.analytics.user().anonymousId(),
         userId: window.analytics.user().id()
       }
+      if (window && window.Visitor && adobeOrgId) {
+        options['Adobe Analytics'] = {
+          marketingCloudVisitorId: window.Visitor.getInstance(
+            adobeOrgId
+          ).getMarketingCloudVisitorID()
+        }
+      }
       window.analytics.track(event, properties, options, fn)
     })
+  },
+  setAdobeOrganizationId: id => {
+    adobeOrgId = id
   }
 }

--- a/packages/sui-analytics/test/suiAnalyticsSpec.js
+++ b/packages/sui-analytics/test/suiAnalyticsSpec.js
@@ -30,5 +30,43 @@ describe('#suiAnalytics', () => {
         traits: {anonymousId: 'fakeAnonymousId', userId: 'fakeId'}
       })
     })
+
+    describe('when adobe visitor is set', () => {
+      beforeEach(() => {
+        window.Visitor = {}
+        window.Visitor.getInstance = sinon.stub().returns({
+          getMarketingCloudVisitorID: sinon.stub().returns('fakeCloudId')
+        })
+      })
+
+      afterEach(() => {
+        delete window.Visitor
+      })
+
+      describe('when organization id has been set', () => {
+        beforeEach(() => {
+          suiAnalytics.setAdobeOrganizationId('fakeOrgId')
+        })
+
+        it('should add the right adobe integration', () => {
+          suiAnalytics.track('fakeEvent', {fakePropKey: 'fakePropValue'})
+
+          sinon.assert.callCount(window.analytics.track, 1)
+          expect(window.analytics.track.getCall(0).args[2]).to.deep.equal({
+            traits: {
+              anonymousId: 'fakeAnonymousId',
+              userId: 'fakeId'
+            },
+            'Adobe Analytics': {
+              marketingCloudVisitorId: 'fakeCloudId'
+            }
+          })
+
+          expect(window.Visitor.getInstance.getCall(0).args[0]).to.equal(
+            'fakeOrgId'
+          )
+        })
+      })
+    })
   })
 })


### PR DESCRIPTION
We have a common orgId but I'm not sure if we should hardcode it here, therefore, I added a way to add this id but we have to set it as soon as possible
