### PR TITLE
feat(sui-studio-utils): adds compatibility with inlineError

### DIFF
--- a/packages/sui-studio-utils/src/domain-builder/index.js
+++ b/packages/sui-studio-utils/src/domain-builder/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 export default class DomainBuilder {
   static extend({domain = {}}) {
     return new DomainBuilder({domain})
@@ -59,18 +58,24 @@ export default class DomainBuilder {
         data !== undefined ? {err: null, data} : {err: fail, data: null}
 
       const createResponse = ({err, data}) => {
-        const {resolve, reject} = Promise
-        if (inlineError) return resolve([err, data])
-
-        return err ? reject(err) : resolve(data)
+        if (inlineError) return Promise.resolve([err, data])
+        return err ? Promise.reject(err) : Promise.resolve(data)
       }
       return createResponse(responseParams)
     }
 
+    const buildGet = useCase => {
+      if (useCase === 'config') {
+        return this._config
+      }
+      if (self._useCases[useCase]) {
+        return {execute: exeUseCase(useCase)}
+      }
+      return self._domain.get(useCase)
+    }
+
     return {
-      get: useCase => ({
-        execute: exeUseCase(useCase)
-      }),
+      get: buildGet,
       _map: Object.assign(self._domain._map || {}, self._useCases),
       useCases: Object.assign(self._domain.useCases || {}, self._useCases)
     }

--- a/packages/sui-studio-utils/src/domain-builder/index.js
+++ b/packages/sui-studio-utils/src/domain-builder/index.js
@@ -72,7 +72,7 @@ export default class DomainBuilder {
                         ? [null, successResponse]
                         : successResponse
                     )
-                  : Promise.reject(
+                  : Promise.resolve(
                       inlineError
                         ? [self._useCases[useCase].fail, null]
                         : self._useCases[useCase].fail

--- a/packages/sui-studio-utils/src/domain-builder/index.js
+++ b/packages/sui-studio-utils/src/domain-builder/index.js
@@ -4,7 +4,6 @@ export default class DomainBuilder {
     return new DomainBuilder({domain})
   }
 
-  // @ts-ignore
   constructor({domain} = {}) {
     this._domain = domain
     this._useCase = false
@@ -12,7 +11,6 @@ export default class DomainBuilder {
     this._useCases = {}
   }
 
-  // @ts-ignore
   for({useCase} = {}) {
     if (this._useCase) {
       throw new Error(
@@ -25,7 +23,6 @@ export default class DomainBuilder {
     return this
   }
 
-  // @ts-ignore
   respondWith({success, fail} = {}) {
     if (success !== undefined && fail !== undefined) {
       throw new Error(


### PR DESCRIPTION
## Description
Currently, Domain useCases using the [@inlineError](https://github.com/SUI-Components/sui/blob/master/packages/sui-decorators/src/decorators/error.js#L6) decorator are not supported by `DomainBuilder` to override responses when Demoing components.

This PR adds compatibility so we'll be able to use both: Domain useCases using the pattern `[error, response]` and `response` only.

- [x] Refactored nested ternaries to improve readability. 
Thanks to @midudev and @zecafa for your help 😍 

## Example
Let's say I want to build a Demo for some component using the current logged `userId`. We can simulate a `get_current_user_use_case` response via DomainBuilder:

```javascript
domain: DomainBuilder.extend({domain: new Milanuncios()})
   .for({useCase: 'get_current_user_use_case'})
   .respondWith({
        success: {id: 179587252}
})
```
So far, DomainBuilder was not taking into account possible useCase decorated responses with `@inlineError` so we were unable to use this feature. This PR fixes this scenario.
