### PR TITLE
Feat/add redis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
   - npm run phoenix:ci
 
 script:
+  - npm update
   - npm run lint
   - npm run test:ci
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ install:
   - npm run phoenix:ci
 
 script:
-  - npm update
   - npm run lint
   - npm run test:ci
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js: '13'
 
 services:
   - docker
+  - redis-server
 
 before_install:
   - npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "co": "sui-mono commit",
     "lint": "sui-lint js && sui-lint sass",
     "test": "cross-env NODE_ENV=test npm run test:client && cross-env NODE_ENV=test npm run test:server",
-    "test:ci": "cross-env NODE_ENV=test npx sui-test browser --ci -T 4000 && cross-env NODE_ENV=test npx sui-test server -T 4000",
+    "test:ci": "npm run test:server",
     "test:client": "cross-env NODE_ENV=test sui-test browser -P \"packages/*/test/**/*Spec.js\" -I 'packages/*/test/server/*Spec.js'",
     "test:client:watch": "npm run test:client -- --watch",
     "test:server": "cross-env NODE_ENV=test & sui-test server -P \"./packages/*/\\!\\(browser\\)/server/*.js\"",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "co": "sui-mono commit",
     "lint": "sui-lint js && sui-lint sass",
     "test": "cross-env NODE_ENV=test npm run test:client && cross-env NODE_ENV=test npm run test:server",
-    "test:ci": "npm run test:server",
+    "test:ci": "cross-env NODE_ENV=test npx sui-test browser --ci -T 4000 && cross-env NODE_ENV=test npx sui-test server -T 4000",
     "test:client": "cross-env NODE_ENV=test sui-test browser -P \"packages/*/test/**/*Spec.js\" -I 'packages/*/test/server/*Spec.js'",
     "test:client:watch": "npm run test:client -- --watch",
     "test:server": "cross-env NODE_ENV=test & sui-test server -P \"./packages/*/\\!\\(browser\\)/server/*.js\"",

--- a/packages/sui-decorators/README.md
+++ b/packages/sui-decorators/README.md
@@ -82,7 +82,7 @@ person.greetingAsync('Carlos');
 
 There are two types of cache handlers (Memory LRU and Redis LRU):
 
-### Memory LRU cache
+#### Memory LRU cache
 
 Creates a cache of calls to any method of a class, only when the response is not an error.
 
@@ -122,14 +122,17 @@ For this method the cache is of 2 seconds.
 It is possible to set TTL using a string with the format `ttl: 'XXX [second|seconds|minute|minutes|hour|hours]'`,
 thus, avoiding writing very large integers.
 
-### Redis LRU cache:
+#### Redis LRU cache:
 
-Creates a cache of the decorated method response of a class, only when the response is not an error.
-You must decorate methods that return a promise and its resolved value is a plain javascript object, a json or a simple type (number, string...). 
+It creates a cache of the decorated method response of a class, only when the response is not an error.
+You must decorate methods that return a promise and its resolved value is a plain javascript object, a JSON, or a simple type (number, string...).
 
