### PR TITLE
[sui-ssr] Use skipSSR flag instead of checking status code

### DIFF
--- a/packages/sui-ssr/server/ssr/index.js
+++ b/packages/sui-ssr/server/ssr/index.js
@@ -41,8 +41,7 @@ const initialFlush = res => {
 export default (req, res, next) => {
   const {url, query} = req
   let [headTplPart, bodyTplPart] = getTplParts(req)
-  const criticalCSS = req.criticalCSS
-  const skipSSR = req.skipSSR
+  const {skipSSR, criticalCSS} = req
 
   if (skipSSR) {
     return next()

--- a/packages/sui-ssr/server/ssr/index.js
+++ b/packages/sui-ssr/server/ssr/index.js
@@ -42,8 +42,9 @@ export default (req, res, next) => {
   const {url, query} = req
   let [headTplPart, bodyTplPart] = getTplParts(req)
   const criticalCSS = req.criticalCSS
+  const skipSSR = req.skipSSR
 
-  if (res.statusCode === 404) {
+  if (skipSSR) {
     return next()
   }
 


### PR DESCRIPTION
Use skipSSR flag instead of checking status code

## Description
See #786 

After consideration, we have seen it is more convenient having a flag that any hook can set to skip the SSR phase. 

## Example
```js
[TYPES.PRE_SSR_HANDLER]: (req, res, next) => {
    req.skipSSR = true
    return next()
}
```