### PR TITLE
fix(sui-ssr): send custom headers properly inside an options object

### DIFF
--- a/packages/sui-ssr/server/criticalCss/index.js
+++ b/packages/sui-ssr/server/criticalCss/index.js
@@ -65,8 +65,11 @@ export default config => (req, res, next) => {
 
         const serviceRequestURL = `https://critical-css-service.now.sh/${device}/${urlRequest}`
         const headers = config.customHeaders
+        const options = {
+          ...(headers && {headers})
+        }
 
-        https.get(serviceRequestURL, {...headers}, res => {
+        https.get(serviceRequestURL, options, res => {
           let css = ''
           if (res.statusCode !== 200) {
             logMessage(`No 200 request, statusCode: ${res.statusCode}`)


### PR DESCRIPTION
`headers` object wasn't sent properly inside the options object of the `https` request method 😭 