### PR TITLE
feat(sui-studio): provide the displayName to the tested components

### DIFF
--- a/packages/sui-studio/src/components/test/index.js
+++ b/packages/sui-studio/src/components/test/index.js
@@ -43,7 +43,9 @@ const Test = ({open, importTest, importComponent, contexts}) => {
       )
       hoistNonReactStatics(NextComponent, Component)
 
-      window[cleanDisplayName(EnhanceComponent.displayName)] = NextComponent
+      const displayName = cleanDisplayName(EnhanceComponent.displayName)
+      NextComponent.displayName = displayName
+      window[displayName] = NextComponent
 
       importTest()
         .then(() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`hoistNonReactStatics` only preserve the static (non-react) METHODS
The desired behaviour requires to preserve the displayName to get them in testing

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
```
class A extends React.PureComponent {
  static displayName = 'A'
  render() { return null }
}
A.staticMethod = () => 'B'
const AA = props => (
  <SUIContext.Provider value={nextContexts.default}>
    <A {...props} />
  </SUIContext.Provider>
)
hoistNonReactStatics(AA, A)
A.displayName // 'A'
A.staticMethod // f()...
AA.displayName	// undefined
AA.staticMethod // f()...
```
