### PR TITLE
fix(sui-svg): sui svg must keep atomIcon display name in order to not…

### DIFF
--- a/packages/sui-svg/templates/icon-component.js
+++ b/packages/sui-svg/templates/icon-component.js
@@ -2,7 +2,10 @@ const template = (code, config, state) => {
   return `import React, {memo} from 'react'
 import AtomIcon from '@s-ui/react-atom-icon'
 
-export default memo(props => <AtomIcon {...props}>${code}</AtomIcon>)
+const MemoAtomIcon = memo(props => <AtomIcon {...props}>${code}</AtomIcon>)
+MemoAtomIcon.displayName = 'AtomIcon'
+
+export default MemoAtomIcon
 `
 }
 


### PR DESCRIPTION
… break atom button implementation.

<!--- Provide a general summary of your changes in the Title above -->

## Description
AtomButton uses AtomIcon display name for check if received icon is an AtomIcon or not in order to fix it size.
👀 See:
https://github.com/SUI-Components/sui-components/blob/master/components/atom/button/src/ButtonIcon.js
```
const isAtomIcon = icon => icon?.type?.displayName === ATOM_ICON_DISPLAY_NAME

const prepareAtomIcon = (atomIconElement, {size}) => {
  const atomIconSize = ATOM_ICON_SIZES_MAPPER[size]
  return React.cloneElement(atomIconElement, {
    color: undefined,
    size: atomIconSize
  })
}
```
The problem is that without displayName, Button Icon always uses default size and is not good for large size buttons.

SUI-SVG uses a template in order to wrap all svg with AtomIcon. In this template we use `React.memo()` and memo wraps the component with a function and this "new" function does not has child displayName.