-So if you are using redis cache decorator with [sui-domain extended project](https://github.com/SUI-Components/sui/tree/master/packages/sui-domain) methods, you should decorate `UseCase` classes `execute` methods which are the ones returning plain JSON objects.
 
-````javascript
+If you are using Redis cache decorator in a [sui-domain extended project](https://github.com/SUI-Components/sui/tree/master/packages/sui-domain), you should decorate `UseCase` classes `execute` methods which are the ones returning plain JSON objects.
+
+**Note: Redis cache only works in server side.**
+
+```javascript
 import {UseCase} from '@s-ui/domain'
 import {inlineError, cache} from '@s-ui/decorators'
 
@@ -152,20 +155,20 @@ export class GetSeoTagsSearchUseCase extends UseCase {
     return seoTagsResponse?.toJSON()
   }
 }
-````
+```
 
-To have redis cache fully working, previously a redis server should be up and running, you must set `server` flag to `true` and provide desired `redis` server connection config: `@cache({server: true, redis: {host: YOUR_REDIS_HOST, port: YOUR_REDIS_PORT_NUMBER}})`, if one of these params is not provided redis cache won't be activated.
+#### Configuration
 
-To do real requests against your redis server you must set `USE_REDIS_IN_SUI_DECORATORS_CACHE` variable to `true` (`process.env.USE_REDIS_IN_SUI_DECORATORS_CACHE` in SSR).
+To have Redis cache fully working, previously a Redis server should be up and running, you must set `server` flag to `true` and provide desired `redis` server connection config: `@cache({server: true, redis: {host: YOUR_REDIS_HOST, port: YOUR_REDIS_PORT_NUMBER}})`, if one of these params is not provided redis cache won't be activated.
+
+To do real requests against your Redis server you must set `USE_REDIS_IN_SUI_DECORATORS_CACHE` variable to `true` (`process.env.USE_REDIS_IN_SUI_DECORATORS_CACHE` in SSR).
 
 You can add it in your web-app `config-[dev|pre|pro]` file as `USE_REDIS_IN_SUI_DECORATORS_CACHE: true`, or as you wish.
 In case you want to pass tests against a real redis server you should set this variable, otherwise tests are running against a mocked redis.
 
 This decorator will look for a `USE_VERSION_NAMESPACE_FOR_REDIS_SUI_DECORATORS_CACHE` variable in the host, `global.USE_VERSION_NAMESPACE_FOR_REDIS_SUI_DECORATORS_CACHE` in SSR. This variable will add a version tag namespace in the cache key stored in Redis, it would be helpful to avoid not cleaned cache entries for different web-app deployed versions. If it's not decalred cache entry will be stored without version namespace in the key.
 
-You can set version in the web-app like this: `global.USE_VERSION_NAMESPACE_FOR_REDIS_SUI_DECORATORS_CACHE = Date.now()`
-
-### Options:
+#### Options:
 
 Common for both LRU and Redis:
 
@@ -181,7 +184,7 @@ Only for Redis:
 
 * redis: desired redis server connection config `@cache({server: true, redis: {host: YOUR_REDIS_HOST, port: YOUR_REDIS_PORT_NUMBER}})`. (default: `undefined`, if `redis={} -> {host: '127.0.0.1', port: 6379}`) Remember `server` flag must be true and `process.env.USE_REDIS_IN_SUI_DECORATORS_CACHE` must be setted to true to connect to the provided redis server.
 
-### How to disable the cache
+#### How to disable the cache
 In some cases we might want to disable the `cache` for certain environment or testing purposes. In that case, we should expose a variable into the global scope as:
 ```
 // For client side

--- a/packages/sui-decorators/README.md
+++ b/packages/sui-decorators/README.md
@@ -80,7 +80,11 @@ person.greetingAsync('Carlos');
 
 ### @cache
 
-Creates a cache of calls to any method of a class.
+There are two types of cache handlers (Memory LRU and Redis LRU):
+
+### Memory LRU cache
+
+Creates a cache of calls to any method of a class, only when the response is not an error.
 
 ```javascript
 import {cache} from '@s-ui/decorators';
@@ -118,15 +122,69 @@ For this method the cache is of 2 seconds.
 It is possible to set TTL using a string with the format `ttl: 'XXX [second|seconds|minute|minutes|hour|hours]'`,
 thus, avoiding writing very large integers.
 
+### Redis LRU cache:
+
+Creates a cache of the decorated method response of a class, only when the response is not an error.
+You must decorate methods that return a promise and its resolved value is a plain javascript object, a json or a simple type (number, string...). 
+
+So if you are using redis cache decorator with [sui-domain extended project](https://github.com/SUI-Components/sui/tree/master/packages/sui-domain) methods, you should decorate `UseCase` classes `execute` methods which are the ones returning plain JSON objects.
+
+````javascript
+import {UseCase} from '@s-ui/domain'
+import {inlineError, cache} from '@s-ui/decorators'
+
+export class GetSeoTagsSearchUseCase extends UseCase {
+  constructor({service, adSearchParamsSearchAggregateFactory}) {
+    super()
+    this._service = service
+  }
+
+  @cache({
+          server: true,
+          ttl: '1 minute',
+          redis: {host: 'localhost', port: 6379}
+        })
+  @inlineError
+  async execute({adSearchParamsAggregate}) {
+    const [seoTagsError, seoTagsResponse] = await this._service.execute({
+      adSearchParamsAggregate
+    })
+
+    if (seoTagsError) {
+      return Promise.reject(seoTagsError)
+    }
+
+    return seoTagsResponse?.toJSON()
+  }
+}
+````
+
+To have redis cache fully working, previously a redis server should be up and running, you must set `server` flag to `true` and provide desired `redis` server connection config: `@cache({server: true, redis: {host: YOUR_REDIS_HOST, port: YOUR_REDIS_PORT_NUMBER}})`, if one of these params is not provided redis cache won't be activated.
+
+To do real requests against your redis server you must set `USE_REDIS_IN_SUI_DECORATORS_CACHE` variable to `true` (`process.env.USE_REDIS_IN_SUI_DECORATORS_CACHE` in SSR).
+
+You can add it in your web-app `config-[dev|pre|pro]` file as `USE_REDIS_IN_SUI_DECORATORS_CACHE: true`, or as you wish.
+In case you want to pass tests against a real redis server you should set this variable, otherwise tests are running against a mocked redis.
+
+This decorator will look for a `USE_VERSION_NAMESPACE_FOR_REDIS_SUI_DECORATORS_CACHE` variable in the host, `global.USE_VERSION_NAMESPACE_FOR_REDIS_SUI_DECORATORS_CACHE` in SSR. This variable will add a version tag namespace in the cache key stored in Redis, it would be helpful to avoid not cleaned cache entries for different web-app deployed versions. If it's not decalred cache entry will be stored without version namespace in the key.
+
+You can set version in the web-app like this: `global.USE_VERSION_NAMESPACE_FOR_REDIS_SUI_DECORATORS_CACHE = Date.now()`
+
 ### Options:
+
+Common for both LRU and Redis:
 
 * ttl: Time to life for each cache register (default: `500ms`)
 
-* server: If the cache will be used in a NodeJS env. Be careful that could break your server. (default: `false`)
+* server: If the cache will be used in a NodeJS env. Be careful that could break your server. You should set it to true if you are adding redis config and want to activate redis cache. (default: `false`)
 
 * algorithm: Which algorithm will be used to discard register in the cache when will be full. For now, only `lru` available. (default: `lru`)
 
-* size: How many register can be in the cache before start to remove register. (default: `100`)
+* size: Maximum number of registers in the cache, when they exceed this number they will be erased (default: `100`)
+
+Only for Redis:
+
+* redis: desired redis server connection config `@cache({server: true, redis: {host: YOUR_REDIS_HOST, port: YOUR_REDIS_PORT_NUMBER}})`. (default: `undefined`, if `redis={} -> {host: '127.0.0.1', port: 6379}`) Remember `server` flag must be true and `process.env.USE_REDIS_IN_SUI_DECORATORS_CACHE` must be setted to true to connect to the provided redis server.
 
 ### How to disable the cache
 In some cases we might want to disable the `cache` for certain environment or testing purposes. In that case, we should expose a variable into the global scope as:

--- a/packages/sui-decorators/README.md
+++ b/packages/sui-decorators/README.md
@@ -134,11 +134,6 @@ import {UseCase} from '@s-ui/domain'
 import {inlineError, cache} from '@s-ui/decorators'
 
 export class GetSeoTagsSearchUseCase extends UseCase {
-  constructor({service, adSearchParamsSearchAggregateFactory}) {
-    super()
-    this._service = service
-  }
-
   @cache({
           server: true,
           ttl: '1 minute',

--- a/packages/sui-decorators/package.json
+++ b/packages/sui-decorators/package.json
@@ -19,12 +19,12 @@
     "perf_hooks": false,
     "hot-shots": false,
     "redis": false,
-    "@s-ui/redis-lru": false
+    "redis-lru": false
   },
   "dependencies": {
     "@s-ui/js": "2",
-    "@s-ui/redis-lru": "1.0.0",
     "redis": "3.0.2",
+    "redis-lru": "0.6.0",
     "tiny-lru": "6.0.1"
   }
 }

--- a/packages/sui-decorators/package.json
+++ b/packages/sui-decorators/package.json
@@ -11,15 +11,20 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "sinon": "2",
-    "hot-shots": "7.0.0"
+    "hot-shots": "7.0.0",
+    "redis-mock": "0.49.0",
+    "sinon": "2"
   },
   "browser": {
     "perf_hooks": false,
-    "hot-shots": false
+    "hot-shots": false,
+    "redis": false,
+    "@s-ui/redis-lru": false
   },
   "dependencies": {
     "@s-ui/js": "2",
+    "@s-ui/redis-lru": "1.0.0",
+    "redis": "3.0.2",
     "tiny-lru": "6.0.1"
   }
 }

--- a/packages/sui-decorators/src/decorators/cache/algorithms/Redis.js
+++ b/packages/sui-decorators/src/decorators/cache/algorithms/Redis.js
@@ -1,7 +1,7 @@
 import Cache from './Cache'
 import redis from 'redis'
 import redisMock from 'redis-mock'
-import lru from '@s-ui/redis-lru'
+import lru from 'redis-lru'
 
 const useRedis = process.env.USE_REDIS_IN_SUI_DECORATORS_CACHE
 

--- a/packages/sui-decorators/src/decorators/cache/algorithms/Redis.js
+++ b/packages/sui-decorators/src/decorators/cache/algorithms/Redis.js
@@ -1,0 +1,46 @@
+import Cache from './Cache'
+import redis from 'redis'
+import redisMock from 'redis-mock'
+import lru from '@s-ui/redis-lru'
+
+const useRedis = process.env.USE_REDIS_IN_SUI_DECORATORS_CACHE
+
+export default class Redis extends Cache {
+  constructor({
+    redisConnection = {host: '127.0.0.1', port: 6379},
+    size = 100,
+    namespace,
+    ttl
+  } = {}) {
+    super()
+    this._ttl = ttl
+    this._redisClient = useRedis
+      ? redis.createClient({
+          port: redisConnection.port,
+          host: redisConnection.host
+        })
+      : redisMock.createClient()
+    this._lruRedis = lru(this._redisClient, {
+      max: size,
+      namespace
+    })
+  }
+
+  get(key) {
+    return this._lruRedis.get(key)
+  }
+
+  /**
+   *
+   * @param {string} key
+   * @param {string} value
+   * @param {number} maxAge expire time in ms, default = 500ms
+   */
+  set(key, value, maxAge = this._ttl) {
+    return this._lruRedis.set(key, value, maxAge)
+  }
+
+  del(key) {
+    this._lruRedis.del(key)
+  }
+}

--- a/packages/sui-decorators/src/decorators/cache/algorithms/Redis.js
+++ b/packages/sui-decorators/src/decorators/cache/algorithms/Redis.js
@@ -10,7 +10,7 @@ export default class Redis extends Cache {
     redisConnection = {host: '127.0.0.1', port: 6379},
     size = 100,
     namespace,
-    ttl
+    ttl = 500
   } = {}) {
     super()
     this._ttl = ttl

--- a/packages/sui-decorators/src/decorators/cache/handlers/inMemory.js
+++ b/packages/sui-decorators/src/decorators/cache/handlers/inMemory.js
@@ -1,0 +1,34 @@
+import {createHash} from '@s-ui/js/lib/hash'
+import isPromise from '../../../helpers/isPromise'
+
+export const inMemory = (target, cache, original, fnName, instance, ttl) => (
+  ...args
+) => {
+  const key = `${target.constructor.name}::${fnName}::${createHash(
+    JSON.stringify(args)
+  )}`
+  const now = Date.now()
+
+  if (cache.get(key) === undefined) {
+    cache.set(key, {createdAt: now, returns: original.apply(instance, args)})
+  }
+
+  if (isPromise(cache.get(key).returns)) {
+    cache
+      .get(key)
+      .returns.then(args => {
+        if (args.__INLINE_ERROR__ && Array.isArray(args) && args[0]) {
+          cache.del(key)
+        }
+      })
+      .catch(() => cache.del(key))
+  }
+
+  if (now - cache.get(key).createdAt > ttl) {
+    cache.del(key)
+  }
+
+  return cache.get(key) !== undefined
+    ? cache.get(key).returns
+    : original.apply(instance, args)
+}

--- a/packages/sui-decorators/src/decorators/cache/handlers/inRedis.js
+++ b/packages/sui-decorators/src/decorators/cache/handlers/inRedis.js
@@ -1,0 +1,51 @@
+import {createHash} from '@s-ui/js/lib/hash'
+
+const VERSION_NAMESPACE_TAG = global.USE_VERSION_NAMESPACE_FOR_REDIS_SUI_DECORATORS_CACHE
+  ? `${global.USE_VERSION_NAMESPACE_FOR_REDIS_SUI_DECORATORS_CACHE}::`
+  : ''
+
+export const inRedis = (
+  target,
+  cache,
+  original,
+  fnName,
+  instance,
+  ttl
+) => async (...args) => {
+  const key = `${VERSION_NAMESPACE_TAG}${createHash(JSON.stringify(args))}`
+
+  const cacheItem = await cache.get(key)
+  let response
+
+  if (!cacheItem) {
+    try {
+      response = await original.apply(instance, args)
+    } catch (err) {
+      console.error(
+        `[sui-decorators/cache]:inRedis Error getting original promise response for key: ${key}`
+      )
+      return err
+    }
+
+    try {
+      const isInlineErrorWithoutError =
+        response.__INLINE_ERROR__ &&
+        Array.isArray(response) &&
+        response[0] === null &&
+        response[1]
+      const noInlineError = response && !response.__INLINE_ERROR__
+
+      if (isInlineErrorWithoutError || noInlineError) {
+        cache.set(key, response, ttl)
+      }
+    } catch (err) {
+      console.error(
+        `[sui-decorators/cache]:inRedis Error setting cache for key: ${key}. Infra error: ${err.message}`
+      )
+    }
+  } else {
+    return cacheItem
+  }
+
+  return response
+}

--- a/packages/sui-decorators/src/decorators/cache/handlers/inRedis.js
+++ b/packages/sui-decorators/src/decorators/cache/handlers/inRedis.js
@@ -22,25 +22,28 @@ export const inRedis = (
       response = await original.apply(instance, args)
     } catch (err) {
       console.error(
-        `[sui-decorators/cache]:inRedis Error getting original promise response for key: ${key}`
+        `[sui-decorators/cache]:inRedis Error getting original promise response for key: ${key}. `,
+        err
       )
       return err
     }
 
     try {
-      const isInlineErrorWithoutError =
-        response.__INLINE_ERROR__ &&
+      const isInlineErrorResponseWithoutError =
         Array.isArray(response) &&
+        response.__INLINE_ERROR__ &&
         response[0] === null &&
         response[1]
-      const noInlineError = response && !response.__INLINE_ERROR__
+      const isNormalResponseWithoutError =
+        response && !response.__INLINE_ERROR__
 
-      if (isInlineErrorWithoutError || noInlineError) {
+      if (isInlineErrorResponseWithoutError || isNormalResponseWithoutError) {
         cache.set(key, response, ttl)
       }
     } catch (err) {
       console.error(
-        `[sui-decorators/cache]:inRedis Error setting cache for key: ${key}. Infra error: ${err.message}`
+        `[sui-decorators/cache]:inRedis Error setting cache for key: ${key}. `,
+        err
       )
     }
   } else {

--- a/packages/sui-decorators/src/decorators/cache/index.js
+++ b/packages/sui-decorators/src/decorators/cache/index.js
@@ -66,7 +66,7 @@ export default ({
 
     if (!isNode && redis) {
       console.warn(
-        '[sui-decorators/cache] Your redis config will be ignored in client site. We are using the default LRU strategy.'
+        '[sui-decorators/cache] Your redis config will be ignored in client site. Using the default LRU strategy.'
       )
     }
 

--- a/packages/sui-decorators/src/decorators/cache/index.js
+++ b/packages/sui-decorators/src/decorators/cache/index.js
@@ -1,10 +1,11 @@
-import {createHash} from '@s-ui/js/lib/hash'
-
 import isNode from '../../helpers/isNode'
-import isPromise from '../../helpers/isPromise'
 import stringOrIntToMs from '../../helpers/stringOrIntToMs'
 
+import {inMemory} from './handlers/inMemory'
+import {inRedis} from './handlers/inRedis'
+
 import LRU from './algorithms/LRU'
+import RedisLRU from './algorithms/Redis'
 
 const ALGORITHMS = {LRU: 'lru'}
 const DEFAULT_TTL = 500
@@ -18,68 +19,55 @@ const _cache = ({
   original,
   size,
   target,
-  ttl
+  ttl,
+  redis
 } = {}) => {
   const cacheKey = `${target.constructor.name}::${fnName}`
 
-  caches[cacheKey] =
-    caches[cacheKey] ||
-    (algorithm === ALGORITHMS.LRU
+  let cache = caches[cacheKey]
+
+  if (!cache) {
+    cache = !redis
       ? new LRU({size})
-      : new Error(`[sui-decorators::cache] unknown algorithm: ${algorithm}`))
-
-  const cache = caches[cacheKey]
-
-  return (...args) => {
-    if (
-      (typeof window !== 'undefined' && window.__SUI_CACHE_DISABLED__) ||
-      (typeof global !== 'undefined' && global.__SUI_CACHE_DISABLED__)
-    ) {
-      return original.apply(instance, args)
-    }
-
-    const key = `${target.constructor.name}::${fnName}::${createHash(
-      JSON.stringify(args)
-    )}`
-    const now = Date.now()
-
-    if (cache.get(key) === undefined) {
-      cache.set(key, {createdAt: now, returns: original.apply(instance, args)})
-    }
-
-    if (isPromise(cache.get(key).returns)) {
-      cache
-        .get(key)
-        .returns.then(args => {
-          if (args.__INLINE_ERROR__ && Array.isArray(args) && args[0]) {
-            cache.del(key)
-          }
-        })
-        .catch(() => cache.del(key))
-    }
-
-    if (now - cache.get(key).createdAt > ttl) {
-      cache.del(key)
-    }
-
-    return cache.get(key) !== undefined
-      ? cache.get(key).returns
-      : original.apply(instance, args)
+      : new RedisLRU({size, redisConnection: redis, namespace: cacheKey, ttl})
   }
+
+  if (isNode && redis) {
+    console.warn(
+      `[sui-decorators/cache] You are using redis cache for cacheKey: ${cacheKey}, your method MUST return a promise`
+    )
+    return inRedis(target, cache, original, fnName, instance, ttl)
+  }
+
+  return inMemory(target, cache, original, fnName, instance, ttl)
 }
 
 export default ({
   ttl = DEFAULT_TTL,
   server = false,
   algorithm = ALGORITHMS.LRU,
-  size
+  size,
+  redis
 } = {}) => {
   const timeToLife = stringOrIntToMs({ttl}) || DEFAULT_TTL
   return (target, fnName, descriptor) => {
+    if (
+      (typeof window !== 'undefined' && window.__SUI_CACHE_DISABLED__) ||
+      (typeof global !== 'undefined' && global.__SUI_CACHE_DISABLED__)
+    ) {
+      return descriptor
+    }
+
     // if we're on node but the decorator doesn't have the server flag
     // then we ignore the usage of the decorator and thus the cache
     if (isNode && !server) {
       return descriptor
+    }
+
+    if (!isNode && redis) {
+      console.warn(
+        '[sui-decorators/cache] Your redis config will be ignored in client site. We are using the default LRU strategy.'
+      )
     }
 
     const {configurable, enumerable, writable} = descriptor
@@ -105,7 +93,8 @@ export default ({
             original: fn,
             size,
             target,
-            ttl: timeToLife
+            ttl: timeToLife,
+            redis
           })
 
           Object.defineProperty(this, fnName, {

--- a/packages/sui-decorators/test/server/cacheSpec.js
+++ b/packages/sui-decorators/test/server/cacheSpec.js
@@ -148,7 +148,7 @@ describe('Cache in the server', () => {
     beforeEach(done => {
       redis.flushdb(() => done())
     })
-    it('should not apply cache for inlineError decorated error response and apply cache for ok simple random number response', async () => {
+    it('should apply cache for ok simple random number response and not apply cache for inlineError decorated error response', async () => {
       let shouldReturnError = true
 
       class YummyAsync {
@@ -186,7 +186,7 @@ describe('Cache in the server', () => {
       expect(responseSecond[1]).to.be.eql(responseFourth[1])
     })
 
-    it('should not apply cache for inlineError decorated error response and apply cache for complex json response', async () => {
+    it('should apply cache for a complex json response and not apply cache for inlineError decorated error response', async () => {
       let shouldReturnError = true
 
       class YummyAsync {
@@ -229,7 +229,7 @@ describe('Cache in the server', () => {
       expect(responseSecond[1]).to.be.eql(responseFourth[1])
     })
 
-    it('should not apply cache for inlineError decorated error response and not apply cache for expired ttl complex json response', done => {
+    it('should not apply cache for expired ttl complex json response', done => {
       class YummyAsync {
         @cache({
           server: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Add Redis cache decorator
After adding memory server cache for multiple requests at milanuncios listing, we noticed the SSR node server was running out of memory. So we thought using a Redis cache would work better for this.

- Create two cache handlers: `inMemory` and `InRedis`. Redis cache will only work in SSR, for client-side, it would work with `inMemory` cache.

- Create a Redis client using Redis LRU cache algorithm.

- Testing

Check the readme for more details.
