### PR TITLE
fix(sui-mockmock): fix restore interceptors and use new nock version

### DIFF
--- a/packages/sui-mockmock/src/http/serverMocker.js
+++ b/packages/sui-mockmock/src/http/serverMocker.js
@@ -2,6 +2,10 @@ import {Mocker, Mock} from './mockerInterface'
 import nock from 'nock'
 
 class ServerMocker extends Mocker {
+  restore() {
+    nock.cleanAll()
+  }
+
   httpMock(baseUrl) {
     return new ServerMock(nock, baseUrl)
   }


### PR DESCRIPTION
## Description
In all verticals we are restoring our mocks after each test:
![image](https://user-images.githubusercontent.com/5390428/76602881-21d76a80-650c-11ea-8a82-158c0c72f93c.png)

But sui-mockmock does not use nock implementation for clear all the interceptors created by other test mocks. This PR add this implementation for clean all the interceptors when we use `mocker.restore()`

See docs 👀 https://github.com/nock/nock#restoring

## Issue
In motor we had a test that mocks `/authentication` with `reply({})`.
After this one, we have another test with same mock but with `reply({...someData})`
Given we never restore the interceptors, second test fails because mock replies with `{}` because of nock uses `interceptors.find` it appears earlier in interceptors array.

Just 🤯

## Summary
![image](https://user-images.githubusercontent.com/5390428/76602564-7a5a3800-650b-11ea-8400-6bc1c4e67cd8.png)

