### PR TITLE
feat(sui-widget-embedder): allow multiple containers for single Widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "test:server:watch": "npm run test:server -- --watch",
     "wiki:pull": "git subtree pull --prefix=.wiki https://github.com/SUI-Components/sui.wiki.git master --squash",
     "wiki:push": "git subtree push --prefix=.wiki https://github.com/SUI-Components/sui.wiki.git master",
-    "commitmsg": "validate-commit-msg",
-    "precommit": "sui-precommit run"
+    "commitmsg": "validate-commit-msg"
   },
   "devDependencies": {
     "@babel/cli": "7.8.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:server:watch": "npm run test:server -- --watch",
     "wiki:pull": "git subtree pull --prefix=.wiki https://github.com/SUI-Components/sui.wiki.git master --squash",
     "wiki:push": "git subtree push --prefix=.wiki https://github.com/SUI-Components/sui.wiki.git master",
-    "commitmsg": "validate-commit-msg"
+    "commitmsg": "validate-commit-msg",
+    "precommit": "sui-precommit run"
   },
   "devDependencies": {
     "@babel/cli": "7.8.3",

--- a/packages/sui-widget-embedder/README.md
+++ b/packages/sui-widget-embedder/README.md
@@ -117,7 +117,7 @@ import render from '@s-ui/widget-embedder/react/render'
   * `children` *(required)*: Content of the Widget. Should be a compatible React Element.
   * `domain`: Domain library for your widgets
   * `i18n`: I18n library
-  * `isVisible` *(required - default: true)*: Determine if the widget must be shown.
+  * `isVisible` *(default: true)*: Determine if the widget must be shown.
   * `node` *(deprecated)*: css path that indicates where you want create the new React tree. If that node doesnt exist in the current page you will get a warning in the console.
   * `renderMultiple` *(default: false)*: Determine if the Widget must be rendered on every node found using the selector prop (or deprecated `node` prop). If `false` the Widget will be rendered only in the first node found.
   * `selector`: *(required)* CSS Path to select the node (or nodes) where you want to render the Widget.

--- a/packages/sui-widget-embedder/README.md
+++ b/packages/sui-widget-embedder/README.md
@@ -68,10 +68,10 @@ Note that the quotes here are not 'optional' you can add an expresion without qu
 
 Inside your project-level package.json, you could config the library,
 
-- alias [OPTIONAL]: create aliases to `import` certain modules more easily or to avoid importing them in production.
-- remoteCdn [OPTIONAL] (default: `'/'`): the base path of the cdn where your assets will be located.
-- devPort [OPTIONAL] (default: `3000`): Port where your development server will be listening.
-- manualCompression [OPTIONAL] (default: false): Compress files manually with gzip and brotli to be served via CDN
+- `alias` [OPTIONAL]: create aliases to `import` certain modules more easily or to avoid importing them in production.
+- `remoteCdn` [OPTIONAL] (default: `'/'`): the base path of the cdn where your assets will be located.
+- `devPort` [OPTIONAL] (default: `3000`): Port where your development server will be listening.
+- `manualCompression` [OPTIONAL] (default: false): Compress files manually with gzip and brotli to be served via CDN
 
 ### Page config
 
@@ -92,30 +92,35 @@ Inside each page you must create a package.json file.
 }
 ```
 
-- pathnameRegExp [*REQUIRED]: RegExp or array of RegExp as strings to identify the pathname of the page where this list of widgets must work. In case of array of RegExp, the widget will load if at least one RegExp matches with the current location.
-- hrefRegExp [*REQUIRED]: RegExp or array of RegExp as strings to identify the href of the page where this list of widgets must work. In case of array of RegExp, the widget will load if at least one RegExp matches with the current location.
-- blacklistedRegExps [OPTIONAL]: List of RegExps to identify the pathname of the pages where the widgets don't have to work at.
-- vendor [OPTIONAL]: In case you want to have a vendor file for this page only.
+- `pathnameRegExp` [*REQUIRED]: RegExp or array of RegExp as strings to identify the pathname of the page where this list of widgets must work. In case of array of RegExp, the widget will load if at least one RegExp matches with the current location.
+- `hrefRegExp` [*REQUIRED]: RegExp or array of RegExp as strings to identify the href of the page where this list of widgets must work. In case of array of RegExp, the widget will load if at least one RegExp matches with the current location.
+- `blacklistedRegExps` [OPTIONAL]: List of RegExps to identify the pathname of the pages where the widgets don't have to work at.
+- `vendor` [OPTIONAL]: In case you want to have a vendor file for this page only.
 (*) It's required just one of these two fields: pathnameRegExp or hrefRegExp
 
 ## Working with React
 
 sui-widget-embedder does not expect to work with React. But if you want to create your widgets as React trees in your page, there are 3 helper utilities:
 
-```
+```js
 import Widget from '@s-ui/widget-embedder/react/Widget'
 import Widgets from '@s-ui/widget-embedder/react/Widgets'
 import render from '@s-ui/widget-embedder/react/render'
 ```
 
