### PR TITLE
fix(sui-studio): stop having super large windows when errors are long

### DIFF
--- a/packages/sui-studio/src/components/test/index.scss
+++ b/packages/sui-studio/src/components/test/index.scss
@@ -7,6 +7,7 @@
   &--open,
   &--failures {
     display: block;
+    max-width: 500px;
   }
 }
 


### PR DESCRIPTION
When having an error, if the error is large, it disappears from the window and it's quite annoying because most of the time you can't read the message.

To solve this, you have to force a width in the `dev tools` of that element, and these styles disappear after applying a change in the test.

## Description
Give a `max-width` to the errors and test window to avoid this.


## Example
### Before
![Screen Shot 2020-05-07 at 15 19 27](https://user-images.githubusercontent.com/16169890/81299461-8deece80-9076-11ea-8f98-4125ac9d0d6c.png)

### After
![Screen Shot 2020-05-07 at 15 20 22](https://user-images.githubusercontent.com/16169890/81299580-b676c880-9076-11ea-8d30-998536848d9e.png)

