### PR TITLE
feat(sui-js): add highlightText method to sui-js

### DIFF
--- a/packages/sui-js/src/string/highlighter.js
+++ b/packages/sui-js/src/string/highlighter.js
@@ -1,0 +1,47 @@
+import {remove as removeAccents} from 'remove-accents'
+
+// given a value and a query, if value has the query as a subset highlight it using startTag and endTag
+export const highlightText = ({value, query, startTag, endTag}) => {
+  // replace accents and lowercase
+  const queryWithoutAccents = removeAccents(query).toLowerCase()
+  const valueWithoutAccents = removeAccents(value).toLowerCase()
+  // get all the matches of the query in the value
+  const matches = findMatches(valueWithoutAccents, queryWithoutAccents)
+
+  // highlight the matches of the query in the value
+  const highlighterReducer = (valueHighlightedAccumulator, match, i) => {
+    const start = match.start + i * (startTag + endTag).length
+    const end = match.end + i * (startTag + endTag).length
+    return `${valueHighlightedAccumulator.slice(
+      0,
+      start
+    )}${startTag}${valueHighlightedAccumulator.slice(
+      start,
+      end
+    )}${endTag}${value.slice(match.end)}`
+  }
+
+  return matches.reduce(highlighterReducer, value)
+}
+
+const findMatches = (value, query) => {
+  let from = 0
+  const matches = []
+  let match
+  while ((match = findMatch(value, query, from))) {
+    matches.push(match)
+    from = match.end
+  }
+  return matches
+}
+
+const findMatch = (value, query, from = 0) => {
+  const startingPosition = value.indexOf(query, from)
+  const isQueryEmpty = query === ''
+  if (startingPosition < 0 || isQueryEmpty) {
+    return null
+  }
+  const endingPosition = startingPosition + query.length
+  // return matched start and end index
+  return {start: startingPosition, end: endingPosition}
+}

--- a/packages/sui-js/src/string/highlighter.js
+++ b/packages/sui-js/src/string/highlighter.js
@@ -7,11 +7,11 @@ export const highlightText = ({value, query, startTag, endTag}) => {
   const valueWithoutAccents = removeAccents(value).toLowerCase()
   // get all the matches of the query in the value
   const matches = findMatches(valueWithoutAccents, queryWithoutAccents)
-
+  const tagsLength = (startTag + endTag).length
   // highlight the matches of the query in the value
   const highlighterReducer = (valueHighlightedAccumulator, match, i) => {
-    const start = match.start + i * (startTag + endTag).length
-    const end = match.end + i * (startTag + endTag).length
+    const start = match.start + i * tagsLength
+    const end = match.end + i * tagsLength
     return `${valueHighlightedAccumulator.slice(
       0,
       start

--- a/packages/sui-js/src/string/index.js
+++ b/packages/sui-js/src/string/index.js
@@ -22,3 +22,5 @@ export {default as toKebabCase} from 'just-kebab-case'
 
 export {getRandomString} from './random-string'
 export {slugify} from './slugify'
+
+export {highlightText} from './highlighter'

--- a/packages/sui-js/test/stringSpec.js
+++ b/packages/sui-js/test/stringSpec.js
@@ -4,7 +4,8 @@ import {
   parseQueryString,
   toQueryString,
   fromArrayToCommaQueryString,
-  getRandomString
+  getRandomString,
+  highlightText
 } from '../src/string/index'
 
 describe('@s-ui/js', () => {
@@ -61,6 +62,18 @@ describe('@s-ui/js', () => {
       const randomString = getRandomString()
       expect(randomString).to.be.an('string')
       expect(randomString).to.have.lengthOf(15)
+    })
+  })
+  describe('string:highlightText', () => {
+    it('should highlight text', () => {
+      const highlightedText = highlightText({
+      value: 'Cálaca',
+      query: 'ca',
+      startTag: `<strong>`,
+      endTag: '</strong>'
+    })
+      expect(highlightedText).to.be.an('string')
+      expect(highlightedText).to.be.equal(`<strong>Cá</strong>la<strong>ca</strong>`)
     })
   })
 })


### PR DESCRIPTION
Add highlightText method to sui-js

## Description
highlightText method allows to add a `startTag` and `endTag` around all ocurrences of certain `query` of a `value` in a case-insensitive and accent-insensitive way.

## Related Issue
https://jira.scmspain.com/browse/SUIC-447

## Example
Tests and Documentation updated (see examples)
If value is `Cádiz`, query is `ca`, startTag is `<strong>`, endTag is `</strong>` it returns: `<strong>Cá</strong>diz`
