### PR TITLE
fix(sui-studio): fix Style children array proptype

### DIFF
--- a/packages/sui-studio/src/components/style/index.js
+++ b/packages/sui-studio/src/components/style/index.js
@@ -29,5 +29,5 @@ export default function Style({children, id}) {
 }
 
 Style.propTypes = {
-  children: PropTypes.string
+  children: PropTypes.array
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
fix the children's prop because it now arrives as an array instead of a string

## Related Issue
![image](https://user-images.githubusercontent.com/31726966/78876158-33e6f300-7a4f-11ea-9690-22ad23c3611d.png)
