### PR TITLE
fix(sui-widget-embedder): fix dev mode when page already has widgets on it

### DIFF
--- a/packages/sui-widget-embedder/compiler/development.js
+++ b/packages/sui-widget-embedder/compiler/development.js
@@ -12,7 +12,7 @@ module.exports = ({address, page, port}) =>
       path: '/',
       publicPath: `http://${address}:${port}/`,
       filename: 'bundle.js',
-      jsonpFunction: `webpackJsonp-${page}`
+      jsonpFunction: `webpackJsonp-${page}-dev`
     },
     plugins: pipe(removePlugin('HtmlWebpackPlugin'))(devConfig.plugins)
   })


### PR DESCRIPTION
With this, we avoid the colision of the jsonpCallback that could be already on the page.