### PR TITLE
feat(sui-js): add encode to toQueryString options

### DIFF
--- a/packages/sui-js/src/string/to-query-string.js
+++ b/packages/sui-js/src/string/to-query-string.js
@@ -12,9 +12,9 @@ function toQueryString(queryParams, options = {}) {
   const {arrayFormat, delimiter, encode = true} = options
 
   const mergedOptions = {
+    encode,
     ...(typeof arrayFormat !== 'undefined' && {arrayFormat}),
-    ...(typeof delimiter !== 'undefined' && {delimiter}),
-    ...(typeof encode !== 'undefined' && {encode})
+    ...(typeof delimiter !== 'undefined' && {delimiter})
   }
 
   return stringify(queryParams, mergedOptions)

--- a/packages/sui-js/src/string/to-query-string.js
+++ b/packages/sui-js/src/string/to-query-string.js
@@ -9,7 +9,7 @@ import {stringify} from 'qs'
  * @param {string} [options.delimiter] - delimiter
  */
 function toQueryString(queryParams, options = {}) {
-  const {arrayFormat, delimiter, encode} = options
+  const {arrayFormat, delimiter, encode = true} = options
 
   const mergedOptions = {
     ...(typeof arrayFormat !== 'undefined' && {arrayFormat}),

--- a/packages/sui-js/src/string/to-query-string.js
+++ b/packages/sui-js/src/string/to-query-string.js
@@ -9,11 +9,12 @@ import {stringify} from 'qs'
  * @param {string} [options.delimiter] - delimiter
  */
 function toQueryString(queryParams, options = {}) {
-  const {arrayFormat, delimiter} = options
+  const {arrayFormat, delimiter, encode} = options
 
   const mergedOptions = {
     ...(typeof arrayFormat !== 'undefined' && {arrayFormat}),
-    ...(typeof delimiter !== 'undefined' && {delimiter})
+    ...(typeof delimiter !== 'undefined' && {delimiter}),
+    ...(typeof encode !== 'undefined' && {encode})
   }
 
   return stringify(queryParams, mergedOptions)


### PR DESCRIPTION
…and subsequent call to `stringify`

## Description
One of our use cases uses toQueryString to pass on a URL which doesn't need to be encoded. Hence, we need to be able to pass the option `encode` as `false` to `qs`'s `stringify`. 

## Related Issue
N/A

## Example
N/A
