### PR TITLE
feat(sui-i18n): add percentage formatting capability to i18n

### DIFF
--- a/packages/sui-i18n/src/i18n.js
+++ b/packages/sui-i18n/src/i18n.js
@@ -107,6 +107,14 @@ export default class Rosetta {
     throw new Error(`Invalid type '${type}' passed to i18n.f`)
   }
 
+  formatPercentage(value) {
+    return this.f('percentage', value)
+  }
+
+  formatPhone(phoneNumber) {
+    return this.f('phone', phoneNumber)
+  }
+
   url(urlPattern, allowQueryParams) {
     return urlPattern
       .split('/')

--- a/packages/sui-i18n/src/i18n.js
+++ b/packages/sui-i18n/src/i18n.js
@@ -89,10 +89,11 @@ export default class Rosetta {
 
     switch (type) {
       case 'percentage': {
-        const {minimumFractionDigits = 0} = options
+        const {minimumFractionDigits = 0, maximumFractionDigits = 2} = options
         return this.n(value / 100, {
           style: 'percent',
-          minimumFractionDigits
+          minimumFractionDigits,
+          maximumFractionDigits
         })
       }
       case 'phone': {

--- a/packages/sui-i18n/src/i18n.js
+++ b/packages/sui-i18n/src/i18n.js
@@ -73,6 +73,14 @@ export default class Rosetta {
     })
   }
 
+  // Format percentage number.
+  p(number, minimumFractionDigits = 0) {
+    return this.n(number / 100, {
+      style: 'percent',
+      minimumFractionDigits
+    })
+  }
+
   /**
    * Format minor types.
    *

--- a/packages/sui-i18n/src/i18n.js
+++ b/packages/sui-i18n/src/i18n.js
@@ -108,12 +108,12 @@ export default class Rosetta {
     throw new Error(`Invalid type '${type}' passed to i18n.f`)
   }
 
-  formatPercentage(value) {
-    return this.f('percentage', value)
+  formatPercentage(value, options) {
+    return this.f('percentage', value, options)
   }
 
-  formatPhone(phoneNumber) {
-    return this.f('phone', phoneNumber)
+  formatPhone(phoneNumber, options) {
+    return this.f('phone', phoneNumber, options)
   }
 
   url(urlPattern, allowQueryParams) {

--- a/packages/sui-i18n/src/i18n.js
+++ b/packages/sui-i18n/src/i18n.js
@@ -73,14 +73,6 @@ export default class Rosetta {
     })
   }
 
-  // Format percentage number.
-  p(number, minimumFractionDigits = 0) {
-    return this.n(number / 100, {
-      style: 'percent',
-      minimumFractionDigits
-    })
-  }
-
   /**
    * Format minor types.
    *
@@ -96,6 +88,13 @@ export default class Rosetta {
       throw new Error('i18n.f should receive any value as a second argument')
 
     switch (type) {
+      case 'percentage': {
+        const {minimumFractionDigits = 0} = options
+        return this.n(value / 100, {
+          style: 'percent',
+          minimumFractionDigits
+        })
+      }
       case 'phone': {
         const {separator = ' '} = options
         return value

--- a/packages/sui-i18n/test/i18nSpec.js
+++ b/packages/sui-i18n/test/i18nSpec.js
@@ -166,15 +166,15 @@ describe('I18N', () => {
             )
           })
 
-          it('from agglomerated digits', () => {
+          it('from agglomerated digits, using the formatPhone method', () => {
             expect(i18n.formatPhone('123123123')).to.eql('123 123 123')
           })
 
-          it('from wrong spaced groups', () => {
+          it('from wrong spaced groups, using the formatPhone method', () => {
             expect(i18n.formatPhone('1 23 12312 3')).to.eql('123 123 123')
           })
 
-          it('with custom separator', () => {
+          it('with custom separator, using the formatPhone method', () => {
             expect(i18n.formatPhone('123123123', {separator: '-'})).to.eql(
               '123-123-123'
             )

--- a/packages/sui-i18n/test/i18nSpec.js
+++ b/packages/sui-i18n/test/i18nSpec.js
@@ -135,11 +135,20 @@ describe('I18N', () => {
 
       describe('properly formats minor types like', () => {
         describe('percentage', () => {
-          it('from a non-decimal amount', () => {
+          it('from a non-decimal amount when ', () => {
             expect(i18n.f('percentage', 10)).to.eql('10\xa0%')
           })
+
           it('from a decimal amount', () => {
             expect(i18n.f('percentage', 12.34)).to.eql('12,34\xa0%')
+          })
+
+          it('from a non-decimal amount, using the formatPercentage method', () => {
+            expect(i18n.formatPercentage(10)).to.eql('10\xa0%')
+          })
+
+          it('from a decimal amount, using the formatPercentage method', () => {
+            expect(i18n.formatPercentage(12.34)).to.eql('12,34\xa0%')
           })
         })
         describe('phone', () => {
@@ -153,6 +162,20 @@ describe('I18N', () => {
 
           it('with custom separator', () => {
             expect(i18n.f('phone', '123123123', {separator: '-'})).to.eql(
+              '123-123-123'
+            )
+          })
+
+          it('from agglomerated digits', () => {
+            expect(i18n.formatPhone('123123123')).to.eql('123 123 123')
+          })
+
+          it('from wrong spaced groups', () => {
+            expect(i18n.formatPhone('1 23 12312 3')).to.eql('123 123 123')
+          })
+
+          it('with custom separator', () => {
+            expect(i18n.formatPhone('123123123', {separator: '-'})).to.eql(
               '123-123-123'
             )
           })

--- a/packages/sui-i18n/test/i18nSpec.js
+++ b/packages/sui-i18n/test/i18nSpec.js
@@ -134,6 +134,14 @@ describe('I18N', () => {
       })
 
       describe('properly formats minor types like', () => {
+        describe('percentage', () => {
+          it('from a non-decimal amount', () => {
+            expect(i18n.f('percentage', 10)).to.eql('10\xa0%')
+          })
+          it('from a decimal amount', () => {
+            expect(i18n.f('percentage', 12.34)).to.eql('12,34\xa0%')
+          })
+        })
         describe('phone', () => {
           it('from agglomerated digits', () => {
             expect(i18n.f('phone', '123123123')).to.eql('123 123 123')


### PR DESCRIPTION
Currently on our `i18n` we don't provide with a method to format percentages. 

## Description
This `PR` adds a new method `.p()` that adds a percentage sign to the number we pass on as a value.

## Example
`console.log(i18n.p(69));`

would tipically output:
`69 %`
