### PR TITLE
chore(sui-studio): extend test template

### DIFF
--- a/packages/sui-studio/bin/sui-studio-generate.js
+++ b/packages/sui-studio/bin/sui-studio-generate.js
@@ -225,8 +225,8 @@ chai.use(chaiDOM)
 // use describe() (without context.default) if not using context in demo (context.js)
 describe.context.default('${componentInPascal}', ${componentInPascal} => {
   it('Render', async () => {
-      const {findByText} = render(<${componentInPascal} />)
-      expect(await findByText('hello world')).to.be.visible
+    const {findByText} = render(<${componentInPascal} />)
+    expect(await findByText('hello world')).to.be.visible
   })
 })
 `

--- a/packages/sui-studio/bin/sui-studio-generate.js
+++ b/packages/sui-studio/bin/sui-studio-generate.js
@@ -218,9 +218,11 @@ return (<${componentInPascal} />)
 import chai, {expect} from 'chai'
 import chaiDOM from 'chai-dom'
 import {render} from '@testing-library/react'
+import '@s-ui/studio/src/patcher-mocha'
 
 chai.use(chaiDOM)
 
+// use describe.context.default if using context in demo (context.js)
 describe('${componentInPascal}', () => {
   it('Render', () => {
     render(<${componentInPascal} />)

--- a/packages/sui-studio/bin/sui-studio-generate.js
+++ b/packages/sui-studio/bin/sui-studio-generate.js
@@ -222,11 +222,11 @@ import '@s-ui/studio/src/patcher-mocha'
 
 chai.use(chaiDOM)
 
-// use describe.context.default if using context in demo (context.js)
-describe('${componentInPascal}', () => {
-  it('Render', () => {
-    render(<${componentInPascal} />)
-    expect(true).to.be.eql(false)
+// use describe() (without context.default) if not using context in demo (context.js)
+describe.context.default('${componentInPascal}', ${componentInPascal} => {
+  it('Render', async () => {
+      const {findByText} = render(<${componentInPascal} />)
+      expect(await findByText('hello world')).to.be.visible
   })
 })
 `


### PR DESCRIPTION
Improve test template generated when running `sui-studio generate X Y`
- If context is not defined it also works.
- Use find** with async await as a best practice dealing with async behaviours.