### PR TITLE
Feat/add bidirectional qs parser

### DIFF
--- a/packages/sui-js/src/string/index.js
+++ b/packages/sui-js/src/string/index.js
@@ -1,10 +1,10 @@
-import {stringify} from 'qs'
+import toQueryString from './to-query-string'
 
 export {default as parseQueryString} from './parse-query-string'
+export {default as toQueryString} from './to-query-string'
 export const fromArrayToCommaQueryString = query =>
-  decodeURIComponent(stringify(query, {arrayFormat: 'comma'}))
+  decodeURIComponent(toQueryString(query, {arrayFormat: 'comma'}))
 
-export {stringify as toQueryString} from 'qs'
 export {fromSnakeToCamelCase, fromCamelToSnakeCase} from './snake-case'
 export {has as hasAccents, remove as removeAccents} from 'remove-accents'
 

--- a/packages/sui-js/src/string/index.js
+++ b/packages/sui-js/src/string/index.js
@@ -1,6 +1,6 @@
-import {parse, stringify} from 'qs'
+import {stringify} from 'qs'
 
-export const parseQueryString = query => parse(query, {ignoreQueryPrefix: true})
+export {default as parseQueryString} from './parse-query-string'
 export const fromArrayToCommaQueryString = query =>
   decodeURIComponent(stringify(query, {arrayFormat: 'comma'}))
 

--- a/packages/sui-js/src/string/index.js
+++ b/packages/sui-js/src/string/index.js
@@ -2,6 +2,14 @@ import toQueryString from './to-query-string'
 
 export {default as parseQueryString} from './parse-query-string'
 export {default as toQueryString} from './to-query-string'
+
+/**
+ * @deprecated since version 2.9.0
+ * will be deleted in version 3
+ *
+ * use toQueryString(queryParams, {arrayFormat: 'comma'}) instead
+ * it may not be very convenient to decode with decodeURIComponent knowing that it will be used in the url
+ */
 export const fromArrayToCommaQueryString = query =>
   decodeURIComponent(toQueryString(query, {arrayFormat: 'comma'}))
 

--- a/packages/sui-js/src/string/parse-query-string.js
+++ b/packages/sui-js/src/string/parse-query-string.js
@@ -16,7 +16,7 @@ function parseQueryString(query, options = {}) {
     ...(typeof comma !== 'undefined' && {comma})
   }
 
-  parse(query, mergedOptions)
+  return parse(query, mergedOptions)
 }
 
 export default parseQueryString

--- a/packages/sui-js/src/string/parse-query-string.js
+++ b/packages/sui-js/src/string/parse-query-string.js
@@ -1,0 +1,22 @@
+import {parse} from 'qs'
+
+/**
+ * parse query string to object
+ *
+ * @param {string} query
+ * @param {object} [options={}]
+ * @param {boolean} [options.ignoreQueryPrefix=true] - avoid the leading question mark
+ * @param {boolean} [options.comma] - comma to join array
+ */
+function parseQueryString(query, options = {}) {
+  const {ignoreQueryPrefix = true, comma} = options
+
+  const mergedOptions = {
+    ignoreQueryPrefix,
+    ...(typeof comma !== 'undefined' && {comma})
+  }
+
+  parse(query, mergedOptions)
+}
+
+export default parseQueryString

--- a/packages/sui-js/src/string/to-query-string.js
+++ b/packages/sui-js/src/string/to-query-string.js
@@ -1,0 +1,20 @@
+import {stringify} from 'qs'
+
+/**
+ * converts query params object to query string
+ *
+ * @param {object} queryParams
+ * @param {object} [options={}]
+ * @param {'indices'|'brackets'|'repeat'|'comma'} [options.arrayFormat] - specify the format of the output array
+ */
+function toQueryString(queryParams, options = {}) {
+  const {arrayFormat} = options
+
+  const mergedOptions = {
+    ...(typeof arrayFormat !== 'undefined' && {arrayFormat})
+  }
+
+  return stringify(queryParams, mergedOptions)
+}
+
+export default toQueryString

--- a/packages/sui-js/test/stringSpec.js
+++ b/packages/sui-js/test/stringSpec.js
@@ -14,6 +14,15 @@ describe('@s-ui/js', () => {
       const query = 'a=1&b=test'
       expect(toQueryString(params)).to.be.equal(query)
     })
+
+    it('should convert object params to query string with arrayFormat comma option', () => {
+      const queryParams = {a: 1, b: 'test', m: [1, 2, 3]}
+      const options = {arrayFormat: 'comma'}
+      const queryString = toQueryString(queryParams, options)
+
+      const expected = 'a=1&b=test&m=1%2C2%2C3'
+      expect(expected).to.be.equal(queryString)
+    })
   })
   describe('string:parseQueryString', () => {
     it('should convert query string to object params', () => {

--- a/packages/sui-js/test/stringSpec.js
+++ b/packages/sui-js/test/stringSpec.js
@@ -21,6 +21,15 @@ describe('@s-ui/js', () => {
       const params = {a: '1', b: 'test'}
       expect(parseQueryString(query)).to.deep.equal(params)
     })
+
+    it('should convert query string to object params with comma option', () => {
+      const query = '?a=1&b=test&m=1,2,3'
+      const options = {comma: true}
+      const parsedQueryParams = parseQueryString(query, options)
+
+      const expected = {a: '1', b: 'test', m: ['1', '2', '3']}
+      expect(parsedQueryParams).to.deep.equal(expected)
+    })
   })
   describe('string:fromArrayToCommaQueryString', () => {
     it('should convert params array to comma separated object params', () => {


### PR DESCRIPTION
Bidirectional mapping to query with multiple values

## Description

map multiple values bidirectionally with the next format:
- `a=1&m=1%2C2%2C3` -> `{a: '1', m: ['1', '2', '3']}`
- `{a: '1', m: ['1', '2', '3']}` -> `a=1&m=1%2C2%2C3`

[DEMO - current functionality and what is expected](https://codesandbox.io/s/test-s-uijslibstring-jv4y3) thanks for the demo a @desko27 

## Tasks

- Add second parameter to `parseQueryString` function with own options API.
- Remove export of `stringify` function propagation from `qs` library.
This has been reviewed the use in repositories of the organization of [SUI-Components](https://github.com/search?q=org%3ASUI-Components+toQueryString&type=Code) and in [our private repositories](https://github.mpi-internal.com/search?l=JavaScript&p=1&q=toQueryString%28&type=Code) and only one use with the second parameter was found at https://github.mpi-internal.com/scmspain/frontend-ij--lib-jobs/blob/master/src/offers/Repositories/factory.js#L24.
Where support is already given.
- Create `toQueryString` function with own options API.
- Add respective tests to changes.

PD: I think that with this change in the future should the `fromArrayToCommaQueryString` be removed because `toQueryString` support this feature.
