### PR TITLE
feat(sui-test): add record flag

### DIFF
--- a/packages/sui-test/bin/sui-test-e2e.js
+++ b/packages/sui-test/bin/sui-test-e2e.js
@@ -49,7 +49,7 @@ program
   .option('-G, --gui', 'Run the tests in GUI mode.')
   .option('-R, --record', 'Record tests and send result to Dashboard Service')
   .option(
-    '-K, --key',
+    '-K, --key <key>',
     'It is used to authenticate the project into the Dashboard Service'
   )
   .on('--help', () => console.log(HELP_MESSAGE))
@@ -62,7 +62,8 @@ const {
   gui,
   screenshotsOnError,
   scope,
-  record
+  record,
+  key
 } = program
 const cypressConfig = {
   integrationFolder: path.join(TESTS_FOLDER, scope || ''),
@@ -91,7 +92,8 @@ resolveLazyNPMBin('cypress/bin/cypress', `cypress@${CYPRESS_VERSION}`)
       gui ? 'open' : 'run',
       '--config=' + objectToCommaString(cypressConfig),
       '--project=' + CYPRESS_FOLDER_PATH,
-      record && '--record'
+      record && '--record',
+      key && '--key=' + key
     ])
   )
   .catch(showError)

--- a/packages/sui-test/bin/sui-test-e2e.js
+++ b/packages/sui-test/bin/sui-test-e2e.js
@@ -47,7 +47,11 @@ program
   )
   .option('-s, --scope <spec>', 'Run tests specifying a subfolder of specs')
   .option('-G, --gui', 'Run the tests in GUI mode.')
-  .option('-R, --record', 'Record tests and send result to Dashboard')
+  .option('-R, --record', 'Record tests and send result to Dashboard Service')
+  .option(
+    '-K, --key',
+    'It is used to authenticate the project into the Dashboard Service'
+  )
   .on('--help', () => console.log(HELP_MESSAGE))
   .parse(process.argv)
 

--- a/packages/sui-test/bin/sui-test-e2e.js
+++ b/packages/sui-test/bin/sui-test-e2e.js
@@ -47,6 +47,7 @@ program
   )
   .option('-s, --scope <spec>', 'Run tests specifying a subfolder of specs')
   .option('-G, --gui', 'Run the tests in GUI mode.')
+  .option('-R, --record', 'Record tests and send result to Dashboard')
   .on('--help', () => console.log(HELP_MESSAGE))
   .parse(process.argv)
 
@@ -56,7 +57,8 @@ const {
   userAgent,
   gui,
   screenshotsOnError,
-  scope
+  scope,
+  record
 } = program
 const cypressConfig = {
   integrationFolder: path.join(TESTS_FOLDER, scope || ''),
@@ -84,7 +86,8 @@ resolveLazyNPMBin('cypress/bin/cypress', `cypress@${CYPRESS_VERSION}`)
     getSpawnPromise(cypressBinPath, [
       gui ? 'open' : 'run',
       '--config=' + objectToCommaString(cypressConfig),
-      '--project=' + CYPRESS_FOLDER_PATH
+      '--project=' + CYPRESS_FOLDER_PATH,
+      record && '--record'
     ])
   )
   .catch(showError)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- add --record flag to sui-test e2e command
- add --key flag to sui-test e2e command

This flag will allow to record e2e tests while running into CI and be able to debug/inspect the errors more easily if some tests fail.
[Official Documentation](https://docs.cypress.io/guides/dashboard/projects.html#Set-up-a-project-to-record)