### PR TITLE
feat(sui-widget-embedder): show/hide prop where URLs are not deterministic

### DIFF
--- a/packages/sui-widget-embedder/src-react/Widget.js
+++ b/packages/sui-widget-embedder/src-react/Widget.js
@@ -9,30 +9,36 @@ export default class Widget extends Component {
     children: PropTypes.element,
     node: PropTypes.string,
     i18n: PropTypes.object,
-    domain: PropTypes.object
+    domain: PropTypes.object,
+    isVisible: PropTypes.bool
+  }
+
+  static defaultProps = {
+    isVisible: true
   }
 
   componentDidMount() {
-    const {node: selector, children, i18n, domain} = this.props
+    const {node: selector, children, i18n, domain, isVisible} = this.props
     const node = document.querySelector(selector)
 
     if (!node) {
       return console.warn(`[Widget] unable find the selector ${selector}`) // eslint-disable-line
     }
 
-    ReactDOM.render(
-      <Context.Provider
-        value={{
-          i18n,
-          domain
-        }}
-      >
-        <ProviderLegacy i18n={i18n} domain={domain}>
-          {children}
-        </ProviderLegacy>
-      </Context.Provider>,
-      node
-    )
+    isVisible &&
+      ReactDOM.render(
+        <Context.Provider
+          value={{
+            i18n,
+            domain
+          }}
+        >
+          <ProviderLegacy i18n={i18n} domain={domain}>
+            {children}
+          </ProviderLegacy>
+        </Context.Provider>,
+        node
+      )
   }
 
   render() {


### PR DESCRIPTION
When there is no way to target a deterministic URL to load a specific Widget via RegEx, this `isVisible` prop can handle logic to show/hide Widget based in a Boolean condition.

This feature has a default prop to be backward compatible with the previous version.

## Description
- [x] Adds `isVisible` boolean prop
- [x] Adds a default value to `true`
- [x] Wraps `ReactDOM.render` funcion in a conditional rendering based on `isVisible`

## Related Issue
https://jira.scmspain.com/browse/MMAA-12153
