### PR TITLE
Feat/cache decorator add cache key string param

### DIFF
--- a/packages/sui-decorators/README.md
+++ b/packages/sui-decorators/README.md
@@ -180,7 +180,7 @@ Common for both LRU and Redis:
 
 * size: Maximum number of registers in the cache, when they exceed this number they will be erased (default: `100`)
 
-* cacheKeyString: String param containing cache key(it must be unique). It is useful to define a fixed cache key(constructor name + function name, e.g. `cacheKeyString: GetAdListSearchUseCase#execute`) and avoid problems with code minification. By default the following cache key will be created for  each `${target.constructor.name}::${fnName}` (default: `undefined`)
+* cacheKeyString: String param containing cache key(it must be unique). It is useful to define a fixed cache key(constructor name + function name, e.g. `cacheKeyString: GetAdListSearchUseCase#execute`) and avoid problems with code minification. By default the following cache key will be created for `${target.constructor.name}::${fnName}` (default: `undefined`)
 
 Only for Redis:
 

--- a/packages/sui-decorators/README.md
+++ b/packages/sui-decorators/README.md
@@ -180,6 +180,8 @@ Common for both LRU and Redis:
 
 * size: Maximum number of registers in the cache, when they exceed this number they will be erased (default: `100`)
 
+* cacheKeyString: String param containing cache key(it must be unique). It is useful to define a fixed cache key(constructor name + function name, e.g. `cacheKeyString: GetAdListSearchUseCase#execute`) and avoid problems with code minification. By default the following cache key will be created for  each `${target.constructor.name}::${fnName}` (default: `undefined`)
+
 Only for Redis:
 
 * redis: desired redis server connection config `@cache({server: true, redis: {host: YOUR_REDIS_HOST, port: YOUR_REDIS_PORT_NUMBER}})`. (default: `undefined`, if `redis={} -> {host: '127.0.0.1', port: 6379}`) Remember `server` flag must be true and `process.env.USE_REDIS_IN_SUI_DECORATORS_CACHE` must be setted to true to connect to the provided redis server.

--- a/packages/sui-decorators/src/decorators/cache/handlers/inMemory.js
+++ b/packages/sui-decorators/src/decorators/cache/handlers/inMemory.js
@@ -4,9 +4,7 @@ import isPromise from '../../../helpers/isPromise'
 export const inMemory = (target, cache, original, fnName, instance, ttl) => (
   ...args
 ) => {
-  const key = `${target.constructor.name}::${fnName}::${createHash(
-    JSON.stringify(args)
-  )}`
+  const key = createHash(JSON.stringify(args))
   const now = Date.now()
 
   if (cache.get(key) === undefined) {

--- a/packages/sui-decorators/src/decorators/cache/handlers/inRedis.js
+++ b/packages/sui-decorators/src/decorators/cache/handlers/inRedis.js
@@ -10,20 +10,22 @@ export const inRedis = (
   original,
   fnName,
   instance,
-  ttl
+  ttl,
+  cacheKey
 ) => async (...args) => {
   const key = `${VERSION_NAMESPACE_TAG}${createHash(JSON.stringify(args))}`
-
   const cacheItem = await cache.get(key)
   let response
 
   if (!cacheItem) {
-    console.log(`[sui-decorators/cache]:inRedis Miss for key: ${key}. `)
+    console.log(
+      `[sui-decorators/cache]:inRedis Miss for key(${cacheKey}): ${key}`
+    )
     try {
       response = await original.apply(instance, args)
     } catch (err) {
       console.error(
-        `[sui-decorators/cache]:inRedis Error getting original promise response for key: ${key}. `,
+        `[sui-decorators/cache]:inRedis Error getting original promise response for key(${cacheKey}): ${key}.`,
         err
       )
       return err
@@ -38,10 +40,14 @@ export const inRedis = (
 
     if (isInlineErrorResponseWithoutError || isNormalResponseWithoutError) {
       cache.set(key, response, ttl)
-      console.log(`[sui-decorators/cache]:inRedis Add key: ${key}. `)
+      console.log(
+        `[sui-decorators/cache]:inRedis Add key(${cacheKey}): ${key}. `
+      )
     }
   } else {
-    console.log(`[sui-decorators/cache]:inRedis Hit for key: ${key}. `)
+    console.log(
+      `[sui-decorators/cache]:inRedis Hit for key(${cacheKey}): ${key}. `
+    )
     return cacheItem
   }
 

--- a/packages/sui-decorators/src/decorators/cache/index.js
+++ b/packages/sui-decorators/src/decorators/cache/index.js
@@ -25,7 +25,7 @@ const _cache = ({
 } = {}) => {
   const shouldUseRedisCache = redis && isNode
   const shouldUseMemoryCache = !isNode || !redis
-  const cacheKey = cacheKeyString ?? `${target.constructor.name}::${fnName}`
+  const cacheKey = cacheKeyString || `${target.constructor.name}::${fnName}`
 
   let cache = caches[cacheKey]
 

--- a/packages/sui-decorators/src/decorators/cache/index.js
+++ b/packages/sui-decorators/src/decorators/cache/index.js
@@ -20,11 +20,12 @@ const _cache = ({
   size,
   target,
   ttl,
-  redis
+  redis,
+  cacheKeyString
 } = {}) => {
   const shouldUseRedisCache = redis && isNode
   const shouldUseMemoryCache = !isNode || !redis
-  const cacheKey = `${target.constructor.name}::${fnName}`
+  const cacheKey = cacheKeyString ?? `${target.constructor.name}::${fnName}`
 
   let cache = caches[cacheKey]
 
@@ -51,7 +52,7 @@ const _cache = ({
   }
 
   return shouldUseRedisCache
-    ? inRedis(target, cache, original, fnName, instance, ttl)
+    ? inRedis(target, cache, original, fnName, instance, ttl, cacheKey)
     : inMemory(target, cache, original, fnName, instance, ttl)
 }
 
@@ -60,7 +61,8 @@ export default ({
   server = false,
   algorithm = ALGORITHMS.LRU,
   size,
-  redis
+  redis,
+  cacheKeyString
 } = {}) => {
   const timeToLife = stringOrIntToMs({ttl}) || DEFAULT_TTL
   return (target, fnName, descriptor) => {
@@ -107,7 +109,8 @@ export default ({
             size,
             target,
             ttl: timeToLife,
-            redis
+            redis,
+            cacheKeyString
           })
 
           Object.defineProperty(this, fnName, {


### PR DESCRIPTION
## Description
Add `cacheKeyString` param in cache decorator, it contains a cache key string(it must be unique). 

It is useful to define a fixed cache key(constructor name + function name, e.g. `cacheKeyString: GetAdListSearchUseCase#execute`) and avoid problems with code minification. 

If By default the following cache key will be created `${target.constructor.name}::${fnName}`

## Related Issue
In milanuncios we detected an issue with minified production code cache keys(`target.constructor.name`)

