### PR TITLE
[sui-bundler] Avoid load source maps

### DIFF
--- a/packages/sui-bundler/bin/sui-bundler-build.js
+++ b/packages/sui-bundler/bin/sui-bundler-build.js
@@ -117,7 +117,8 @@ webpack(nextConfig).run((error, stats) => {
       'runtime~', // webpack's runtime chunks are not meant to be cached
       '.gz', // avoid gzipped files
       '.br', // avoid brotli files
-      'LICENSE.txt' // avoid LICENSE files
+      'LICENSE.txt', // avoid LICENSE files
+      '.map' // source maps
     ]
     const manifestStatics = Object.values(manifest).filter(
       url => !rulesOfFilesToNotCache.some(rule => url.includes(rule))


### PR DESCRIPTION
We don't need to load the SourceMaps files when installing on ServiceWorker

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sui-components/sui/865)
<!-- Reviewable:end -->
