### PR TITLE
[sui-decorators] Reuse cache instances

### DIFF
--- a/packages/sui-decorators/src/decorators/cache/index.js
+++ b/packages/sui-decorators/src/decorators/cache/index.js
@@ -38,6 +38,7 @@ const _cache = ({
       namespace: cacheKey,
       ttl
     })
+    caches[cacheKey] = cache
   }
 
   if (!cache && shouldUseMemoryCache) {
@@ -46,6 +47,7 @@ const _cache = ({
         '[sui-decorators/cache] Your redis config will be ignored in client side. Using the default inMemory LRU strategy.'
       )
     cache = new LRU({size})
+    caches[cacheKey] = cache
   }
 
   return shouldUseRedisCache

--- a/packages/sui-decorators/test/server/cacheSpec.js
+++ b/packages/sui-decorators/test/server/cacheSpec.js
@@ -23,7 +23,7 @@ describe('Cache in the server', () => {
       expect(buzz.syncRndNumber()).to.be.not.eql(buzz.syncRndNumber())
     })
 
-    it('should apply cache if server param is true', () => {
+    it('should apply cache if server param is true for different instances', () => {
       class Buzz1 {
         constructor() {
           this.rnd = () => Math.random()
@@ -31,11 +31,14 @@ describe('Cache in the server', () => {
 
         @cache({server: true})
         syncRndNumber() {
-          return this.rnd()
+          const rnd = this.rnd()
+          return rnd
         }
       }
-      const buzz1 = new Buzz1()
-      expect(buzz1.syncRndNumber()).to.be.eql(buzz1.syncRndNumber())
+      const buzz11 = new Buzz1()
+      const buzz12 = new Buzz1()
+
+      expect(buzz11.syncRndNumber()).to.be.eql(buzz12.syncRndNumber())
     })
 
     it('with inlineError should apply cache if server param is true', () => {


### PR DESCRIPTION
We added a fix to the sui-decorators, to manage the same method in different instances of the class.
