### PR TITLE
feat(sui-studio): add scroll to the tests section

### DIFF
--- a/packages/sui-studio/src/components/test/index.scss
+++ b/packages/sui-studio/src/components/test/index.scss
@@ -7,7 +7,8 @@
   &--open,
   &--failures {
     display: block;
-    max-width: 500px;
+    max-width: 700px;
+    overflow-y: auto;
   }
 }
 


### PR DESCRIPTION
When having some tests and/or errors that overflow the window, we have no scroll.

## Implementation
* Made max-width of the test window wider
* Added scroll in case of overflow

## Example 
<img width="710" alt="Screen Shot 2020-05-21 at 09 26 06" src="https://user-images.githubusercontent.com/16169890/82534501-8682f700-9b45-11ea-984d-b242b849e0cd.png">
