### PR TITLE
Feat/add ci flag

### DIFF
--- a/packages/sui-mono/bin/sui-mono-phoenix.js
+++ b/packages/sui-mono/bin/sui-mono-phoenix.js
@@ -122,7 +122,7 @@ const executePhoenixOnPackages = () => {
     queue
       .add(() => installPackages({cwd}))
       .then(() => {
-        if (progress) {
+        if (progress && !ci) {
           const {size, pending} = queue
           logUpdate(
             `${figures.play} ${packageName}: ${size + pending} of ${

--- a/packages/sui-mono/bin/sui-mono-phoenix.js
+++ b/packages/sui-mono/bin/sui-mono-phoenix.js
@@ -22,7 +22,6 @@ const CI_FLAGS = [
   'ignore-scripts',
   'loglevel=error',
   'no-audit',
-  'no-bin-links',
   'no-fund',
   'no-optional',
   'no-package-lock',

--- a/packages/sui-mono/bin/sui-mono-phoenix.js
+++ b/packages/sui-mono/bin/sui-mono-phoenix.js
@@ -19,7 +19,6 @@ const DEFAULT_CHUNK = 5
 const SINGLE_CHUNK = 1
 
 const CI_FLAGS = [
-  'ignore-scripts',
   'loglevel=error',
   'no-audit',
   'no-fund',

--- a/packages/sui-mono/bin/sui-mono-phoenix.js
+++ b/packages/sui-mono/bin/sui-mono-phoenix.js
@@ -6,17 +6,43 @@ const figures = require('figures')
 const {basename} = require('path')
 const {default: Queue} = require('p-queue')
 const logUpdate = require('log-update')
-
+const execa = require('execa')
 const config = require('../src/config')
-const {serialSpawn, showError} = require('@s-ui/helpers/cli')
 
 const DEFAULT_CHUNK = 5
+/** NOTE:
+ * Latest version of node & npm seems to have some concurrency problem
+ * when installing packages. In order to be sure the CI deployment work as expected,
+ * we're only installing one package at a time.
+ * Related issue: https://github.com/npm/cli/issues/496
+ */
+const SINGLE_CHUNK = 1
+
+const CI_FLAGS = [
+  'ignore-scripts',
+  'loglevel=error',
+  'no-audit',
+  'no-bin-links',
+  'no-fund',
+  'no-optional',
+  'no-package-lock',
+  'no-progress',
+  'no-save',
+  'no-shrinkwrap',
+  'prefer-offline',
+  'production'
+].map(flag => `--${flag}`)
 
 program
   .option(
     '-c, --chunk <number>',
     `Execute by chunks of N packages (defaults to ${DEFAULT_CHUNK})`
   )
+  .option(
+    '--ci',
+    'Optimized mode for CI. Avoid removing folders, showing progress, auditing, write package-lock files and more'
+  )
+  .option('--no-audit', 'Avoid auditing packages for better performance')
   .option(
     '--no-root',
     'Avoid executing the script on root folder in case you already did it'
@@ -25,7 +51,6 @@ program
     '--no-progress',
     'Force to not show progress of tasks (perfect for CI environments)'
   )
-  .option('--no-audit', 'Avoid auditing packages for better performance')
   .on('--help', () => {
     console.log(`
   Description:
@@ -39,36 +64,68 @@ program
   })
   .parse(process.argv)
 
-const {audit, chunk = DEFAULT_CHUNK, progress = true, root} = program
+const {
+  audit = true,
+  chunk = DEFAULT_CHUNK,
+  ci = false,
+  progress = true,
+  root = true
+} = program
 
-const NPM_CMD = ['npm', ['install', audit ? '--no-audit' : '']]
+const NPM_CMD = ['npm', ['install', audit ? '' : '--no-audit']]
 const RIMRAF_CMD = [
   require.resolve('rimraf/bin'),
   ['package-lock.json', 'node_modules']
 ]
-const rootExecution = root ? [RIMRAF_CMD, NPM_CMD] : []
 
-const queue = new Queue({concurrency: +chunk})
-
-const executePhoenixOnPackages = () => {
-  if (config.isMonoPackage()) {
-    return
+/**
+ * Execute needed commands to install packages
+ * @param {Object} params
+ * @param {string=} params.cwd
+ * @param {string=} params.stdin
+ */
+const installPackages = ({cwd = undefined, stdin = 'inherit'} = {}) => {
+  const executionParams = {cwd, stdin}
+  if (ci) {
+    const [npm] = NPM_CMD
+    return execute([npm, ['install', ...CI_FLAGS]], executionParams)
   }
 
+  return execute(RIMRAF_CMD, executionParams).then(() =>
+    execute(NPM_CMD, executionParams)
+  )
+}
+
+/**
+ * Execute command abstraction
+ * @param {Array<string | string[]>} cmd Array with the executable and the arguments to pass
+ * @param {object} params
+ * @param {string=} params.cwd
+ * @param {string=} params.stdin
+ */
+const execute = (cmd, {cwd, stdin}) => {
+  const [command, args] = cmd
+  return execa(command, args, {cwd, stdin, stderr: 'inherit'})
+}
+
+const concurrency = ci ? SINGLE_CHUNK : chunk
+const queue = new Queue({concurrency: ci ? SINGLE_CHUNK : chunk})
+console.log(`Using concurrency of: ${concurrency}`)
+
+const executePhoenixOnPackages = () => {
+  // if we're on a monorepo, then we don't have packages to install
+  if (config.isMonoPackage()) return
+
   const scopes = config.getScopesPaths()
+  logUpdate(`${figures.play} Preparing ${scopes.length} packages to install...`)
 
   scopes.map(cwd => {
-    const commands = [
-      [...RIMRAF_CMD, {cwd, stdio: 'ignore'}],
-      [...NPM_CMD, {cwd, stdio: 'ignore'}]
-    ]
-
+    const packageName = basename(cwd).grey
     queue
-      .add(() => serialSpawn(commands))
+      .add(() => installPackages({cwd}))
       .then(() => {
         if (progress) {
           const {size, pending} = queue
-          const packageName = basename(cwd).grey
           logUpdate(
             `${figures.play} ${packageName}: ${size + pending} of ${
               scopes.length
@@ -77,6 +134,7 @@ const executePhoenixOnPackages = () => {
         }
       })
       .catch(err => {
+        console.error(`Error installing ${packageName}:`)
         console.error(err)
       })
   })
@@ -86,6 +144,9 @@ const executePhoenixOnPackages = () => {
     .then(() => logUpdate(`${figures.tick} Installed all packages`))
 }
 
-serialSpawn(rootExecution)
+logUpdate(`${figures.play} Installing root packages...`)
+;(root ? installPackages({stdin: 'inherit'}) : Promise.resolve())
   .then(executePhoenixOnPackages)
-  .catch(showError)
+  .catch(error => {
+    console.error(error)
+  })

--- a/packages/sui-mono/package.json
+++ b/packages/sui-mono/package.json
@@ -21,6 +21,7 @@
     "commander": "4.0.1",
     "commitizen": "4.0.3",
     "conventional-changelog": "3.1.18",
+    "execa": "3.4.0",
     "figures": "3.1.0",
     "log-update": "3.3.0",
     "p-queue": "6.2.1",


### PR DESCRIPTION
‼️ Add `--ci` flag:

- Limit concurrency to one until the issue with npm is fixed: https://github.com/npm/cli/issues/496
- Use execa instead serialSpawn that's offering better performance and better error handling.
- Add a bunch of optimizations to `npm install`

This PR also is adding JSDoc Typescript complaint comments for better documentation.