### PR TITLE
feat(sui-studio): add assets folder to .npmignore

### DIFF
--- a/packages/sui-studio/bin/sui-studio-generate.js
+++ b/packages/sui-studio/bin/sui-studio-generate.js
@@ -98,7 +98,11 @@ Promise.all([
 node_modules`
   ),
 
-  writeFile(COMPONENT_PACKAGE_NPMIGNORE_FILE, `src`),
+  writeFile(
+    COMPONENT_PACKAGE_NPMIGNORE_FILE,
+    `src
+assets`
+  ),
 
   writeFile(
     COMPONENT_PACKAGE_JSON_FILE,


### PR DESCRIPTION
It is a common scenario to add images to a component's documentation. While useful, these images shouldn't have an impact on the package size.

## Description
This PR adds the `assets` folder -commonly used for images and other static files for documentation- to the `.npmignore` file of the component.  