### PR TITLE
feat(sui-i18n): add get languages method

### DIFF
--- a/packages/sui-i18n/src/i18n.js
+++ b/packages/sui-i18n/src/i18n.js
@@ -40,6 +40,10 @@ export default class Rosetta {
     return this._currency
   }
 
+  get languages() {
+    return this._languages
+  }
+
   set languages(languages) {
     this._languages = languages
   }


### PR DESCRIPTION
## Description
Add get languages method to get the translation object.

The current option would be `i18n._languages[i18n.culture].MONTH.LONG`.

The new option `i18n.languages[i18n.culture].MONTH.LONG` without accessing private property 🙄.

