### PR TITLE
[sui-studio] Add patcher to mocha to allow switch contexts

### DIFF
--- a/packages/sui-studio/README.md
+++ b/packages/sui-studio/README.md
@@ -121,6 +121,56 @@ describe('AtomButton', () => {
 
 The component will be a global object when running tests, so it is PARAMOUNT NOT to import it. In order to avoid problems with the linter, add relevant comments, as in the example above. 
 
+### How works with different contexts
+
+If there is a `demo/context.js` file where you define several contexts for your components. You have to apply a patch to Mocha to allow setup describe by context. This allows you to have a "contextify" version of your component, for the context selected.
+
+First, you have to import the patcher to create the `context` object, inside the `describe` object
+
+```js
+import '@s-ui/studio/patcher-mocha'
+```
+
+After that, you can use the `describe.context` object to has a key by each context define in your `demo/context.js` file.
+
+For example, if your context.js file looks like:
+
+```js
+export default () => {
+  return Promise.resolve({
+    default: {
+      user: {id: 12},
+      language: 'es'
+    },
+    other: {
+      user: {id: 34},
+      language: 'ca'
+    }
+  })
+}
+```
+the test file should be like:
+
+```js
+import '@s-ui/studio/patcher-mocha'
+
+chai.use(chaiDOM)
+
+describe.context.default('atom/button', AtomButton => {
+  it('Render', () => {
+    const {getByText} = render(<AtomButton>HOLA</AtomButton>)
+    expect(getByText('HOLA')).to.have.text('HOLA 12')
+  })
+})
+
+describe.context.other('atom/button', AtomButton => {
+  it('Render', () => {
+    const {getByText} = render(<AtomButton>HOLA</AtomButton>)
+    expect(getByText('HOLA')).to.have.text('HOLA 34')
+  })
+})
+```
+
 ## File structure
 
 SUIStudio profusely uses the concept of "convention over configuration" for file structure.

--- a/packages/sui-studio/README.md
+++ b/packages/sui-studio/README.md
@@ -131,7 +131,7 @@ First, you have to import the patcher to create the `context` object, inside the
 import '@s-ui/studio/patcher-mocha'
 ```
 
-After that, you can use the `describe.context` object to has a key by each context define in your `demo/context.js` file.
+After that, you can use the `describe.context` object to has a key by every context definition in your `demo/context.js` file.
 
 For example, if your context.js file looks like:
 

--- a/packages/sui-studio/patcher-mocha/index.js
+++ b/packages/sui-studio/patcher-mocha/index.js
@@ -1,0 +1,72 @@
+/* eslint no-extend-native:0 */
+
+import React from 'react'
+import SUIContext from '@s-ui/react-context'
+import withContext from '../src/components/demo/HoC/withContext'
+import {cleanDisplayName} from '../src/components/demo/utilities'
+
+const global = globalThis || window // eslint-disable-line
+const __CONTEXTS__ = global.__STUDIO_CONTEXTS__ || {}
+const __COMPONENT__ = global.__STUDIO_COMPONENT__
+const functionsToPatch = ['describe']
+
+Function.prototype.partial = function() {
+  const fn = this
+  const args = Array.prototype.slice.call(arguments)
+  return function() {
+    let arg = 0
+    for (var i = 0; i < args.length && arg < arguments.length; i++)
+      if (args[i] === undefined) args[i] = arguments[arg++]
+    return fn.apply(this, args)
+  }
+}
+
+functionsToPatch.forEach(fnName => {
+  const handler = {
+    get: function(obj, prop) {
+      const originalFn = global[fnName]
+
+      if (!__CONTEXTS__) {
+        // eslint-disable-next-line
+        console.error(
+          'Your demo doesn´t have any context define. Create a context.js file in the demo folder.'
+        )
+        return function(title, cb) {
+          return originalFn(title, cb)
+        }
+      }
+
+      let context = __CONTEXTS__[prop]
+      if (!context) {
+        // eslint-disable-next-line
+        console.error(
+          `Your trying to use the context ${prop} but it is not define in your contexts.js file.
+          Only are allow the following contexts: ${Object.keys(__CONTEXTS__)}.
+          as fallback you will use the "default" context in your test`
+        )
+
+        context = __CONTEXTS__.default
+      }
+
+      const EnhanceComponentWithLegacyContext = withContext(
+        context,
+        context
+      )(__COMPONENT__)
+      const EnhanceComponent = props => (
+        <SUIContext.Provider value={context}>
+          <EnhanceComponentWithLegacyContext {...props} />
+        </SUIContext.Provider>
+      )
+      EnhanceComponent.displayName = cleanDisplayName(
+        EnhanceComponentWithLegacyContext.displayName
+      )
+
+      return function(title, cb) {
+        return originalFn(`[${prop}] ${title}`, cb.partial(EnhanceComponent))
+      }
+    }
+  }
+  const context = new global.Proxy({}, handler)
+
+  global[fnName].context = context
+})

--- a/packages/sui-studio/patcher-mocha/index.js
+++ b/packages/sui-studio/patcher-mocha/index.js
@@ -29,7 +29,7 @@ functionsToPatch.forEach(fnName => {
       if (!__CONTEXTS__) {
         // eslint-disable-next-line
         console.error(
-          'Your demo doesn´t have any context define. Create a context.js file in the demo folder.'
+          `You're trying to use the context ${prop} but it's not defined in your contexts.js file`
         )
         return function(title, cb) {
           return originalFn(title, cb)

--- a/packages/sui-studio/src/components/test-page/index.js
+++ b/packages/sui-studio/src/components/test-page/index.js
@@ -35,7 +35,7 @@ const TestPage = ({params}) => {
                 category: params.category
               })
             }
-            context={requires?.contexts?.default}
+            context={requires?.contexts}
           />
         )}
       </When>


### PR DESCRIPTION

![Captura de pantalla 2020-02-11 a las 10 43 31](https://user-images.githubusercontent.com/179462/74225665-6d9fb580-4cbb-11ea-94ad-5c8bb3960449.png)


test/atom/button/index.js

```js
import '@s-ui/studio/patcher-mocha'

chai.use(chaiDOM)

describe.context.default('atom/button', AtomButton => {
  it('Render', () => {
    const {getByText} = render(<AtomButton>HOLA</AtomButton>)
    expect(getByText('HOLA')).to.have.text('HOLA 12')
  })
})

describe.context.other('atom/button', AtomButton => {
  it('Render', () => {
    const {getByText} = render(<AtomButton>HOLA</AtomButton>)
    expect(getByText('HOLA')).to.have.text('HOLA 34')
  })
})
```

demo/atom/button/context.js

```js
export default () => {
  return Promise.resolve({
    default: {
      user: {id: 12},
      language: 'es'
    },
    other: {
      user: {id: 34},
      language: 'ca'
    }
  })
}
```

components/atom/button/index.js

```js
export default function AtomButton({children}) {
  const {user} = useContext(SUIContext)

  console.log({user}) // eslint-disable-line

  return (
    <div className="sui-AtomButton">
      <h1>AtomButton</h1>
      <button>
        {children} <span>{user.id}</span>
      </button>
    </div>
  )
}
```