### PR TITLE
feat(sui-mockmock): add patch method to sui-mockmock

### DIFF
--- a/packages/sui-mockmock/src/http/clientMocker.js
+++ b/packages/sui-mockmock/src/http/clientMocker.js
@@ -57,6 +57,13 @@ class ClientMock extends Mock {
     return this
   }
 
+  patch(path) {
+    this._method = 'PATCH'
+    this._path = path
+
+    return this
+  }
+
   post(path) {
     this._method = 'POST'
     this._path = path

--- a/packages/sui-mockmock/src/http/mockerInterface.js
+++ b/packages/sui-mockmock/src/http/mockerInterface.js
@@ -4,6 +4,7 @@
 class Mock {
   get(path) {}
   getRegexp(path) {}
+  patch(path) {}
   post(path) {}
   query(queryObject) {}
   reply(response, statusCode) {}

--- a/packages/sui-mockmock/src/http/serverMocker.js
+++ b/packages/sui-mockmock/src/http/serverMocker.js
@@ -31,6 +31,13 @@ class ServerMock extends Mock {
     return this
   }
 
+  patch(path) {
+    this._method = 'patch'
+    this._path = path
+
+    return this
+  }
+
   post(path) {
     this._method = 'post'
     this._path = path

--- a/packages/sui-mockmock/test/mockerSpec.js
+++ b/packages/sui-mockmock/test/mockerSpec.js
@@ -47,5 +47,21 @@ describe('#ClientMocker', () => {
         })
       })
     })
+
+    describe('when mocking with PATCH method', () => {
+      beforeEach(() => {
+        mocker
+          .httpMock(fakeUrl)
+          .patch(fakePath)
+          .reply({})
+      })
+
+      it('should resolve statusCode 200', done => {
+        axios.patch(`${fakeUrl}${fakePath}`).then(({status}) => {
+          expect(status).to.be.eq(200)
+          done()
+        })
+      })
+    })
   })
 })


### PR DESCRIPTION
## Description
Just add `PATCH` as a new method to mock in our tests.

## Example
```
const mocker = new Mocker()

mocker
        .httpMock(_API_BASE_URL)
        .patch(
          `${_API_UPDATE_VEHICLE_URL}?vehicleId=${VEHICLE_ID}`
        )
        .reply(updateUserVehicleUseCaseApiResponse, 200)
```