### PR TITLE
fix(sui-svg): add missing lodash.camelcase dependency

### DIFF
--- a/packages/sui-svg/package.json
+++ b/packages/sui-svg/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@s-ui/lint": "2",
+    "lodash.camelcase": "^4.3.0",
     "validate-commit-msg": "2.14.0"
   },
   "keywords": [],

--- a/packages/sui-svg/package.json
+++ b/packages/sui-svg/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@s-ui/lint": "2",
-    "lodash.camelcase": "^4.3.0",
+    "lodash.camelcase": "4.3.0",
     "validate-commit-msg": "2.14.0"
   },
   "keywords": [],


### PR DESCRIPTION
## Description
`lodash.camelcase` dependency was missing from the dependencies list of this package.

This `require()` https://github.com/SUI-Components/sui/blob/master/packages/sui-svg/bin/sui-svg-build.js#L9 was modified in #553 but probably another package was importing lodash, since it has been working fine until recently. 

Unfortunately it produces an error when trying to build the icon library for milanuncios.

