### PR TITLE
feat(sui-polyfills): add element.closest() polyfill

### DIFF
--- a/packages/sui-polyfills/src/element-closest.js
+++ b/packages/sui-polyfills/src/element-closest.js
@@ -1,0 +1,19 @@
+// Polyfill for Element.closest()
+// from https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#Polyfill
+if (!Element.prototype.matches) {
+  Element.prototype.matches =
+    Element.prototype.msMatchesSelector ||
+    Element.prototype.webkitMatchesSelector
+}
+
+if (!Element.prototype.closest) {
+  Element.prototype.closest = function(s) {
+    var el = this
+
+    do {
+      if (el.matches(s)) return el
+      el = el.parentElement || el.parentNode
+    } while (el !== null && el.nodeType === 1)
+    return null
+  }
+}

--- a/packages/sui-polyfills/src/index.js
+++ b/packages/sui-polyfills/src/index.js
@@ -18,4 +18,6 @@ require('core-js/fn/string/includes')
 require('core-js/fn/string/starts-with')
 require('core-js/fn/string/trim')
 
+require('./element-closest')
+
 module.exports = {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add `Element.closest()` polyfill

## Description
Internet Explorer 11 has no support for Element.closest(), so we are adding a polyfill for this. The code is the proposed in MDN (https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#Polyfill) for browsers that support `element.matches()` (IE9+).

I couldn't find any polyfill for it available in core-js.
