### PR TITLE
[sui-dashboard] Use serial spawn over parallel

### DIFF
--- a/packages/sui-dashboard/bin/sui-dashboard-components.js
+++ b/packages/sui-dashboard/bin/sui-dashboard-components.js
@@ -4,7 +4,7 @@
 const os = require('os')
 const path = require('path')
 const program = require('commander')
-const {parallelSpawn} = require('@s-ui/helpers/cli')
+const {parallelSpawn, serialSpawn} = require('@s-ui/helpers/cli')
 const {stats} = require('../src')
 
 program
@@ -88,7 +88,7 @@ const installCommands = repositories.map(repo => [
 ;(async () => {
   await parallelSpawn(cloneSUIComponentsCommand)
   await parallelSpawn(cloneCommands)
-  await parallelSpawn(installCommands)
+  await serialSpawn(installCommands)
   const statsComponents = await stats({repositories, root: WORK_DIRECTORY})
 
   console.log(statsComponents)


### PR DESCRIPTION
We are seeing some instability when installing the packages before displaying the SUI metrics. We hope that by running the installations in series rather than in parallel, we will eliminate those bugs.

The cost in time is almost double:

```
Serie:

real	12m57.145s
user	6m29.825s
sys	2m41.791s

Parallel:

real	5m47.174s
user	7m26.293s
sys	2m49.787s
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sui-components/sui/888)
<!-- Reviewable:end -->