-- render: A method that expects a tree of React components starting with a Widgets root
-- Widgets: React component that encapsules all your widgets
-- Widget: React component that renders the children as a new React tree in another place of the page.
-  * `children`: Content of the Widget. Should be a compatible React Element.
-  * `i18n`: I18n library
+- `render`: A method that expects a tree of React components starting with a Widgets root.
+
+- `Widgets`: React Component that encapsules all your widgets.
+
+- `Widget`: React Component that renders the children as a new React tree in another place of the page. Available props:
+  * `browser`: Browser object with useful info about the browser of the User Agent.
+  * `children` *(required)*: Content of the Widget. Should be a compatible React Element.
   * `domain`: Domain library for your widgets
-  * 
+  * `i18n`: I18n library
+  * `isVisible` *(required - default: true)*: Determine if the widget must be shown.
   * `node` *(deprecated)*: css path that indicates where you want create the new React tree. If that node doesnt exist in the current page you will get a warning in the console.
+  * `renderMultiple` *(default: false)*: Determine if the Widget must be rendered on every node found using the selector prop (or deprecated `node` prop). If `false` the Widget will be rendered only in the first node found.
+  * `selector`: *(required)* CSS Path to select the node (or nodes) where you want to render the Widget.
 
 ## How to develop
 

--- a/packages/sui-widget-embedder/README.md
+++ b/packages/sui-widget-embedder/README.md
@@ -111,9 +111,11 @@ import render from '@s-ui/widget-embedder/react/render'
 - render: A method that expects a tree of React components starting with a Widgets root
 - Widgets: React component that encapsules all your widgets
 - Widget: React component that renders the children as a new React tree in another place of the page.
-  ** i18n: I18n library
-  ** domain: Domain library for your widgets
-  \*\* node: css path that indicates where you want create the new React tree. If that node doesnt exist in the current page you will get a warning in the console.
+  * `children`: Content of the Widget. Should be a compatible React Element.
+  * `i18n`: I18n library
+  * `domain`: Domain library for your widgets
+  * 
+  * `node` *(deprecated)*: css path that indicates where you want create the new React tree. If that node doesnt exist in the current page you will get a warning in the console.
 
 ## How to develop
 

