### PR TITLE
feat(sui-lint): equal prettier and  stylelint rule

### DIFF
--- a/packages/sui-lint/stylelint.config.js
+++ b/packages/sui-lint/stylelint.config.js
@@ -54,7 +54,7 @@ module.exports = {
     'no-duplicate-selectors': true,
     'no-empty-source': true,
     'no-invalid-double-slash-comments': true,
-    'number-leading-zero': null,
+    'number-leading-zero': 'always',
     'property-no-unknown': true,
     'selector-pseudo-class-no-unknown': true,
     'selector-pseudo-element-no-unknown': true,


### PR DESCRIPTION
So, now that we're using prettier for stylelint it seems that we can't keep using no-leading-zero rule as prettier enforces it and is causing a mismatch between both. In order to fix it, we will need to embrace the leading-zero rule to be used always.

Related: https://github.com/prettier/prettier/issues/2705