### PR TITLE
fix(sui-studio): sui-studio test breaks if we does not use patcher-mo…

### DIFF
--- a/packages/sui-studio/src/components/test/index.js
+++ b/packages/sui-studio/src/components/test/index.js
@@ -34,7 +34,7 @@ const Test = ({open, importTest, importComponent, context}) => {
       !EnhanceComponent.displayName &&
         console.error('[sui-Test] Component without displayName') // eslint-disable-line
       window[cleanDisplayName(EnhanceComponent.displayName)] = props => (
-        <SUIContext.Provider value={nextContext.default}>
+        <SUIContext.Provider value={nextContext}>
           <EnhanceComponent {...props} />
         </SUIContext.Provider>
       )


### PR DESCRIPTION
Given this code:
```
import React from 'react'

import chai, {expect} from 'chai'
import chaiDOM from 'chai-dom'
import {render} from '@testing-library/react'

chai.use(chaiDOM)

describe('FormColor', () => {
  it('Render', () => {
    render(<FormColor />)
    expect(true).to.be.eql(false)
  })
})
```
Sui-studio does not inject well the context:
![image](https://user-images.githubusercontent.com/5390428/74433027-e6d80d80-4e5f-11ea-8804-8ba1bc6fc9bc.png)

