### PR TITLE
feat(sui-ssr): accept host patterns in multisite config

### DIFF
--- a/packages/sui-ssr/README.md
+++ b/packages/sui-ssr/README.md
@@ -242,19 +242,20 @@ Configs accepted:
         ]
        }
     }
-    ``` 
-  
+    ```
+
 - **`dynamicsURLS`** (`[]`): Array of allowed urls in order to make them be rendered dynamically based on the Dynamic Rendering guidelines by Google: https://developers.google.com/search/docs/guides/dynamic-rendering
 
 - **`useLegacyContext`** (`true`): If you don't want to use the legacy context you have to set this flag to `false`. If you leave it as default, you'll be still using the legacy context but also the new one in order to be able to migrate your code easily.
 
-- **`multiSite`** (`undefined`): Should be an object containing a mapping with an association of hostname (key) and public folder (value) in order to make your server work with more than one public folder. **Important! You must set at least a `default` value to enable this feature.** See one simple example below:
+- **`multiSite`** (`undefined`): Should be an object containing a mapping with an association of hostname or hostname pattern (key as string) and public folder (value) in order to make your server work with more than one public folder. **Important! You must set at least a `default` value to enable this feature.** See one simple example below:
 
   ```json
   {
     "multiSite": {
       "my-motorcycles.com": "public-motorcycles",
       "my-trucks.com": "public-trucks",
+      "v([0-9]+).my-trucks.com": "public-trucks",
       "default": "public-cars"
     }
   }
@@ -373,7 +374,7 @@ If this were your `src/index.html` file:
 
   <!--THIRD_PARTY--><script defer importance="high" src="<%= utagScript %>"></script>
   <!--THIRD_PARTY--><script defer importance="low" src="<%= openAdsScript %>"></script>
-  
+
 </head>
 
 <body>
@@ -432,7 +433,7 @@ The sui-ssr response would be an HTML like the following:
 
   <!--THIRD_PARTY-->
   <!--THIRD_PARTY-->
-  
+
 </head>
 
 <body>

--- a/packages/sui-ssr/server/index.js
+++ b/packages/sui-ssr/server/index.js
@@ -1,3 +1,4 @@
+/* eslint no-console:0 */
 import express from 'express'
 import ssr from './ssr'
 import criticalCss from './criticalCss'
@@ -14,7 +15,7 @@ import compression from 'compression'
 import ssrConf from './config'
 import {
   isMultiSite,
-  siteFromReq,
+  hostFromReq,
   useStaticsByHost,
   readHtmlTemplate
 } from './utils'
@@ -114,7 +115,7 @@ const _memoizedHtmlTemplatesMapping = {}
     // Since `_memoizedHtmlTemplatesMapping` will be always an object
     // we need to define a key for each multisite and one default
     // for single sites too.
-    const site = isMultiSite ? siteFromReq(req) : 'default'
+    const site = isMultiSite ? hostFromReq(req) : 'default'
     const memoizedHtmlTemplate =
       _memoizedHtmlTemplatesMapping && _memoizedHtmlTemplatesMapping[site]
 

--- a/packages/sui-ssr/server/utils.js
+++ b/packages/sui-ssr/server/utils.js
@@ -14,13 +14,20 @@ const multiSiteKeys = multiSiteMapping && Object.keys(multiSiteMapping)
 export const isMultiSite =
   multiSiteKeys && multiSiteKeys.length > 0 && multiSiteKeys.includes('default')
 
-export const siteFromReq = (req, header = DEFAULT_SITE_HEADER) =>
+export const hostFromReq = (req, header = DEFAULT_SITE_HEADER) =>
   req.get(header) || req.hostname
 
-export const publicFolderByHost = req =>
-  isMultiSite
-    ? multiSiteMapping[siteFromReq(req)] || multiSiteMapping.default
-    : DEFAULT_PUBLIC_FOLDER
+export const hostPattern = req => {
+  const host = hostFromReq(req)
+
+  return multiSiteKeys.find(hostPattern => host.match(hostPattern)) || 'default'
+}
+
+export const publicFolderByHost = req => {
+  const site = hostPattern(req)
+
+  return isMultiSite ? multiSiteMapping[site] : DEFAULT_PUBLIC_FOLDER
+}
 
 export const useStaticsByHost = expressStatic => {
   let middlewares
@@ -35,9 +42,9 @@ export const useStaticsByHost = expressStatic => {
   }
 
   return function serveStaticByHost(req, res, next) {
-    const site = siteFromReq(req)
+    const site = hostPattern(req)
     const middleware = isMultiSite
-      ? middlewares[site] || middlewares.default
+      ? middlewares[site]
       : expressStatic(DEFAULT_PUBLIC_FOLDER, EXPRESS_STATIC_CONFIG)
 
     middleware(req, res, next)


### PR DESCRIPTION
## Description
Accept hotname patterns (reg exps) in multisite config. 

## Example
  ```json
  {
    "multiSite": {
      "my-trucks.com": "public-trucks",
      "v([0-9]+).my-trucks.com": "public-trucks",
      "default": "public-cars"
    }
  }
  ```