### PR TITLE
perf(sui-bundler): avoid repetated libraries

### DIFF
--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -67,10 +67,11 @@ module.exports = {
     splitChunks: {
       cacheGroups: {
         vendor: {
-          chunks: 'initial',
+          chunks: 'all',
           name: 'vendor',
           test: 'vendor',
-          enforce: true
+          enforce: true,
+          reuseExistingChunk: true
         }
       }
     }


### PR DESCRIPTION
PR to avoid putting in chunks repeated libraries that are not in initial chunks. In this example, you could see @s-ui/js library repeated over different chunks.

Before (chunks over ~7KB):
![image](https://user-images.githubusercontent.com/1561955/74250018-52986a00-4cea-11ea-887c-1ae073a1b142.png)

After (chunks over ~4KB) as @s-ui/js is already in the app or other chunk:
![image](https://user-images.githubusercontent.com/1561955/74250092-6cd24800-4cea-11ea-96ed-85fe98473767.png)
