### PR TITLE
feat(sui-polyfills): add Array.flat polyfill

### DIFF
--- a/packages/sui-polyfills/src/index.js
+++ b/packages/sui-polyfills/src/index.js
@@ -1,6 +1,7 @@
 require('core-js/features/array/fill')
 require('core-js/features/array/find-index')
 require('core-js/features/array/find')
+require('core-js/features/array/flat')
 require('core-js/features/array/from')
 require('core-js/features/array/includes')
 require('core-js/features/array/is-array')


### PR DESCRIPTION
Add Array.flat polyfill since it is not natively supported in IE11.