### PR TITLE
Feat/move studio to new sui react router

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "test:server:watch": "npm run test:server -- --watch",
     "wiki:pull": "git subtree pull --prefix=.wiki https://github.com/SUI-Components/sui.wiki.git master --squash",
     "wiki:push": "git subtree push --prefix=.wiki https://github.com/SUI-Components/sui.wiki.git master",
-    "commitmsg": "validate-commit-msg",
-    "precommit": "sui-precommit run"
+    "commitmsg": "validate-commit-msg"
   },
   "devDependencies": {
     "@babel/cli": "7.8.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:server:watch": "npm run test:server -- --watch",
     "wiki:pull": "git subtree pull --prefix=.wiki https://github.com/SUI-Components/sui.wiki.git master --squash",
     "wiki:push": "git subtree push --prefix=.wiki https://github.com/SUI-Components/sui.wiki.git master",
-    "commitmsg": "validate-commit-msg"
+    "commitmsg": "validate-commit-msg",
+    "precommit": "sui-precommit run"
   },
   "devDependencies": {
     "@babel/cli": "7.8.3",

--- a/packages/sui-studio/package.json
+++ b/packages/sui-studio/package.json
@@ -27,7 +27,7 @@
     "@s-ui/helpers": "1",
     "@s-ui/mono": "1",
     "@s-ui/react-context": "1",
-    "@s-ui/react-router": "^1.0.0-beta.9",
+    "@s-ui/react-router": "^1.0.0-beta.10",
     "@testing-library/react": "10.0.4",
     "@testing-library/user-event": "10.0.1",
     "bundle-loader": "0.5.6",

--- a/packages/sui-studio/package.json
+++ b/packages/sui-studio/package.json
@@ -46,7 +46,7 @@
     "just-kebab-case": "1.1.0",
     "just-pascal-case": "1.1.0",
     "normalize.css": "8.0.1",
-    "react-router": "3.2.6",
+    "@s-ui/react-router": "1.0.0-beta.8",
     "react-docgen": "5.1.0",
     "terminal-banner": "1.1.0"
   },

--- a/packages/sui-studio/package.json
+++ b/packages/sui-studio/package.json
@@ -27,6 +27,7 @@
     "@s-ui/helpers": "1",
     "@s-ui/mono": "1",
     "@s-ui/react-context": "1",
+    "@s-ui/react-router": "^1.0.0-beta.9",
     "@testing-library/react": "10.0.4",
     "@testing-library/user-event": "10.0.1",
     "bundle-loader": "0.5.6",
@@ -46,7 +47,6 @@
     "just-kebab-case": "1.1.0",
     "just-pascal-case": "1.1.0",
     "normalize.css": "8.0.1",
-    "@s-ui/react-router": "1.0.0-beta.8",
     "react-docgen": "5.1.0",
     "terminal-banner": "1.1.0"
   },

--- a/packages/sui-studio/src/components/navigation/index.js
+++ b/packages/sui-studio/src/components/navigation/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import React, {useState} from 'react'
-import {Link} from 'react-router'
+import {Link} from '@s-ui/react-router'
 import Logo from './Logo'
 
 import {getComponentsList, getStudioName} from '../utils'

--- a/packages/sui-studio/src/components/root/index.js
+++ b/packages/sui-studio/src/components/root/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
-import {Router, browserHistory} from 'react-router'
+import {Router} from '@s-ui/react-router'
 import routes from '../../routes'
 import '../../index.scss'
 
-export default () => <Router routes={routes} history={browserHistory} />
+export default () => <Router routes={routes} />

--- a/packages/sui-studio/src/components/workbench/index.js
+++ b/packages/sui-studio/src/components/workbench/index.js
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react'
 import PropTypes from 'prop-types'
-import {Link} from 'react-router'
+import {Link} from '@s-ui/react-router'
 import cx from 'classnames'
 
 import {FILES} from '../../constants'

--- a/packages/sui-studio/src/routes.js
+++ b/packages/sui-studio/src/routes.js
@@ -12,6 +12,10 @@ import TestPage from './components/test-page/index'
 
 export default (
   <Route>
+    <Redirect
+      from="workbench/:category/:component"
+      to="/workbench/:category/:component/demo"
+    />
     <Route path="/" component={Layout}>
       <Route path="workbench/:category/:component" component={Workbench}>
         <Route path="test" component={TestPage} />
@@ -37,10 +41,6 @@ export default (
         </Route>
       </Route>
     </Route>
-    <Redirect
-      from="workbench/:category/:component"
-      to="workbench/:category/:component/demo"
-    />
     <Redirect from="**" to="/" />
   </Route>
 )

--- a/packages/sui-studio/src/routes.js
+++ b/packages/sui-studio/src/routes.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import {IndexRedirect, Route, Redirect} from 'react-router'
+import {Route, Redirect} from '@s-ui/react-router'
 import Layout from './components/layout'
 import Workbench from './components/workbench'
 import Demo from './components/demo'
@@ -14,7 +14,6 @@ export default (
   <Route>
     <Route path="/" component={Layout}>
       <Route path="workbench/:category/:component" component={Workbench}>
-        <IndexRedirect to="demo" />
         <Route path="test" component={TestPage} />
         <Route path="demo" component={Demo} />
         <Route path="documentation" component={Documentation}>
@@ -38,6 +37,10 @@ export default (
         </Route>
       </Route>
     </Route>
+    <Redirect
+      from="workbench/:category/:component"
+      to="workbench/:category/:component/demo"
+    />
     <Redirect from="**" to="/" />
   </Route>
 )


### PR DESCRIPTION
Before rolling the new react-router, let's eat our own dog food by using the new react-router in our studio.

- [x] Adapt routes to use `<Redirect>` instead `<IndexRedirect />`.

**Note:**
Thanks to testing the router in SUI-Studio we have detected some missing functionality regarding using the Router without `match` and relying only on client-side:
https://github.com/SUI-Components/sui/pull/712/commits/2b86b28b047be277ce7ab68c507bfc2d10498901
