### PR TITLE
feat(sui-js): add delimiter option

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "wiki:pull": "git subtree pull --prefix=.wiki https://github.com/SUI-Components/sui.wiki.git master --squash",
     "wiki:push": "git subtree push --prefix=.wiki https://github.com/SUI-Components/sui.wiki.git master",
     "commitmsg": "validate-commit-msg",
-    "precommit": "sui-precommit run"
+    "precommit": "sui-precommit run",
+    "test:test": "cross-env NODE_ENV=test & sui-test browser"
   },
   "devDependencies": {
     "@babel/cli": "7.8.3",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "wiki:pull": "git subtree pull --prefix=.wiki https://github.com/SUI-Components/sui.wiki.git master --squash",
     "wiki:push": "git subtree push --prefix=.wiki https://github.com/SUI-Components/sui.wiki.git master",
     "commitmsg": "validate-commit-msg",
-    "precommit": "sui-precommit run",
-    "test:test": "cross-env NODE_ENV=test & sui-test browser"
+    "precommit": "sui-precommit run"
   },
   "devDependencies": {
     "@babel/cli": "7.8.3",

--- a/packages/sui-js/src/string/parse-query-string.js
+++ b/packages/sui-js/src/string/parse-query-string.js
@@ -7,13 +7,15 @@ import {parse} from 'qs'
  * @param {object} [options={}]
  * @param {boolean} [options.ignoreQueryPrefix=true] - avoid the leading question mark
  * @param {boolean} [options.comma] - comma to join array
+ * @param {string} [options.delimiter] - delimiter
  */
 function parseQueryString(query, options = {}) {
-  const {ignoreQueryPrefix = true, comma} = options
+  const {ignoreQueryPrefix = true, comma, delimiter} = options
 
   const mergedOptions = {
     ignoreQueryPrefix,
-    ...(typeof comma !== 'undefined' && {comma})
+    ...(typeof comma !== 'undefined' && {comma}),
+    ...(typeof delimiter !== 'undefined' && {delimiter})
   }
 
   return parse(query, mergedOptions)

--- a/packages/sui-js/test/stringSpec.js
+++ b/packages/sui-js/test/stringSpec.js
@@ -39,6 +39,15 @@ describe('@s-ui/js', () => {
       const expected = {a: '1', b: 'test', m: ['1', '2', '3']}
       expect(parsedQueryParams).to.deep.equal(expected)
     })
+
+    it('should convert query string to object params with delimiter option', () => {
+      const query = '?a=b:c=d'
+      const options = {delimiter: ':'}
+      const parsedQueryParams = parseQueryString(query, options)
+
+      const expected = {a: 'b', c: 'd'}
+      expect(parsedQueryParams).to.deep.equal(expected)
+    })
   })
   describe('string:fromArrayToCommaQueryString', () => {
     it('should convert params array to comma separated object params', () => {


### PR DESCRIPTION
Fix adding delimiter option for `parseQueryString`