### PR TITLE
Fix/cache decorator error response

### DIFF
--- a/packages/sui-decorators/src/decorators/cache/index.js
+++ b/packages/sui-decorators/src/decorators/cache/index.js
@@ -20,13 +20,15 @@ const _cache = ({
   target,
   ttl
 } = {}) => {
-  caches[`${target.constructor.name}::${fnName}`] =
-    caches[`${target.constructor.name}::${fnName}`] ||
+  const cacheKey = `${target.constructor.name}::${fnName}`
+
+  caches[cacheKey] =
+    caches[cacheKey] ||
     (algorithm === ALGORITHMS.LRU
       ? new LRU({size})
       : new Error(`[sui-decorators::cache] unknown algorithm: ${algorithm}`))
 
-  const cache = caches[`${target.constructor.name}::${fnName}`]
+  const cache = caches[cacheKey]
 
   return (...args) => {
     if (

--- a/packages/sui-decorators/src/decorators/cache/index.js
+++ b/packages/sui-decorators/src/decorators/cache/index.js
@@ -20,13 +20,13 @@ const _cache = ({
   target,
   ttl
 } = {}) => {
-  caches[fnName] =
-    caches[fnName] ||
+  caches[`${target.constructor.name}::${fnName}`] =
+    caches[`${target.constructor.name}::${fnName}`] ||
     (algorithm === ALGORITHMS.LRU
       ? new LRU({size})
       : new Error(`[sui-decorators::cache] unknown algorithm: ${algorithm}`))
 
-  const cache = caches[fnName]
+  const cache = caches[`${target.constructor.name}::${fnName}`]
 
   return (...args) => {
     if (
@@ -40,6 +40,7 @@ const _cache = ({
       JSON.stringify(args)
     )}`
     const now = Date.now()
+
     if (cache.get(key) === undefined) {
       cache.set(key, {createdAt: now, returns: original.apply(instance, args)})
     }
@@ -48,11 +49,7 @@ const _cache = ({
       cache
         .get(key)
         .returns.then(args => {
-          if (
-            args.__INLINE_ERROR__ &&
-            Array.isArray(args) &&
-            args[0] !== undefined
-          ) {
+          if (args.__INLINE_ERROR__ && Array.isArray(args) && args[0]) {
             cache.del(key)
           }
         })

--- a/packages/sui-decorators/test/browser/cacheSpec.js
+++ b/packages/sui-decorators/test/browser/cacheSpec.js
@@ -5,7 +5,7 @@ import {expect} from 'chai'
 import cache from '../../src/decorators/cache'
 import inlineError from '../../src/decorators/error'
 
-describe('Cache', () => {
+describe('Cache in browser', () => {
   it('Should exist', () => {
     expect(cache).to.be.a('function')
   })

--- a/packages/sui-decorators/test/server/cacheSpec.js
+++ b/packages/sui-decorators/test/server/cacheSpec.js
@@ -3,51 +3,136 @@
 import {expect} from 'chai'
 
 import cache from '../../src/decorators/cache'
+import inlineError from '../../src/decorators/error'
 
-describe('Cache', () => {
-  it('should ignore the cache in Node by default', () => {
-    class Buz {
-      constructor() {
-        this.rnd = () => Math.random()
+describe('Cache in the server', () => {
+  describe('decorating a sync method', () => {
+    it('should not apply cache in Node by default', () => {
+      class Buz {
+        constructor() {
+          this.rnd = () => Math.random()
+        }
+
+        @cache()
+        @inlineError
+        syncRndNumber() {
+          return this.rnd()
+        }
+      }
+      const buz = new Buz()
+      expect(buz.syncRndNumber()).to.be.not.eql(buz.syncRndNumber())
+    })
+
+    it('should apply cache if server param is true', () => {
+      class Buz1 {
+        constructor() {
+          this.rnd = () => Math.random()
+        }
+
+        @cache({server: true})
+        syncRndNumber() {
+          return this.rnd()
+        }
+      }
+      const buz = new Buz1()
+      expect(buz.syncRndNumber()).to.be.eql(buz.syncRndNumber())
+    })
+
+    it('witth inlineError should apply cache if server param is true', () => {
+      class Buz2 {
+        constructor() {
+          this.rnd = () => Math.random()
+        }
+
+        @cache({server: true})
+        @inlineError
+        syncRndNumber() {
+          return this.rnd()
+        }
+      }
+      const buz = new Buz2()
+      expect(buz.syncRndNumber()).to.be.eql(buz.syncRndNumber())
+    })
+
+    it('should not apply cache for inlineError decorated error response', () => {
+      let shouldReturnError = true
+
+      class Yummy {
+        @cache({server: true})
+        @inlineError
+        rndNumber() {
+          if (shouldReturnError) {
+            throw new Error('Error')
+          }
+
+          return Math.random()
+        }
       }
 
-      @cache()
-      syncRndNumber() {
-        return this.rnd()
-      }
-    }
-    const buz = new Buz()
-    expect(buz.syncRndNumber()).to.be.not.eql(buz.syncRndNumber())
+      const yummy = new Yummy()
+      const responseFirst = yummy.rndNumber()
+      shouldReturnError = false
+      const responseSecond = yummy.rndNumber()
+      const responseThird = yummy.rndNumber()
+
+      expect(responseFirst[0]).to.be.not.null
+      expect(responseSecond[1]).to.be.eql(responseThird[1])
+    })
   })
 
-  it('should have a cache if the force the cache in node', () => {
-    class Buz {
-      constructor() {
-        this.rnd = () => Math.random()
+  describe('decorating an async method', () => {
+    it('should return twice the same random number without params', done => {
+      class Dummy {
+        @cache({server: true})
+        @inlineError
+        asyncRndNumber() {
+          return new Promise(resolve => setTimeout(resolve, 100, Math.random()))
+        }
+      }
+      const dummy = new Dummy()
+      Promise.all([dummy.asyncRndNumber(), dummy.asyncRndNumber()]).then(
+        ([firstCall, secondCall]) => {
+          expect(firstCall).to.be.eql(secondCall)
+          done()
+        }
+      )
+    })
+
+    it('should not apply cache for inlineError decorated error response', async () => {
+      let shouldReturnError = true
+
+      class YummyAsync {
+        @cache({
+          server: true,
+          ttl: '1 minute'
+        })
+        @inlineError
+        async asyncRndNumber() {
+          if (shouldReturnError) {
+            return Promise.reject(new Error('Error'))
+          }
+
+          return Math.random()
+        }
       }
 
-      @cache({server: true})
-      syncRndNumber() {
-        return this.rnd()
-      }
-    }
-    const buz = new Buz()
-    expect(buz.syncRndNumber()).to.be.eql(buz.syncRndNumber())
-  })
+      const yummyAsync = new YummyAsync()
+      // Error response, it should not be cached
+      const responseFirst = await yummyAsync.asyncRndNumber()
 
-  it('return twice the same random number without params', done => {
-    class Dummy {
-      @cache({server: true})
-      asyncRndNumber() {
-        return new Promise(resolve => setTimeout(resolve, 100, Math.random()))
-      }
-    }
-    const dummy = new Dummy()
-    Promise.all([dummy.asyncRndNumber(), dummy.asyncRndNumber()]).then(
-      ([firstCall, secondCall]) => {
-        expect(firstCall).to.be.eql(secondCall)
-        done()
-      }
-    )
+      // Ok response, it should be cached
+      shouldReturnError = false
+      const responseSecond = await yummyAsync.asyncRndNumber()
+      const responseThird = await yummyAsync.asyncRndNumber()
+
+      // Here we force an error and expect not response error because it is cached
+      shouldReturnError = true
+      const responseFourth = await yummyAsync.asyncRndNumber()
+
+      expect(responseFirst[0]).to.be.not.null
+      expect(responseSecond[1]).to.be.eql(responseThird[1])
+      expect(responseFourth[0]).to.be.null
+      expect(responseSecond[1]).to.be.eql(responseFourth[1])
+    })
   })
 })

--- a/packages/sui-decorators/test/server/cacheSpec.js
+++ b/packages/sui-decorators/test/server/cacheSpec.js
@@ -8,7 +8,7 @@ import inlineError from '../../src/decorators/error'
 describe('Cache in the server', () => {
   describe('decorating a sync method', () => {
     it('should not apply cache in Node by default', () => {
-      class Buz {
+      class Buzz {
         constructor() {
           this.rnd = () => Math.random()
         }
@@ -19,12 +19,12 @@ describe('Cache in the server', () => {
           return this.rnd()
         }
       }
-      const buz = new Buz()
-      expect(buz.syncRndNumber()).to.be.not.eql(buz.syncRndNumber())
+      const buzz = new Buzz()
+      expect(buzz.syncRndNumber()).to.be.not.eql(buzz.syncRndNumber())
     })
 
     it('should apply cache if server param is true', () => {
-      class Buz1 {
+      class Buzz1 {
         constructor() {
           this.rnd = () => Math.random()
         }
@@ -34,12 +34,12 @@ describe('Cache in the server', () => {
           return this.rnd()
         }
       }
-      const buz = new Buz1()
-      expect(buz.syncRndNumber()).to.be.eql(buz.syncRndNumber())
+      const buzz1 = new Buzz1()
+      expect(buzz1.syncRndNumber()).to.be.eql(buzz1.syncRndNumber())
     })
 
-    it('witth inlineError should apply cache if server param is true', () => {
-      class Buz2 {
+    it('with inlineError should apply cache if server param is true', () => {
+      class Buzz2 {
         constructor() {
           this.rnd = () => Math.random()
         }
@@ -50,8 +50,8 @@ describe('Cache in the server', () => {
           return this.rnd()
         }
       }
-      const buz = new Buz2()
-      expect(buz.syncRndNumber()).to.be.eql(buz.syncRndNumber())
+      const buzz2 = new Buzz2()
+      expect(buzz2.syncRndNumber()).to.be.eql(buzz2.syncRndNumber())
     })
 
     it('should not apply cache for inlineError decorated error response', () => {


### PR DESCRIPTION
## Description

- Improved cache key to be target constructor name + fnName.

- Don't apply cache for error responses when combining with @inlineError decorator.

