### PR TITLE
[sui-ssr] Create context in SETUP_CONTEXT hook before ssr

### DIFF
--- a/packages/sui-ssr/hooks-types.js
+++ b/packages/sui-ssr/hooks-types.js
@@ -4,6 +4,7 @@ export default {
   LOGGING: 'logging',
   NOT_FOUND: 'not_found',
   PRE_HEALTH: 'pre_health',
+  SETUP_CONTEXT: 'setup_context',
   PRE_SSR_HANDLER: 'pre_ssr_handler',
   PRE_STATIC_PUBLIC: 'pre_static_public'
 }

--- a/packages/sui-ssr/server/hooksFactory/index.js
+++ b/packages/sui-ssr/server/hooksFactory/index.js
@@ -5,14 +5,19 @@ import {resolve} from 'path'
 import {getTplParts, HtmlBuilder} from '../template'
 import {publicFolderByHost} from '../utils'
 
+import {createServerContextFactoryParams} from '@s-ui/react-initial-props'
+
 // __MAGIC IMPORTS__
 // They came from {SPA}/src
 // import userHooks from 'hooks'
 let userHooks
+let contextFactory
 try {
   userHooks = require('hooks')
+  contextFactory = require('contextFactory').default
 } catch (e) {
   userHooks = {}
+  contextFactory = async () => ({})
 }
 // END __MAGIC IMPORTS__
 
@@ -63,6 +68,15 @@ export const hooksFactory = async () => {
     [TYPES.PRE_HEALTH]: NULL_MDWL,
     [TYPES.LOGGING]: NULL_MDWL,
     [TYPES.PRE_STATIC_PUBLIC]: NULL_MDWL,
+    [TYPES.SETUP_CONTEXT]: async (req, res, next) => {
+      const context = await contextFactory(
+        createServerContextFactoryParams(req)
+      )
+
+      req.context = context
+
+      return next()
+    },
     [TYPES.PRE_SSR_HANDLER]: NULL_MDWL,
     [TYPES.APP_CONFIG_SETUP]: builAppConfig,
     [TYPES.NOT_FOUND]: async (req, res, next) => {

--- a/packages/sui-ssr/server/index.js
+++ b/packages/sui-ssr/server/index.js
@@ -115,6 +115,8 @@ const _memoizedHtmlTemplatesMapping = {}
     next()
   })
 
+  app.use(hooks[TYPES.SETUP_CONTEXT])
+
   app.use(hooks[TYPES.PRE_SSR_HANDLER])
 
   app.get('*', [

--- a/packages/sui-ssr/server/ssr/index.js
+++ b/packages/sui-ssr/server/ssr/index.js
@@ -5,11 +5,7 @@ import routes from 'routes'
 import {RouterContext, match} from 'react-router'
 import {HeadProvider} from '@s-ui/react-head'
 import {renderHeadTagsToString} from '@s-ui/react-head/lib/server'
-import {
-  createServerContextFactoryParams,
-  ssrComponentWithInitialProps
-} from '@s-ui/react-initial-props'
-// END __MAGIC IMPORTS__
+import {ssrComponentWithInitialProps} from '@s-ui/react-initial-props'
 
 import qs from 'querystring'
 import {getTplParts, HtmlBuilder} from '../template'
@@ -18,15 +14,6 @@ import withAllContexts from '@s-ui/hoc/lib/withAllContexts'
 import withSUIContext from '@s-ui/hoc/lib/withSUIContext'
 import {buildDeviceFrom} from '../../build-device'
 import ssrConfig from '../config'
-
-// __MAGIC IMPORTS__
-let contextFactory
-try {
-  contextFactory = require('contextFactory').default
-} catch (e) {
-  contextFactory = async () => ({})
-}
-// END __MAGIC IMPORTS__
 
 // const SERVER_TIMING_HEADER = 'Server-Timing'
 const HTTP_PERMANENT_REDIRECT = 301
@@ -81,15 +68,12 @@ export default (req, res, next) => {
       }
 
       const device = buildDeviceFrom({request: req})
+      const {context} = req
 
       // Flush if early-flush is enabled
       if (req.app.locals.earlyFlush) {
         initialFlush(res)
       }
-
-      const context = await contextFactory(
-        createServerContextFactoryParams(req)
-      )
 
       let initialData
       const headTags = []


### PR DESCRIPTION
Create context in SETUP_CONTEXT hook before ssr

## Description
This PR adds a new hook (`setup_context`) to the server that creates the context object. 

The purpose of this is being able to access context from hooks declared before the SSR phase, for example, the `pre-ssr`. 

The new generated `context` is appended to the `req` object.

The hook allows also to be redefined if needed.

## Example
in your hooks/index.js file:
```js
...,
[TYPES.SETUP_CONTEXT]: async (req, res, next) => {
     const context = await contextFactory(
        createServerContextFactoryParams(req)
     )

    req.context = context
    // or any other addition
    // req.context = {...context, device}

    return next()
},
```
