### PR TITLE
feat(sui-ssr): add criticalcss invalidation param

### DIFF
--- a/packages/sui-ssr/server/criticalCss/index.js
+++ b/packages/sui-ssr/server/criticalCss/index.js
@@ -29,7 +29,7 @@ export default config => (req, res, next) => {
   if (req.url.match('x-criticalcss-cache-invalidate')) {
     __CACHE__ = {}
 
-    console.log('CriticalCSS cache invalidated')
+    logMessage('CriticalCSS cache invalidated')
   }
 
   if (

--- a/packages/sui-ssr/server/criticalCss/index.js
+++ b/packages/sui-ssr/server/criticalCss/index.js
@@ -25,6 +25,8 @@ export default config => (req, res, next) => {
 
   if (req.url.match('x-criticalcss-cache-invalidate')) {
     __CACHE__ = {}
+
+    console.log('CriticalCSS cache invalidated')
   }
 
   if (

--- a/packages/sui-ssr/server/criticalCss/index.js
+++ b/packages/sui-ssr/server/criticalCss/index.js
@@ -6,7 +6,7 @@ import parser from 'ua-parser-js'
 
 const PRODUCTION = 'production'
 const {NODE_ENV = PRODUCTION} = process.env
-const __CACHE__ = {}
+let __CACHE__ = {}
 
 const generateMinimalCSSHash = routes => {
   return routes.reduce((acc, route) => {
@@ -19,6 +19,10 @@ const logMessage = message =>
   NODE_ENV !== PRODUCTION && console.log('[CRITICAL CSS]', message)
 
 export default config => (req, res, next) => {
+  if (req.url.match('x-criticalcss-cache-invalidate')) {
+    __CACHE__ = {}
+  }
+
   if (!config || process.env.DISABLE_CRITICAL_CSS === 'true') {
     return next()
   }


### PR DESCRIPTION
## Description
Add criticalcss invalidation param with the format `x-criticalcss-cache-invalidate` 

## Example
Call http://www.milanuncios.com/fax?x-criticalcss-cache-invalidate to invalidate all generated critical CSS just in case they were generated badly or with errors.