### PR TITLE
[Feature] sui tests add new flags

### DIFF
--- a/packages/sui-test/README.md
+++ b/packages/sui-test/README.md
@@ -137,6 +137,8 @@ Then you can use in your specs `cy.login()`
     -G, --gui                                Run the tests in GUI mode.
     -C, --ci                                 CI Mode, reduces memory consumption
     -h, --help                               output usage information
+    -b, --browser <browser>                  Select a different browser (chrome|edge|firefox)
+    -N, --noWebSecurity                      Disable all web securities (CORS)
 ```
 
 #### `sui-test e2e --gui`

--- a/packages/sui-test/bin/sui-test-e2e.js
+++ b/packages/sui-test/bin/sui-test-e2e.js
@@ -46,6 +46,10 @@ program
     'Overwrite string to UserAgent header.'
   )
   .option('-s, --scope <spec>', 'Run tests specifying a subfolder of specs')
+  .option(
+    '-b, --browser <browser>',
+    'Select a different browser (chrome|edge|firefox)'
+  )
   .option('-G, --gui', 'Run the tests in GUI mode.')
   .option('-R, --record', 'Record tests and send result to Dashboard Service')
   .option('-C, --ci', 'Continuos integration mode, reduces memory consumption')
@@ -65,7 +69,8 @@ const {
   scope,
   record,
   key,
-  ci
+  ci,
+  browser
 } = program
 const cypressConfig = {
   integrationFolder: path.join(TESTS_FOLDER, scope || ''),
@@ -99,6 +104,7 @@ resolveLazyNPMBin('cypress/bin/cypress', `cypress@${CYPRESS_VERSION}`)
       gui ? 'open' : 'run',
       '--config=' + objectToCommaString(cypressConfig),
       '--project=' + CYPRESS_FOLDER_PATH,
+      browser && '--browser=' + browser,
       record && '--record',
       key && '--key=' + key
     ])

--- a/packages/sui-test/bin/sui-test-e2e.js
+++ b/packages/sui-test/bin/sui-test-e2e.js
@@ -2,6 +2,7 @@
 /* eslint no-console:0 */
 
 const path = require('path')
+const os = require('os')
 const program = require('commander')
 const fs = require('fs')
 const {getSpawnPromise, showError} = require('@s-ui/helpers/cli')
@@ -50,6 +51,7 @@ program
     '-b, --browser <browser>',
     'Select a different browser (chrome|edge|firefox)'
   )
+  .option('-N, --noWebSecurity', 'Disable all web securities')
   .option('-G, --gui', 'Run the tests in GUI mode.')
   .option('-R, --record', 'Record tests and send result to Dashboard Service')
   .option('-C, --ci', 'Continuos integration mode, reduces memory consumption')
@@ -70,7 +72,8 @@ const {
   record,
   key,
   ci,
-  browser
+  browser,
+  noWebSecurity
 } = program
 const cypressConfig = {
   integrationFolder: path.join(TESTS_FOLDER, scope || ''),
@@ -98,12 +101,30 @@ if (ci) {
   cypressConfig.numSnapshotsKeptInMemory = 1
 }
 
+let projectURI = CYPRESS_FOLDER_PATH
+if (noWebSecurity) {
+  const defaultConfig = require(path.join(CYPRESS_FOLDER_PATH, 'cypress.json'))
+  const nextCypressConfig = {
+    ...defaultConfig,
+    chromeWebSecurity: false
+  }
+
+  const nextFolderPath = path.join(os.tmpdir(), '' + Date.now())
+  fs.mkdirSync(nextFolderPath)
+  fs.writeFileSync(
+    path.join(nextFolderPath, 'cypress.json'),
+    JSON.stringify(nextCypressConfig, null, 2),
+    'utf8'
+  )
+  projectURI = nextFolderPath
+}
+
 resolveLazyNPMBin('cypress/bin/cypress', `cypress@${CYPRESS_VERSION}`)
   .then(cypressBinPath =>
     getSpawnPromise(cypressBinPath, [
       gui ? 'open' : 'run',
       '--config=' + objectToCommaString(cypressConfig),
-      '--project=' + CYPRESS_FOLDER_PATH,
+      '--project=' + projectURI,
       browser && '--browser=' + browser,
       record && '--record',
       key && '--key=' + key


### PR DESCRIPTION
There is a need in UniqTools to be able to run E2E tests without Cors and in various browsers.
For them we have added two new flags:

--noWebSecurity
--browser

Example of use:

```
λ npx sui-test e2e --noWebSecurity --baseUrl=http://localhost:3000 --gui --browser firefox
```

Pending update of README

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sui-components/sui/843)
<!-- Reviewable:end -->
