### PR TITLE
fix(sui-react-router): avoid not needed re-renders

### DIFF
--- a/packages/sui-react-router/src/Router.js
+++ b/packages/sui-react-router/src/Router.js
@@ -60,11 +60,17 @@ const Router = ({
   const [state, setState] = useState({router, params, components})
 
   useEffect(() => {
+    let prevState = {}
     const handleTransition = (err, nextState) => {
       if (err) {
         if (onError) return onError(err)
         throw err
       }
+
+      // avoid not needed re-renders of the state if the prevState and the nextState
+      // are the same reference
+      if (prevState === nextState) return
+      prevState = nextState
 
       const {components, params, location, routes} = nextState
       const nextRouter = {...state.router, params, location, routes}


### PR DESCRIPTION
Create a prevState reference to compare with the nextState so we avoid updating the state (and cause a re-render of the app) if it's not needed.