### PR TITLE
feat(sui-bundler): remove terser pinned  version

### DIFF
--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -54,7 +54,6 @@
     "script-ext-html-webpack-plugin": "2.1.4",
     "source-map-loader": "0.2.4",
     "style-loader": "1.0.0",
-    "terser": "4.4.0",
     "terser-webpack-plugin": "2.2.1",
     "thread-loader": "2.1.3",
     "update-check": "1.5.3",


### PR DESCRIPTION
Remove terser pinned version needed for the bug caused on 4.4.1. 4.4.2 is already published and working as expected.