### PR TITLE
Feat/sui mono upgrade dependencies

### DIFF
--- a/packages/sui-mono/bin/sui-mono-commit.js
+++ b/packages/sui-mono/bin/sui-mono-commit.js
@@ -5,7 +5,8 @@ const bootstrap = require('commitizen/dist/cli/git-cz').bootstrap
 
 /**
  * Get the list of modified files by the user
- * @param {boolean} checkIfStaged Determine if we should change if the modified file is staged
+ * @param {object}  params
+ * @param {boolean} params.checkIfStaged Determine if we should change if the modified file is staged
  */
 function getDiffedFiles({checkIfStaged = false} = {}) {
   return new Promise((resolve, reject) => {

--- a/packages/sui-mono/package.json
+++ b/packages/sui-mono/package.json
@@ -17,12 +17,12 @@
   "dependencies": {
     "@s-ui/cz": "1",
     "@s-ui/helpers": "1",
-    "colors": "1.3.0",
-    "commander": "2.9.0",
-    "commitizen": "2.10.1",
-    "conventional-changelog": "1.1.0",
-    "listr": "0.14.1",
-    "rimraf": "2.6.2"
+    "colors": "1.4.0",
+    "commander": "4.0.1",
+    "commitizen": "4.0.3",
+    "conventional-changelog": "3.1.18",
+    "listr": "0.14.3",
+    "rimraf": "3.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Upgrade sui-mono dependencies in order to fix problems with spawn-sync sub-dependency:
![image](https://user-images.githubusercontent.com/1561955/70902562-6763c480-1ffd-11ea-9b2c-405c57635122.png)

Besides removing deprecated spawn-sync dependency, new versions are dropping node older version support along with some bugfixing. No other breaking change detected or noted on changelog, and tested with some of our projects everything seems to be working as expected.
