### PR TITLE
feat(sui-widget-embedder): add new param hrefRegExp to identify the h…

### DIFF
--- a/packages/sui-widget-embedder/README.md
+++ b/packages/sui-widget-embedder/README.md
@@ -80,6 +80,7 @@ Inside each page you must create a package.json file.
 ```json
 {
   "pathnameRegExp": ["/d\\w+\\.html"],
+  "hrefRegExp":["/d\\w+\\.html"],
   "blacklistedRegExps": [
     "about.html",
     "contact.html"
@@ -91,9 +92,11 @@ Inside each page you must create a package.json file.
 }
 ```
 
-- pathnameRegExp [REQUIRED]: RegExp or array of RegExp as strings to identify the pathname of the page where this list of widgets must work. In case of array of RegExp, the widget will load if at least one RegExp matches with the current location.
+- pathnameRegExp [*REQUIRED]: RegExp or array of RegExp as strings to identify the pathname of the page where this list of widgets must work. In case of array of RegExp, the widget will load if at least one RegExp matches with the current location.
+- hrefRegExp [*REQUIRED]: RegExp or array of RegExp as strings to identify the href of the page where this list of widgets must work. In case of array of RegExp, the widget will load if at least one RegExp matches with the current location.
 - blacklistedRegExps [OPTIONAL]: List of RegExps to identify the pathname of the pages where the widgets don't have to work at.
 - vendor [OPTIONAL]: In case you want to have a vendor file for this page only.
+(*) It's required just one of these two fields: pathnameRegExp or hrefRegExp
 
 ## Working with React
 

--- a/packages/sui-widget-embedder/downloader/index.js
+++ b/packages/sui-widget-embedder/downloader/index.js
@@ -108,12 +108,12 @@
   }
 
   function matchNameWithRegExp(name, regExp) {
-    if(!regExp) {
+    if (!regExp) {
       return false
     }
     if (Array.isArray(regExp)) {
       return regExp.some(function(re) {
-        name.match(new RegExp(re))
+        return name.match(new RegExp(re))
       })
     }
 

--- a/packages/sui-widget-embedder/downloader/index.js
+++ b/packages/sui-widget-embedder/downloader/index.js
@@ -107,24 +107,38 @@
     })
   }
 
-  function matchPathnameWithRegExp(regExp) {
-    var pathname = window.location.pathname
+  function matchNameWithRegExp(name, regExp) {
+    if(!regExp) {
+      return false
+    }
     if (Array.isArray(regExp)) {
       return regExp.some(function(re) {
-        pathname.match(new RegExp(re))
+        name.match(new RegExp(re))
       })
     }
 
-    return pathname.match(new RegExp(regExp))
+    return name.match(new RegExp(regExp))
+  }
+  function matchPathnameWithRegExp(regExp) {
+    return matchNameWithRegExp(window.location.pathname, regExp)
+  }
+
+  function matchhRefWithRegExp(regExp) {
+    return matchNameWithRegExp(window.location.href, regExp)
+  }
+
+  function match(pathnameRegExp, hrefRegExp) {
+    return matchPathnameWithRegExp(pathnameRegExp) || matchhRefWithRegExp(hrefRegExp)
   }
 
   var pages = []
   for (var page in pageConfigs) {
     var blacklistedRegExps = pageConfigs[page].blacklistedRegExps || []
     var pathnameRegExp = pageConfigs[page].pathnameRegExp
+    var hrefRegExp = pageConfigs[page].hrefRegExp
     var isBlacklisted = blacklistedRegExps.some(matchPathnameWithRegExp)
 
-    if (!isBlacklisted && matchPathnameWithRegExp(pathnameRegExp)) {
+    if (!isBlacklisted && match(pathnameRegExp,hrefRegExp)) {
       pages.push(page)
     }
   }

--- a/packages/sui-widget-embedder/file-templates/_package.json.js
+++ b/packages/sui-widget-embedder/file-templates/_package.json.js
@@ -1,5 +1,6 @@
 module.exports = (regExp = '(.*)') => `{
   "pathnameRegExp": "${regExp}",
+  "hrefRegExp": "${regExp}",
   "private": true,
   "version": "1.0.0"
 }`


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
We need to download a widget for this kind of  url: _https://adevinta-spain.ofertas-trabajo.infojobs.net/_
The allowed regex to download widgets are based on pathname but it does not allow to get the whole href.
The idea is to add a new param to download the widget with a regex based on href. 

<!--- Describe your changes in detail -->

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