--- a/packages/sui-widget-embedder/package.json
+++ b/packages/sui-widget-embedder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/widget-embedder",
-  "version": "3.13.0-beta.0",
+  "version": "3.13.0-beta.1",
   "description": "",
   "bin": {
     "sui-widget-embedder": "./bin/sui-widget-embedder.js"

--- a/packages/sui-widget-embedder/package.json
+++ b/packages/sui-widget-embedder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/widget-embedder",
-  "version": "3.13.0-beta.1",
+  "version": "3.12.0",
   "description": "",
   "bin": {
     "sui-widget-embedder": "./bin/sui-widget-embedder.js"

--- a/packages/sui-widget-embedder/package.json
+++ b/packages/sui-widget-embedder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/widget-embedder",
-  "version": "3.12.0",
+  "version": "3.13.0-beta.0",
   "description": "",
   "bin": {
     "sui-widget-embedder": "./bin/sui-widget-embedder.js"
@@ -18,6 +18,7 @@
     "@s-ui/helpers": "1",
     "@s-ui/react-context": "1",
     "@s-ui/react-domain-connector": "1",
+    "@s-ui/react-hooks": "1",
     "commander": "2.11.0",
     "copy-paste": "1.3.0",
     "iltorb": "2.4.3",

--- a/packages/sui-widget-embedder/src-react/Widget.js
+++ b/packages/sui-widget-embedder/src-react/Widget.js
@@ -54,9 +54,13 @@ export default function Widget({
 
 Widget.propTypes = {
   browser: PropTypes.object,
-  children: PropTypes.element,
+  children: PropTypes.element.isRequired,
   domain: PropTypes.object,
   i18n: PropTypes.object,
   isVisible: PropTypes.bool,
-  node: PropTypes.string
+  node: () =>
+    new Error(
+      'Prop `node` is deprecated and it will be removed in the next major version. Use `selector` instead for passing the CSS Path.'
+    ),
+  selector: PropTypes.string.isRequired
 }

--- a/packages/sui-widget-embedder/src-react/Widget.js
+++ b/packages/sui-widget-embedder/src-react/Widget.js
@@ -30,14 +30,14 @@ export default function Widget({
     const selectorToUse = selector || node
     if (!selectorToUse) {
       return console.warn(
-        `[Widget] You must define a selector or node to use the Widget`
+        `[Widget] You must define a selector or node (deprecated) to use the Widget`
       )
     }
 
     const nodes = document.querySelectorAll(selectorToUse)
     if (!nodes.length) {
       return console.warn(
-        `[Widget] unable find nodes using selector ${selector}`
+        `[Widget] unable find nodes using selector ${selectorToUse}`
       )
     }
     // depending on renderMultiple, get the full array or only the first one
@@ -53,10 +53,10 @@ export default function Widget({
 }
 
 Widget.propTypes = {
+  browser: PropTypes.object,
   children: PropTypes.element,
-  node: PropTypes.string,
-  i18n: PropTypes.object,
   domain: PropTypes.object,
+  i18n: PropTypes.object,
   isVisible: PropTypes.bool,
-  browser: PropTypes.object
+  node: PropTypes.string
 }

--- a/packages/sui-widget-embedder/src-react/Widget.js
+++ b/packages/sui-widget-embedder/src-react/Widget.js
@@ -41,7 +41,7 @@ export default function Widget({
       )
     }
     // depending on renderMultiple, get the full array or only the first one
-    const nodesToRender = renderMultiple ? [...nodes] : [nodes[0]]
+    const nodesToRender = renderMultiple ? [].slice.call(nodes) : [nodes[0]]
     // create the context object
     const context = {browser, domain, i18n}
 

--- a/packages/sui-widget-embedder/src-react/Widget.js
+++ b/packages/sui-widget-embedder/src-react/Widget.js
@@ -1,56 +1,62 @@
-import React, {Component} from 'react'
+/* eslint-disable no-console */
+
+import React from 'react'
 import PropTypes from 'prop-types'
 import ReactDOM from 'react-dom'
 import Context from '@s-ui/react-context'
 import {Provider as ProviderLegacy} from '@s-ui/react-domain-connector'
+import {useMount} from '@s-ui/react-hooks'
 
-export default class Widget extends Component {
-  static propTypes = {
-    children: PropTypes.element,
-    node: PropTypes.string,
-    i18n: PropTypes.object,
-    domain: PropTypes.object,
-    isVisible: PropTypes.bool,
-    browser: PropTypes.object
-  }
+function renderWidgetOnDOM({children, context, node}) {
+  ReactDOM.render(
+    <Context.Provider value={context}>
+      <ProviderLegacy {...context}>{children}</ProviderLegacy>
+    </Context.Provider>,
+    node
+  )
+}
 
-  static defaultProps = {
-    isVisible: true
-  }
-
-  componentDidMount() {
-    const {
-      node: selector,
-      children,
-      i18n,
-      domain,
-      isVisible,
-      browser
-    } = this.props
-    const node = document.querySelector(selector)
-
-    if (!node) {
-      return console.warn(`[Widget] unable find the selector ${selector}`) // eslint-disable-line
+export default function Widget({
+  browser,
+  children,
+  domain,
+  i18n,
+  isVisible = true,
+  node, // deprecated
+  selector,
+  renderMultiple = false
+}) {
+  useMount(function() {
+    const selectorToUse = selector || node
+    if (!selectorToUse) {
+      return console.warn(
+        `[Widget] You must define a selector or node to use the Widget`
+      )
     }
 
-    isVisible &&
-      ReactDOM.render(
-        <Context.Provider
-          value={{
-            i18n,
-            domain,
-            browser
-          }}
-        >
-          <ProviderLegacy i18n={i18n} domain={domain} browser={browser}>
-            {children}
-          </ProviderLegacy>
-        </Context.Provider>,
-        node
+    const nodes = document.querySelectorAll(selectorToUse)
+    if (!nodes.length) {
+      return console.warn(
+        `[Widget] unable find nodes using selector ${selector}`
       )
-  }
+    }
+    // depending on renderMultiple, get the full array or only the first one
+    const nodesToRender = renderMultiple ? [...nodes] : [nodes[0]]
+    // create the context object
+    const context = {browser, domain, i18n}
 
-  render() {
-    return null
-  }
+    isVisible &&
+      nodesToRender.map(node => renderWidgetOnDOM({children, context, node}))
+  })
+
+  return null
+}
+
+Widget.propTypes = {
+  children: PropTypes.element,
+  node: PropTypes.string,
+  i18n: PropTypes.object,
+  domain: PropTypes.object,
+  isVisible: PropTypes.bool,
+  browser: PropTypes.object
 }


### PR DESCRIPTION
We've found in Fotocasa that sometimes we want to render the same Widget in, for example, a list of cards. So we're adding a way to render the same component over different HTML nodes while keeping the old compatibility.

- [x] Deprecate the old `node` prop was not correct semantically and now is misleading.
- [x] Allow multiple containers by using a new prop `selector`.
- [x] Add new prop `renderMultiple` to render the widget to all the nodes found using the `selector`. 
- [x] Update README with the new props and fixing old as well.