### PR TITLE
fix(sui-js): enable delimiter to toQueryString method

### DIFF
--- a/packages/sui-js/src/string/to-query-string.js
+++ b/packages/sui-js/src/string/to-query-string.js
@@ -8,10 +8,11 @@ import {stringify} from 'qs'
  * @param {'indices'|'brackets'|'repeat'|'comma'} [options.arrayFormat] - specify the format of the output array
  */
 function toQueryString(queryParams, options = {}) {
-  const {arrayFormat} = options
+  const {arrayFormat, delimiter} = options
 
   const mergedOptions = {
-    ...(typeof arrayFormat !== 'undefined' && {arrayFormat})
+    ...(typeof arrayFormat !== 'undefined' && {arrayFormat}),
+    ...(typeof delimiter !== 'undefined' && {delimiter})
   }
 
   return stringify(queryParams, mergedOptions)

--- a/packages/sui-js/test/stringSpec.js
+++ b/packages/sui-js/test/stringSpec.js
@@ -23,6 +23,15 @@ describe('@s-ui/js', () => {
       const expected = 'a=1&b=test&m=1%2C2%2C3'
       expect(expected).to.be.equal(queryString)
     })
+
+    it('should convert object params to query string with arrayFormat repeat and delimiter :', () => {
+      const queryParams = {a: 1, b: 'test', m: [1, 2]}
+      const options = {arrayFormat: 'repeat', delimiter: ':'}
+      const queryString = toQueryString(queryParams, options)
+
+      const expected = 'a=1:b=test:m=1:m=2'
+      expect(expected).to.be.equal(queryString)
+    })
   })
   describe('string:parseQueryString', () => {
     it('should convert query string to object params', () => {


### PR DESCRIPTION
Fix adding delimiter option for toQueryString