### PR TITLE
Feat/allow ssr redirections

### DIFF
--- a/packages/sui-react-initial-props/README.md
+++ b/packages/sui-react-initial-props/README.md
@@ -92,17 +92,29 @@ contextFactory(
 universal - react page component
 
 const Placeholder = () => <h1>Loading...</h1>
-const Page = (props) => (
-  <div>
-    <h1>This is the page</h1>
-    <p>{props.initialContent}</p>
-  </div>
-)
+const Page = (props) => {
+  useEffect(()=> {
+    // If defined previously as seen below, access __HTTP__ object as follows:
+    const {initialContent, __HTTP__} = props
+    const {redirectTo} = __HTTP__
+    window.location.href = redirectTo
+  })
+
+  return (
+    <div>
+      <h1>This is the page</h1>
+      <p>{initialContent}</p>
+    </div>
+  )
+}
+
 
 Page.renderLoading = () => <Placeholder />
 Page.getInitialProps = ({ context, routeInfo }) =>
   Promise.resolve({
-    initialContent: 'This is the initial content'
+    initialContent: 'This is the initial content',
+    // Optional __HTTP__ object to perform 301 Redirects
+    __HTTP__: {redirectTo: 'https://<301 Redirect Route>'}
   })
 ```
 
@@ -161,11 +173,12 @@ renderProps | `object` | Props used by React Router with some useful info. We're
 
 ##### Response
 
-The response is a promise resolved with two parameters.
+The response is a promise resolved with two parameters. In addition, you can define an optional `__HTTP__` object in `initialProps` to allow server side redirects using SUI-SSR:
 
 Field | Type | Description
 --- | --- | ---
 initialProps | `object` | Result of executing the `getInitialProps` of the pageComponent.
+initialprops.__HTTP__ | `object` | An optional object containing a `redirectTo` key where an url might be included to allow 301 server side redirects using [sui-ssr](https://github.com/SUI-Components/sui/tree/master/packages/sui-ssr). 
 reactString | `string` | String with the renderized app ready to be sent.
 
 #### loadPage(contextFactory, importPage)

--- a/packages/sui-ssr/README.md
+++ b/packages/sui-ssr/README.md
@@ -4,7 +4,7 @@
 
 SSR can be tought to configure and maintain. SSR handles that for you providing:
 
-- SSRaS Server-Side Rendering as a Service
+- SSRaaS Server-Side Rendering as a Service
 - Server improvements shared accross projects
 
 ## Installation
@@ -235,6 +235,11 @@ SOME_OTHER_ENV_VAR: https://pre.somedomain.com/contact
 - Whatever you add in this file will be available in your context factory as `appConfig.envs` param.
 - This file must not contain secrets as it is meant to be available in both server and client side.
 - :warning: And of course, this file is not meant to be versioned.
+
+## Server Side Redirects
+
+SUI-SSR allows 301 redirects in server side rendering when combined with SUI-REACT-INITIAL-PROPS.
+Check out its [documentation](https://github.com/SUI-Components/sui/tree/master/packages/sui-react-initial-props#response-2) to get detailed information and an implementation example.
 
 ## Use the ssr in a lambda function
 

--- a/packages/sui-ssr/server/ssr/index.js
+++ b/packages/sui-ssr/server/ssr/index.js
@@ -115,6 +115,14 @@ export default (req, res, next) => {
 
       const {initialProps, reactString, performance} = initialData
 
+      const {__HTTP__} = initialProps
+      if (__HTTP__) {
+        const {redirectTo} = __HTTP__
+        if (redirectTo) {
+          return res.redirect(HTTP_PERMANENT_REDIRECT, __HTTP__.redirectTo)
+        }
+      }
+
       // The first html content has the be set after any possible call to next().
       // Otherwise some undesired/duplicated html could be attached to the error pages if an error occurs
       // no matter the error page strategy set (loadSPAOnNotFound: true|false)


### PR DESCRIPTION
## Allow SUI-SSR server-side 301 redirects
This PR addresses optional server-side redirections when combined with `SUI-REACT-INITIAL-PROPS`

### Description
This PR has a proposal of including a new `__HTTP__` object inside current `initialProps` to allow server-side redirects. If this object exists, Express will look for a URL defined in a key `__HTTP__.redirectTo` and will perform a `redirect` using its own method.

### Example
This is an implementation example of how to do a redirect using `getInitialPRops`:

```javascript

MyComponent.getInitialProps = async ({context: {domain}}) => {
 const [error, response] = await domain
   .get('get_redirection_url_use_case')
    .execute()

    return {
       error: error && error),
       __HTTP__: {redirectTo: response.url}
    }
}
```
