### PR TITLE
feat(sui-ssr): allow sending custom headers to critical css service

### DIFF
--- a/packages/sui-ssr/README.md
+++ b/packages/sui-ssr/README.md
@@ -193,9 +193,10 @@ Configs accepted:
 
 - **`criticalCSS`** (`false`): If you setup this flag to true, you will get this awesome feature for free. More about Critical CSS [here](https://www.smashingmagazine.com/2015/08/understanding-critical-css/). You have the posibility of setup several config for fine tuning of this feature.
 
-  - **`criticalCSS.protocol`** (`undefined`): Define the protocol used to make the request to the micriservice for generate the CriticalCSS
-  - **`criticalCSS.host`** (`undefined`): Define the HOST used to make the request to the micriservice for generate the CriticalCSS
-  - **`criticalCSS.blackListURLs`** (`undefined`): Array of RegEx of urls. If some of this URLs match with the current page url. this feature will be disabled for the page. That is usefull the enabled CriticalCSS in your site but not in one or two pages.
+  - **`criticalCSS.protocol`** (`undefined`): Define the protocol used to make the request to the microservice for generating the Critical CSS.
+  - **`criticalCSS.host`** (`undefined`): Define the HOST used to make the request to the microservice for generating the Critical CSS.
+  - **`criticalCSS.blackListURLs`** (`undefined`): Array of RegEx of URLs. If some of these URLs match with the current page URL, this feature will be disabled for that page. This is useful to enable CriticalCSS in your site just for a few pages.
+  - **`criticalCSS.customHeaders`** (`undefined`): Object containing all the custom headers you want to send to the Critical CSS service in order to make it work without any limitation or regarding any requirement your target URL needs.
 
 - **`dynamicsURLS`** (`[]`): Array of allowed urls in order to make them be rendered dynamically based on the Dynamic Rendering guidelines by Google: https://developers.google.com/search/docs/guides/dynamic-rendering
 

--- a/packages/sui-ssr/server/criticalCss/index.js
+++ b/packages/sui-ssr/server/criticalCss/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import routes from 'routes'
 import {match} from 'react-router'
 import https from 'https'
@@ -13,6 +14,8 @@ const generateMinimalCSSHash = routes => {
     return acc
   }, '')
 }
+
+const logMessage = message => NODE_ENV !== PRODUCTION && console.log(message)
 
 export default criticalCSS => (req, res, next) => {
   if (!criticalCSS || process.env.DISABLE_CRITICAL_CSS === 'true') {
@@ -62,28 +65,23 @@ export default criticalCSS => (req, res, next) => {
       const criticalCSS = __CACHE__[hash]
 
       if (!criticalCSS) {
-        NODE_ENV !== PRODUCTION &&
-          console.log(
-            'Generation Critical CSS for -> ',
-            urlRequest,
-            'with hash: ',
-            hash
-          )
+        logMessage(`Generation Critical CSS for -> ${urlRequest} with ${hash}`)
 
         const serviceRequestURL = `https://critical-css-service.now.sh/${device}/${urlRequest}`
-        https.get(serviceRequestURL, res => {
+        const headers = criticalCSS.customHeaders
+
+        https.get(serviceRequestURL, {...headers}, res => {
           let css = ''
           if (res.statusCode !== 200) {
-            NODE_ENV !== PRODUCTION &&
-              console.log('No 200 request, statusCode:', res.statusCode)
+            logMessage(`No 200 request, statusCode: ${res.statusCode}`)
+
             return
           }
           res.on('data', data => {
             css += data
           })
           res.on('end', () => {
-            NODE_ENV !== PRODUCTION &&
-              console.log(`Add cache entry for ${hash}`)
+            logMessage(`Add cache entry for ${hash}`)
             __CACHE__[hash] = css
           })
         })


### PR DESCRIPTION
This feature allows to set an object containing all the custom headers you want to send to the Critical CSS service in order to make it work without any limitation or regarding any requirement your target URL needs.