### PR TITLE
Fix/do-not-redirect-after-flush

### DIFF
--- a/packages/sui-ssr/server/ssr/index.js
+++ b/packages/sui-ssr/server/ssr/index.js
@@ -108,19 +108,22 @@ export default (req, res, next) => {
         return next(err)
       }
 
-      // Flush now if early-flush is disabled
-      if (!req.app.locals.earlyFlush) {
-        initialFlush(res)
-      }
-
       const {initialProps, reactString, performance} = initialData
+
+      // The __HTTP__ object is created before earlyFlush is applied
+      // to avoid unspected behaviors
 
       const {__HTTP__} = initialProps
       if (__HTTP__) {
         const {redirectTo} = __HTTP__
         if (redirectTo) {
-          return res.redirect(HTTP_PERMANENT_REDIRECT, __HTTP__.redirectTo)
+          return res.redirect(HTTP_PERMANENT_REDIRECT, redirectTo)
         }
+      }
+
+      // Flush now if early-flush is disabled
+      if (!req.app.locals.earlyFlush) {
+        initialFlush(res)
       }
 
       // The first html content has the be set after any possible call to next().

--- a/packages/sui-ssr/server/ssr/index.js
+++ b/packages/sui-ssr/server/ssr/index.js
@@ -111,7 +111,7 @@ export default (req, res, next) => {
       const {initialProps, reactString, performance} = initialData
 
       // The __HTTP__ object is created before earlyFlush is applied
-      // to avoid unspected behaviors
+      // to avoid unexpected behaviors
 
       const {__HTTP__} = initialProps
       if (__HTTP__) {


### PR DESCRIPTION
## Description
This PR is just a fix to avoid calling `initialFlush()` _before_ `res.redirect()`.
We don't want to send a 200 response and change it right away to a 301.

Thanks, @midudev for pointing that out in the middle of the night 😄 

### References
Please, check out this [previously closed](https://github.com/SUI-Components/sui/pull/668) PR in order to get more context.

