### PR TITLE
feat(sui-js): add getRandomString function

### DIFF
--- a/packages/sui-js/README.md
+++ b/packages/sui-js/README.md
@@ -104,6 +104,14 @@ console.log(fromArrayToCommaQueryString({userId: 1, adId: 2, products: [3, 4, 5]
 import {htmlStringToReactElement} from '@s-ui/js/lib/string'
 
 htmlStringToReactElement('<p>No more dangerouslySetInnerHTML</p>')
+
+
+import {getRandomString} from '@s-ui/js/lib/string'
+
+const randomStringLength = 6
+const randomString = getRandomString(randomStringLength)
+console.log(randomString.length) // log = 6 || 15 by default
+console.log(randomString) // qwerty
 ```
 
 ## ua-parser

--- a/packages/sui-js/src/string/index.js
+++ b/packages/sui-js/src/string/index.js
@@ -11,3 +11,5 @@ export {has as hasAccents, remove as removeAccents} from 'remove-accents'
 export {default as toCamelCase} from 'lodash.camelcase'
 export {default as toCapitalCase} from 'lodash.capitalize'
 export {default as toKebabCase} from 'lodash.kebabcase'
+
+export {getRandomString} from './random-string'

--- a/packages/sui-js/src/string/random-string.js
+++ b/packages/sui-js/src/string/random-string.js
@@ -1,0 +1,7 @@
+const DEFAULT_LENGTH = 15
+
+export const getRandomString = (length = DEFAULT_LENGTH) =>
+  [...Array(length)]
+    .fill()
+    .map(_ => ((Math.random() * 36) | 0).toString(36))
+    .join('')

--- a/packages/sui-js/test/stringSpec.js
+++ b/packages/sui-js/test/stringSpec.js
@@ -3,7 +3,8 @@ import {expect} from 'chai'
 import {
   parseQueryString,
   toQueryString,
-  fromArrayToCommaQueryString
+  fromArrayToCommaQueryString,
+  getRandomString
 } from '../src/string/index'
 
 describe('@s-ui/js', () => {
@@ -26,6 +27,13 @@ describe('@s-ui/js', () => {
       const paramsArray = {a: 1, b: 2, c: [3, 4]}
       const params = 'a=1&b=2&c=3,4'
       expect(fromArrayToCommaQueryString(paramsArray)).to.deep.equal(params)
+    })
+  })
+  describe('string:getRandomString', () => {
+    it('should get a random string', () => {
+      const randomString = getRandomString()
+      expect(randomString).to.be.an('string')
+      expect(randomString).to.have.lengthOf(15)
     })
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add getRandomString in sui-js in order to have the possibility to create random strings with a defined length

## Example
https://github.com/SUI-Components/sui/pull/703/files#diff-e231c378ec264fa0c1d2439f65a9d2afR109

```
import {getRandomString} from '@s-ui/js/lib/string'

const randomStringLength = 6
const randomString = getRandomString(randomStringLength)

console.log(randomString.length) // log = 6 || 15 by default
console.log(randomString) // qwerty
```
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
