### PR TITLE
docs(sui-lint): update Prettier integration in VScode

### DIFF
--- a/packages/sui-lint/Readme.md
+++ b/packages/sui-lint/Readme.md
@@ -151,7 +151,8 @@ Add the next config to your preferences:
     "editor.formatOnSave": true
   },
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": true,
+    "source.fixAll.stylelint": true
   }
 }
 ```

--- a/packages/sui-lint/Readme.md
+++ b/packages/sui-lint/Readme.md
@@ -140,7 +140,9 @@ Prettier is integrated in sui-lint with some specific rules. If you want VSCode 
 `CMD + Shift + P -> Preferences: Open Settings (JSON)`.
 
 Add the next config to your preferences:
-```
+
+```json
+{
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
@@ -148,7 +150,10 @@ Add the next config to your preferences:
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true
   },
-  "eslint.autoFixOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
+}
 ```
 
 It will format and fix the problems of linter on saving. If you prefer to do this manually, you could avoid adding the `eslint.autoFixOnSave` and `editor.formatOnSave` configs.


### PR DESCRIPTION
### Update Prettier integration in VScode

## Description
Following [prettier guidelines](https://github.com/prettier/prettier-vscode#linter-integration) about **VScode** linting integrations is recommended to use the proposed config in this PR:
```json
{
"editor.codeActionsOnSave": {
    "source.fixAll.eslint": true
  }
}
```
