### PR TITLE
Use new context for react-initial-props package

### DIFF
--- a/packages/sui-react-initial-props/package.json
+++ b/packages/sui-react-initial-props/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/react-initial-props",
-  "version": "2.7.0",
+  "version": "2.7.1-beta.0",
   "main": "lib/index.js",
   "description": "Provide a way to get initial props for async pages",
   "scripts": {
@@ -16,10 +16,7 @@
   },
   "devDependencies": {
     "@s-ui/component-peer-dependencies": "1",
-    "@babel/cli": "7.2.3",
+    "@babel/cli": "7.7.7",
     "babel-preset-sui": "3"
-  },
-  "dependencies": {
-    "@s-ui/hoc": "1"
   }
 }

--- a/packages/sui-react-initial-props/package.json
+++ b/packages/sui-react-initial-props/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/react-initial-props",
-  "version": "2.7.1-beta.0",
+  "version": "2.7.0",
   "main": "lib/index.js",
   "description": "Provide a way to get initial props for async pages",
   "scripts": {

--- a/packages/sui-react-initial-props/src/createClientContextFactoryParams.js
+++ b/packages/sui-react-initial-props/src/createClientContextFactoryParams.js
@@ -1,9 +1,7 @@
-export default function createClientContextFactoryParams() {
-  return {
-    appConfig: window.__APP_CONFIG__,
-    cookies: document.cookie,
-    isClient: true,
-    pathName: window.location.pathname,
-    userAgent: window.navigator.userAgent
-  }
-}
+export default () => ({
+  appConfig: window.__APP_CONFIG__,
+  cookies: document.cookie,
+  isClient: true,
+  pathName: window.location.pathname,
+  userAgent: window.navigator.userAgent
+})

--- a/packages/sui-react-initial-props/src/createServerContextFactoryParams.js
+++ b/packages/sui-react-initial-props/src/createServerContextFactoryParams.js
@@ -1,12 +1,9 @@
-export default function createServerContextFactoryParams(req) {
-  // we export the request as well in order to allow some customized params
-  // for example, we might be using a req.uuid here for each request and want to use on the context
-  return {
-    appConfig: req.appConfig,
-    req,
-    cookies: req.headers.cookie,
-    isClient: false,
-    pathName: req.path, // that's a native Express path, we might consider use another one instead
-    userAgent: req.headers['user-agent']
-  }
-}
+export default req => ({
+  appConfig: req.appConfig,
+  req,
+  cookies: req.headers.cookie,
+  isClient: false,
+  // that's a native Express path, we might consider use another one instead
+  pathName: req.path,
+  userAgent: req.headers['user-agent']
+})

--- a/packages/sui-react-initial-props/src/index.js
+++ b/packages/sui-react-initial-props/src/index.js
@@ -1,10 +1,4 @@
-export {
-  default as createClientContextFactoryParams
-} from './createClientContextFactoryParams'
-export {
-  default as createServerContextFactoryParams
-} from './createServerContextFactoryParams'
+export {default as createClientContextFactoryParams} from './createClientContextFactoryParams'
+export {default as createServerContextFactoryParams} from './createServerContextFactoryParams'
 export {default as loadPage} from './loadPage'
-export {
-  default as ssrComponentWithInitialProps
-} from './ssrComponentWithInitialProps'
+export {default as ssrComponentWithInitialProps} from './ssrComponentWithInitialProps'

--- a/packages/sui-react-initial-props/src/initialPropsContext.js
+++ b/packages/sui-react-initial-props/src/initialPropsContext.js
@@ -1,0 +1,3 @@
+import React from 'react'
+
+export default React.createContext({initialProps: {}})

--- a/packages/sui-react-initial-props/src/loadPage.js
+++ b/packages/sui-react-initial-props/src/loadPage.js
@@ -1,10 +1,11 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-
+import React, {useContext} from 'react'
+import InitialPropsContext from './initialPropsContext'
 import withInitialProps from './withInitialProps'
 import createClientContextFactoryParams from './createClientContextFactoryParams'
 
 const EMPTY_GET_INITIAL_PROPS = () => Promise.resolve({})
+
+console.log('new')
 
 const createUniversalPage = (contextFactory, routeInfo) => ({
   default: Page
@@ -33,12 +34,14 @@ const createUniversalPage = (contextFactory, routeInfo) => ({
         .then(context => withInitialProps({context, routeInfo})(Page))
     )
   }
-  // we're in the server, so return just the component and pass the initialProps from the context
-  const ServerPage = (props, {initialProps = {}}) => (
-    <Page {...props} {...initialProps} />
-  )
-  // recover the initialProps if in the server we have retrieved them
-  ServerPage.contextTypes = {initialProps: PropTypes.object}
+  // we're in the server: Create a component that gets the initialProps from context
+  // this context has been created on the `ssrWithComponentWithInitialProps`
+  const ServerPage = props => {
+    const {initialProps} = useContext(InitialPropsContext)
+    console.log({initialProps})
+    return <Page {...props} {...initialProps} />
+  }
+  console.log('created server page')
   // recover the displayName from the original page
   ServerPage.displayName = Page.displayName
   // detect if the page has getInitialProps and wrap it with the routeInfo

--- a/packages/sui-react-initial-props/src/loadPage.js
+++ b/packages/sui-react-initial-props/src/loadPage.js
@@ -5,8 +5,6 @@ import createClientContextFactoryParams from './createClientContextFactoryParams
 
 const EMPTY_GET_INITIAL_PROPS = () => Promise.resolve({})
 
-console.log('new')
-
 const createUniversalPage = (contextFactory, routeInfo) => ({
   default: Page
 }) => {
@@ -22,7 +20,7 @@ const createUniversalPage = (contextFactory, routeInfo) => ({
       // make a copy of the content safely
       const initialProps = {...window.__INITIAL_PROPS__}
       // remove the variable of the window before returning the component
-      delete window.__INITIAL_PROPS__
+      window.__INITIAL_PROPS__ = undefined
       // resolve the promise with the initialProps passed to the client
       return Promise.resolve(props => <Page {...initialProps} {...props} />)
     }
@@ -38,10 +36,8 @@ const createUniversalPage = (contextFactory, routeInfo) => ({
   // this context has been created on the `ssrWithComponentWithInitialProps`
   const ServerPage = props => {
     const {initialProps} = useContext(InitialPropsContext)
-    console.log({initialProps})
     return <Page {...props} {...initialProps} />
   }
-  console.log('created server page')
   // recover the displayName from the original page
   ServerPage.displayName = Page.displayName
   // detect if the page has getInitialProps and wrap it with the routeInfo

--- a/packages/sui-react-initial-props/src/ssrComponentWithInitialProps.js
+++ b/packages/sui-react-initial-props/src/ssrComponentWithInitialProps.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOMServer from 'react-dom/server'
-import withContext from '@s-ui/hoc/lib/withContext'
+import InitialPropsContext from './initialPropsContext'
 
 const EMPTY_FUNC = () => Promise.resolve({})
 
@@ -20,34 +20,30 @@ export default function ssrComponentWithInitialProps({
   const getInitialProps = pageComponent.getInitialProps || EMPTY_FUNC
   return getInitialProps(context).then(initialProps => {
     const diffGetInitialProps = process.hrtime(startGetInitialProps)
-    // create the App component with the context, the initialProps and the Target Component
-    const App = withContext({...context, initialProps})(Target)
-    if (useStream) {
-      const reactStream = ReactDOMServer.renderToNodeStream(
-        <App {...renderProps} initialProps={initialProps} />
-      )
-      return {
-        initialProps,
-        reactStream,
-        performance: {
-          getInitialProps: hrTimeToMs(diffGetInitialProps)
-        }
-      }
-    } else {
-      // start to calculate renderToString
-      const startRenderToString = process.hrtime()
-      // render our whole application with the needed props and get the html string
-      const reactString = ReactDOMServer.renderToString(
-        <App {...renderProps} initialProps={initialProps} />
-      )
-      const diffRenderToString = process.hrtime(startRenderToString)
-      return {
-        initialProps,
-        reactString,
-        performance: {
-          getInitialProps: hrTimeToMs(diffGetInitialProps),
-          renderToString: hrTimeToMs(diffRenderToString)
-        }
+    console.log({initialProps})
+    // Create App with Context with the initialProps
+    const AppWithContext = (
+      <InitialPropsContext.Provider value={{initialProps}}>
+        <Target {...renderProps} initialProps={initialProps} />
+      </InitialPropsContext.Provider>
+    )
+    // use a different action and response key depending if we're using streaming
+    const [renderAction, renderResponseKey] = useStream
+      ? [ReactDOMServer.renderToNodeStream, 'reactStream']
+      : [ReactDOMServer.renderToString, 'reactString']
+    // start to calculate renderToString
+    const startRenderToString = process.hrtime()
+    // render with the needed action
+    const renderResponse = {[renderResponseKey]: renderAction(AppWithContext)}
+    // calculate the difference of time used rendering
+    const diffRenderToString = process.hrtime(startRenderToString)
+    // return all the info
+    return {
+      ...renderResponse,
+      initialProps,
+      performance: {
+        getInitialProps: hrTimeToMs(diffGetInitialProps),
+        renderToString: hrTimeToMs(diffRenderToString)
       }
     }
   })

--- a/packages/sui-react-initial-props/src/ssrComponentWithInitialProps.js
+++ b/packages/sui-react-initial-props/src/ssrComponentWithInitialProps.js
@@ -1,8 +1,6 @@
 import React from 'react'
-import ReactDOMServer from 'react-dom/server'
+import {renderToNodeStream, renderToString} from 'react-dom/server'
 import InitialPropsContext from './initialPropsContext'
-
-const EMPTY_FUNC = () => Promise.resolve({})
 
 const hrTimeToMs = diff => diff[0] * 1e3 + diff[1] * 1e-6
 
@@ -17,10 +15,9 @@ export default function ssrComponentWithInitialProps({
   const pageComponent =
     renderProps.components[renderProps.components.length - 1]
   // use the getInitialProps from the page to retrieve the props to initialize
-  const getInitialProps = pageComponent.getInitialProps || EMPTY_FUNC
+  const getInitialProps = pageComponent.getInitialProps
   return getInitialProps(context).then(initialProps => {
     const diffGetInitialProps = process.hrtime(startGetInitialProps)
-    console.log({initialProps})
     // Create App with Context with the initialProps
     const AppWithContext = (
       <InitialPropsContext.Provider value={{initialProps}}>
@@ -29,8 +26,8 @@ export default function ssrComponentWithInitialProps({
     )
     // use a different action and response key depending if we're using streaming
     const [renderAction, renderResponseKey] = useStream
-      ? [ReactDOMServer.renderToNodeStream, 'reactStream']
-      : [ReactDOMServer.renderToString, 'reactString']
+      ? [renderToNodeStream, 'reactStream']
+      : [renderToString, 'reactString']
     // start to calculate renderToString
     const startRenderToString = process.hrtime()
     // render with the needed action

--- a/packages/sui-react-initial-props/src/withInitialProps.js
+++ b/packages/sui-react-initial-props/src/withInitialProps.js
@@ -19,7 +19,7 @@ export default ({context, routeInfo}) => Page => {
         .catch(error => {
           setState({initialProps: {error}, isLoading: false})
         })
-    })
+    }, [])
 
     const renderLoading = () => {
       // check if the page has a renderLoading method, if not, just render nothing

--- a/packages/sui-react-initial-props/src/withInitialProps.js
+++ b/packages/sui-react-initial-props/src/withInitialProps.js
@@ -1,38 +1,35 @@
-import React, {Component} from 'react'
+import React, {useEffect, useState} from 'react'
 
 // This HoC creates the PageComponent prepared for the Client Side Rendering
 // It renders a placeholder, if any specified as `renderLoading` on the PageComponent
 // Also, executes the getInitialProps to retrieve the initialProps and then
 // Renders the component with the initialProps, hiding the placeholder
-export default ({context, routeInfo}) => Page =>
-  class ClientPage extends Component {
-    static displayName = `ClientPage(${Page.displayName})`
+export default ({context, routeInfo}) => Page => {
+  const ClientPage = props => {
+    const [{initialProps, isLoading}, setState] = useState({
+      initialProps: {},
+      isLoading: false
+    })
 
-    state = {initialProps: {}, isLoading: true}
+    useEffect(function() {
+      Page.getInitialProps({context, routeInfo})
+        .then(initialProps => {
+          setState({initialProps, isLoading: false})
+        })
+        .catch(error => {
+          setState({initialProps: {error}, isLoading: false})
+        })
+    })
 
-    _renderLoading() {
+    const renderLoading = () => {
       // check if the page has a renderLoading method, if not, just render nothing
       return Page.renderLoading ? Page.renderLoading() : null
     }
 
-    componentDidMount() {
-      // get the initialProps by executing the provided method on the page
-      // when got the results, update the state to re-render the page hiding the placeholder
-      Page.getInitialProps({context, routeInfo})
-        .then(initialProps => {
-          this.setState({initialProps, isLoading: false})
-        })
-        .catch(err => {
-          // pass error as prop
-          this.setState({initialProps: {error: err}, isLoading: false})
-        })
-    }
-
-    render() {
-      return this.state.isLoading ? (
-        this._renderLoading()
-      ) : (
-        <Page {...this.state.initialProps} {...this.props} />
-      )
-    }
+    return isLoading ? renderLoading() : <Page {...initialProps} {...props} />
   }
+  // add ClientPage to name of the component
+  ClientPage.displayName = `ClientPage(${Page.displayName})`
+  // return the page
+  return ClientPage
+}

--- a/packages/sui-react-initial-props/src/withInitialProps.js
+++ b/packages/sui-react-initial-props/src/withInitialProps.js
@@ -8,7 +8,7 @@ export default ({context, routeInfo}) => Page => {
   const ClientPage = props => {
     const [{initialProps, isLoading}, setState] = useState({
       initialProps: {},
-      isLoading: false
+      isLoading: true
     })
 
     useEffect(function() {


### PR DESCRIPTION
**react-initial-props** package:

- **Remove usage of old context API** and use the new one instead.
- Use `undefined` instead `delete` in order to keep JS compiler optimizations.
- Avoid repeating code.
- Move ClientPage from class to function using new hooks.
