### PR TITLE
feat(sui-studio): adds optimizely and utag_data globals to avoid Moch…

### DIFF
--- a/packages/sui-studio/src/index.html
+++ b/packages/sui-studio/src/index.html
@@ -8,7 +8,7 @@
   <script class="mocha-init">
     mocha.setup('bdd');
     mocha.checkLeaks();
-    mocha.globals(['google*', '_goog*']);
+    mocha.globals(['google*', '_goog*', 'optimizely', 'utag_data']);
   </script>
 </head>
 <body>

--- a/packages/sui-studio/workbench/src/index.html
+++ b/packages/sui-studio/workbench/src/index.html
@@ -9,7 +9,7 @@
   <script class="mocha-init">
     mocha.setup('bdd');
     mocha.checkLeaks();
-    mocha.globals(['google*', '_goog*']);
+    mocha.globals(['google*', '_goog*', 'optimizely', 'utag_data']);
   </script>
 </head>
 <body>


### PR DESCRIPTION
### Avoid Global leaks Warnings in test
When a component tries to access to the global environment, Mocha throws a warning. Adding those keys will allow using OptimizelyX and Tealium `utag_data`.

<img width="388" alt="Screenshot 2020-03-31 at 09 11 04" src="https://user-images.githubusercontent.com/10925540/77997493-cc82c200-732f-11ea-9a24-8d7b02524885.png">