### PR TITLE
feat(sui-decorators): allow to disable the cache.

### DIFF
--- a/packages/sui-decorators/README.md
+++ b/packages/sui-decorators/README.md
@@ -127,3 +127,13 @@ thus, avoiding writing very large integers
 * trackTo: Is you pass a host, each 20secds will be send a ping to `${trackTo}/__tracking/cache/event/stats` with a header `x-payload` where there is a object with the stats of hit, miss, env and algorithm
 
 * size (100): How many register can be in the cache before start to remove register.
+
+### How to disable the cache
+In some cases we might want to disable the `cache` for certain environment or testing purposes. In that case, we should expose a variable into the global scope as:
+```
+// For client side
+window.__SUI_CACHE_DISABLED__ = true
+
+// Server side
+global.__SUI_CACHE_DISABLED__ = true
+```

--- a/packages/sui-decorators/src/decorators/cache/index.js
+++ b/packages/sui-decorators/src/decorators/cache/index.js
@@ -37,7 +37,7 @@ const _cache = ({
       (typeof window !== 'undefined' && window.__SUI_CACHE_DISABLED__) ||
       (typeof global !== 'undefined' && global.__SUI_CACHE_DISABLED__)
     ) {
-      return original
+      return original.apply(instance, args)
     }
 
     const key = `${target.constructor.name}::${fnName}::${createHash(

--- a/packages/sui-decorators/src/decorators/cache/index.js
+++ b/packages/sui-decorators/src/decorators/cache/index.js
@@ -33,6 +33,13 @@ const _cache = ({
   const cache = caches[fnName]
 
   return (...args) => {
+    if (
+      (typeof window !== 'undefined' && window.__SUI_CACHE_DISABLED__) ||
+      global.__SUI_CACHE_DISABLED__
+    ) {
+      return original
+    }
+
     const key = `${target.constructor.name}::${fnName}::${createHash(
       JSON.stringify(args)
     )}`

--- a/packages/sui-decorators/src/decorators/cache/index.js
+++ b/packages/sui-decorators/src/decorators/cache/index.js
@@ -35,7 +35,7 @@ const _cache = ({
   return (...args) => {
     if (
       (typeof window !== 'undefined' && window.__SUI_CACHE_DISABLED__) ||
-      global.__SUI_CACHE_DISABLED__
+      (typeof global !== 'undefined' && global.__SUI_CACHE_DISABLED__)
     ) {
       return original
     }


### PR DESCRIPTION
## Description
The decorator applies the cache always. In some cases we may need to disable this in certain environment such as testing. For this purpose, add a `__SUI_CACHE_DISABLED__` variable in global scope.

## Example
```
// For client side
window.__SUI_CACHE_DISABLED__ = true

// Server side
global.__SUI_CACHE_DISABLED__ = true
```
