### PR TITLE
feat(sui-component-dependencies): add @s-ui/theme pkg to be imported

### DIFF
--- a/packages/sui-component-dependencies/package.json
+++ b/packages/sui-component-dependencies/package.json
@@ -9,6 +9,7 @@
   "author": "Carlos Villuendas <carlosvillu@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "@s-ui/theme": "8",
     "@schibstedspain/rosetta": "3",
     "@schibstedspain/sui-theme": "8",
     "@schibstedspain/theme-basic": "7",


### PR DESCRIPTION
Install @s-ui/theme in order to be able to import it over the old @schibstedspain/sui-theme. We're keeping the old one in order to keep compatibility.