### PR TITLE
fix(sui-domain): make subscribe method take onNext, onError arguments

### DIFF
--- a/packages/sui-domain/src/EntryPointFactory.js
+++ b/packages/sui-domain/src/EntryPointFactory.js
@@ -48,7 +48,7 @@ export default ({useCases, config}) =>
             },
             $: {
               execute: {
-                subscribe: fn => {
+                subscribe: (onNext,onError) => {
                   // creating an object here that will have a dispose method
                   const ret = {dispose: function() {}}
                   loader().then(factory => {
@@ -56,7 +56,7 @@ export default ({useCases, config}) =>
                     // makes dispose working async and we need it
                     ret.dispose = factory.default[method]({
                       config: this._config
-                    }).$.execute.subscribe(fn).dispose
+                    }).$.execute.subscribe(onNext,OnError).dispose
                   })
                   // return the object that will be mutated async
                   return ret

--- a/packages/sui-domain/src/EntryPointFactory.js
+++ b/packages/sui-domain/src/EntryPointFactory.js
@@ -56,7 +56,7 @@ export default ({useCases, config}) =>
                     // makes dispose working async and we need it
                     ret.dispose = factory.default[method]({
                       config: this._config
-                    }).$.execute.subscribe(onNext,OnError).dispose
+                    }).$.execute.subscribe(onNext,onError).dispose
                   })
                   // return the object that will be mutated async
                   return ret


### PR DESCRIPTION
Fixes the subscribe behaviour on useCases using the `@streamify` decorator.

## Description
So far, only the first argument was taken by the subscribe method (which happened to be `onNext` from `@streamify`). The method is now also taking `onError` for a correct error handling. 

## Related Issue
N/A

## Example
N/A