### PR TITLE
fix(sui-mono): program options are strings, force chunk as number bef…

### DIFF
--- a/packages/sui-mono/bin/sui-mono-phoenix.js
+++ b/packages/sui-mono/bin/sui-mono-phoenix.js
@@ -106,8 +106,8 @@ const execute = (cmd, {cwd, stdin}) => {
   return execa(command, args, {cwd, stdin, stderr: 'inherit'})
 }
 
-const concurrency = ci ? SINGLE_CHUNK : chunk
-const queue = new Queue({concurrency: ci ? SINGLE_CHUNK : chunk})
+const concurrency = ci ? SINGLE_CHUNK : Number(chunk)
+const queue = new Queue({concurrency})
 console.log(`Using concurrency of: ${concurrency}`)
 
 const executePhoenixOnPackages = () => {


### PR DESCRIPTION
…ore execute p-queue command

<!--- Provide a general summary of your changes in the Title above -->

## Description
`p-queue` package requires a concurrency type as Number:
https://github.com/sindresorhus/p-queue/blob/master/source/index.ts#L218

We have defined to pass the command option as `-c, --chunk <number>` but really when nodejs took this from program it is a string type. We need to force it as a Number in order to make it works as expected

## Related Issue
https://travis.mpi-internal.com/scmspain/frontend-mt--uilib-components/builds/1038172
![image](https://user-images.githubusercontent.com/5390428/71668656-16c4c900-2d6a-11ea-9cc2-02da4686f974.png)

In this line we removed the number "force" `+chunk`. I force it again using `Number()` in order to make it more visible =)
https://github.com/SUI-Components/sui/commit/cc2252e84cbd3b8191320b66a40a9f78e0c9664b#diff-97ff545887f3acf269dedb8f9c14e519L51
