### PR TITLE
fix(sui-ssr): fix node version to 14-alpine in dockerfile.tpl

### DIFF
--- a/packages/sui-ssr/archive/Dockerfile.tpl
+++ b/packages/sui-ssr/archive/Dockerfile.tpl
@@ -1,4 +1,4 @@
-FROM keymetrics/pm2:latest-alpine
+FROM keymetrics/pm2:14-alpine
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
## Description
fix node version to 14-alpine in dockerfile.tpl

## Background
Deploy pipelines are blocked because the `pm2:latest-alpine` is installing the node v 14.5.0 and this version is making pods fail when they try to start.
