### PR TITLE
feat(sui-mockmock): get nth request (url, body, headers) from clientMocker

### DIFF
--- a/packages/sui-mockmock/README.md
+++ b/packages/sui-mockmock/README.md
@@ -1,4 +1,5 @@
 # sui-mockmock
+
 > Mocking utilities for testing.
 
 ## Motivation
@@ -17,7 +18,7 @@ npm install @s-ui/mockmock --save-dev
 
 Mocks `http` requests in node and `XMLHttpRequest` requests in the browser.
 
-####  Usage
+#### Usage
 
 ```js
 import {HttpMocker} from '@s-ui/mockmock'
@@ -28,13 +29,12 @@ const mocker = new HttpMocker()
 mocker
   .httpMock('http://fake.api.com')
   .get('/my-service')
-  .reply({ property: 'value' }, 200)
+  .reply({property: 'value'}, 200)
 
 // Make your requests
 axios
   .get('http://fake.api.com/my-service')
-  .then((response) => console.log(response)) // { property: 'value' }
-
+  .then(response => console.log(response)) // { property: 'value' }
 ```
 
 Also available for import
@@ -49,6 +49,7 @@ Since this library internally constructs the url of the original and the mocked 
 it's needed to create the mock request with the same parameter order than the original, if not, it will throw a 404.
 
 ![incorrect] The parameters of both petitions (original and mocked) don't have the same parameter order (err 404 thrown)
+
 ```js
 mocker
   .httpMock(...)
@@ -71,6 +72,7 @@ domain
 ```
 
 ![correct] The mocked and the original HTTP requests have to same parameter order
+
 ```js
 mocker
   .httpMock(...)
@@ -92,5 +94,96 @@ domain
   ...
 ```
 
-[correct]:https://img.shields.io/badge/-OK-green.svg
-[incorrect]:https://img.shields.io/badge/-KO-red.svg
+[correct]: https://img.shields.io/badge/-OK-green.svg
+[incorrect]: https://img.shields.io/badge/-KO-red.svg
+
+## Clean up state
+
+It is important to clean tests before and after so you have a initial state **non dependent**.
+
+Why? Sharing mutable state between components it is a bad idea.
+
+- One tests depends on the others, so you can not run one test in isolation.
+- If you refactor one test, you might break all the others tests, because all tests are part of a chain of actions.
+- If tests are isolated you can: **paralelize** test and **remove** or **add** tests without breaking other ones
+
+Example:
+
+```js
+
+describe('abc', () => {
+  beforeEach(() => {
+    mocker.create()
+  })
+  afterEach(() => {
+    mocker.restore()
+  })
+  ...
+  it('xyz', () =>{
+    ...
+  })
+})
+
+```
+
+## Mocking Requests
+
+The `.reply(response, statusCode, headers)` method causes the 'fake' server to respond to any request not matched by another response with the provided data.
+
+```js
+mocker
+  .httpMock(...)
+  .get('/urlToAttack')
+  .query({
+    search: 'value of the search',
+    working: true,
+  })
+  .reply('{status: "ok"}', 200, {'Access-Control-Allow-Credentials': true})
+  ...
+  ...
+
+const response = domain
+  .get('attacks_the_same_url_use_case')
+  .execute({
+    search: 'value of the search',
+    working: true,
+  })
+
+expect(response.data.status).to.equal('ok')
+```
+
+## Retriving Requests
+
+If you want to test what your use_case, function, etc is doing, probably you will need to check that based on the arguments provided to the function are transformed and as an output or side effect one or various `requests` are done will a certain `url`, `body`, or `headers`.
+
+The `.requestNTH(index)` method returns the nth `request` mocked by the fake server so you can assert things like:
+
+- The content of the `body` of the request is the one expected.
+- The `headers` of the request are the expected.
+- The `url` of the request is the one expected.
+- The order of the `requests` is the correct one.
+
+```js
+mocker
+  .httpMock(...)
+  .get('/urlToAttack')
+  .query({
+    search: 'value of the search',
+    working: true,
+  })
+  .reply('{status: "ok"}', 200, {'Access-Control-Allow-Credentials': true})
+  ...
+  ...
+
+const response = domain
+  .get('attacks_the_same_url_use_case')
+  .execute({
+    search: 'value of the search',
+    working: true,
+  })
+
+const request = mock.requestNTH(0)
+expect(request.body).to.be.equal('year=2030&doors=3&color=blue')
+expect(request.url).to.be.equal('https://.../urlToAttack')
+...
+```

--- a/packages/sui-mockmock/src/http/clientMocker.js
+++ b/packages/sui-mockmock/src/http/clientMocker.js
@@ -108,6 +108,21 @@ class ClientMock extends Mock {
         : `${this._baseUrl}${this._path}${this._query}`,
       this._responseResolver(response, statusCode, headers)
     )
+
+    return this
+  }
+
+  toStandardRequest(request) {
+    return {
+      url: request.url,
+      body: request.requestBody,
+      headers: request.requestHeaders
+    }
+  }
+
+  requestNTH(index) {
+    const request = this._server.requests[index]
+    return this.toStandardRequest(request)
   }
 }
 

--- a/packages/sui-mockmock/src/http/mockerInterface.js
+++ b/packages/sui-mockmock/src/http/mockerInterface.js
@@ -8,6 +8,13 @@ class Mock {
   post(path) {}
   query(queryObject) {}
   reply(response, statusCode) {}
+  toStandardRequest(request) {
+    throw new Error('Mock#toStandardRequest must be implemented')
+  }
+
+  requestNTH(index) {
+    throw new Error('Mock#requestNTH must be implemented')
+  }
 }
 
 /**

--- a/packages/sui-mockmock/src/http/serverMocker.js
+++ b/packages/sui-mockmock/src/http/serverMocker.js
@@ -77,6 +77,8 @@ class ServerMock extends Mock {
     }
 
     mock.reply(statusCode, JSON.stringify(response))
+
+    return this
   }
 }
 


### PR DESCRIPTION
- get nth request (url, body, headers) from clientMocker

## Description
Inside your client tests, now you can get a request mocked by sui-mockmock and inspect it.
For example you want to assert that the body of a certain request has a concrete body in order to test that your usecase is doing the transformations in a properly way

## Example
- First rectangle gets the first request : `const request = mock.requestNTH(0)`
-Second  rectangle asserts that the  request body is equal to a super long string allocated in a variable. `expect(request.body).to.be.equal(category245Ad.body)`

![image](https://user-images.githubusercontent.com/32937662/81941964-cd2e9980-95f9-11ea-906a-38b7335a60eb.png)


## Remain work
Implement both `toStandardRequest` and `requestNTH` in the serverMocker.js.
