### PR TITLE
feat(sui-studio): add mocha global to test url redirects

### DIFF
--- a/packages/sui-studio/src/index.html
+++ b/packages/sui-studio/src/index.html
@@ -8,7 +8,7 @@
   <script class="mocha-init">
     mocha.setup('bdd');
     mocha.checkLeaks();
-    mocha.globals(['google*', '_goog*', 'optimizely', 'utag_data','goog', 'gvjs_*']);
+    mocha.globals(['google*', '_goog*', 'optimizely', 'utag_data','goog', 'gvjs_*', '__ROUTER_PUSH_TRIGGERED__']);
   </script>
 </head>
 <body>

--- a/packages/sui-studio/workbench/src/index.html
+++ b/packages/sui-studio/workbench/src/index.html
@@ -9,7 +9,7 @@
   <script class="mocha-init">
     mocha.setup('bdd');
     mocha.checkLeaks();
-    mocha.globals(['google*', '_goog*', 'optimizely', 'utag_data','goog', 'gvjs_*']);
+    mocha.globals(['google*', '_goog*', 'optimizely', 'utag_data','goog', 'gvjs_*', '__ROUTER_PUSH_TRIGGERED__']);
   </script>
 </head>
 <body>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
add a mocha variable `__ROUTER_PUSH_TRIGGERED__ `, so component tests don't fail due to [`global leak detected error`](https://github.com/mochajs/mocha/issues/110).

## Example:

In context.js file we can mock the `router.push` function with: 
![image](https://user-images.githubusercontent.com/32937662/80610427-a38e4380-8a39-11ea-8b6b-09eb281329b7.png)

then in the test asserting that the url is in the window variable:

![image](https://user-images.githubusercontent.com/32937662/80610765-07b10780-8a3a-11ea-91f0-4b195433b7d2.png)

