### PR TITLE
[sui-ssr] Add check to skip SSR if statusCode is set to 404

### DIFF
--- a/packages/sui-ssr/server/ssr/index.js
+++ b/packages/sui-ssr/server/ssr/index.js
@@ -43,6 +43,10 @@ export default (req, res, next) => {
   let [headTplPart, bodyTplPart] = getTplParts(req)
   const criticalCSS = req.criticalCSS
 
+  if (res.statusCode === 404) {
+    return next()
+  }
+
   if (criticalCSS) {
     headTplPart = headTplPart
       .replace(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add check to skip SSR if statusCode is set to 404

## Description
This code will cause skipping the SSR phase if the status code of the response is set previously to `404`. This solves the issue where the hook `TYPES.NOT_FOUND` is never reached because the ssr always matches routes like `/*`.

## Example
1. First set the status code in `hooks[TYPES.PRE_SSR_HANDLER]` hook, for example. 
```js
[TYPES.PRE_SSR_HANDLER]: (req, res, next) => {
    res.status(404)
    return next()
}
```
2. When the SSR is reached, this code will make it skip ssr and jump to `hooks[TYPES.NOT_FOUND]` hook
3. The `NOT_FOUND` hook will render the static 404 page.
