### PR TITLE
Feature/upgrade precommit to use latest husky version

### DIFF
--- a/packages/sui-precommit/Readme.md
+++ b/packages/sui-precommit/Readme.md
@@ -6,8 +6,8 @@ Installs commit hook to ensure quality rules are executed before any commit (tes
 
 It provides:
 
-* Assurance that all code is compliant with Schibsted's standards.
-* Centralize precommit rule:; quality rules can be improved and seemlessly inherited by all projects.
+* Assurance that all code is compliant with Adevinta's standards.
+* Centralize precommit rule: quality rules can be improved and seemlessly inherited by all projects.
 
 ## Installation
 
@@ -33,27 +33,27 @@ Executes all rules:
 
 Installs `sui-precommit` as git pre-commit hook.
 
-Executes 3 actions:
+Executes **4** actions:
 
 1.  Install [husky](https://www.npmjs.com/package/husky) (if not installed yet) to your project.
-1.  Add `sui-precommit run` as husky's precommit script.
-1.  Add `sui-lint` as npm lint script command so you can execute linting separately.
+2.  If you already have a husky deprecated config, migrate it to the new one.
+3.  Add `sui-precommit run` as husky's precommit script.
+4.  Add `sui-lint` as npm lint script command so you can execute linting separately.
 
 Your package.json might be altered like that:
 
 ```json
 {
   "scripts": {
-    "lint": "sui-lint js && sui-lint sass",
-    "precommit": "sui-precommit run"
+    "lint": "sui-lint js && sui-lint sass"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "sui-precommit run"
+    }
   },
   "devDependencies": {
-    "husky": "0.13.4"
+    "husky": "4.2.5"
   }
 }
 ```
-
-> :warning: **Caution!**
->
-> **Make sure you first remove the pre-commit and commit-msg hooks from the
-> `.git/hooks` directory if already set. `sui-precommit install` will not overwrite them.**

--- a/packages/sui-precommit/Readme.md
+++ b/packages/sui-precommit/Readme.md
@@ -39,6 +39,7 @@ Executes **4** actions:
 2.  If you already have a husky deprecated config, migrate it to the new one.
 3.  Add `sui-precommit run` as husky's precommit script.
 4.  Add `sui-lint` as npm lint script command so you can execute linting separately.
+**Note:** *If `lint` script is already present, it doesn't overwrite it (as some packages might not need executing `sui-lint sass` or `sui-lint js`).*
 
 Your package.json might be altered like that:
 

--- a/packages/sui-precommit/Readme.md
+++ b/packages/sui-precommit/Readme.md
@@ -2,7 +2,7 @@
 
 > Effortless SUI precommit rules integration in your project
 
-Installs commit hook to ensure quality rules are executed before any commit (test, linting, consistent commit, etc)
+Installs commit hook to ensure quality rules are executed before any commit (test, linting, consistent commit, etc).
 
 It provides:
 

--- a/packages/sui-precommit/bin/sui-precommit-install.js
+++ b/packages/sui-precommit/bin/sui-precommit-install.js
@@ -5,10 +5,14 @@ const path = require('path')
 const fs = require('fs')
 const pkgPath = path.join(process.cwd(), 'package.json')
 
+const DEFAULT_PKG_FIELD = 'scripts'
+const HUSKY_VERSION = '4.2.5'
+
 installHuskyIfNotInstalled()
   .then(function() {
-    installScript('lint', 'sui-lint js && sui-lint sass')
-    installScript('precommit', 'sui-precommit run')
+    addToPackageJson('lint', 'sui-lint js && sui-lint sass')
+    addToPackageJson('pre-commit', 'sui-precommit run', 'hooks')
+    removeFromPackageJson('precommit')
   })
   .catch(function(err) {
     log(err.message)
@@ -23,15 +27,50 @@ function log(...args) {
 }
 
 /**
- * Install script on package.json where command was executed
- * @param  {String} name   script name
- * @param  {String} script command to execute
+ * Read package.json file
+ * @returns {object} Package.json content in JSON format
  */
-function installScript(name, script) {
-  const pkg = JSON.parse(fs.readFileSync(pkgPath, {encoding: 'utf8'}))
-  pkg.scripts = pkg.scripts || {}
-  pkg.scripts[name] && log('Script "' + name + '" already set. Overwritting...')
-  pkg.scripts[name] = script
+function readPackageJson() {
+  return JSON.parse(fs.readFileSync(pkgPath, {encoding: 'utf8'}))
+}
+
+/**
+ * Add script on package.json where command was executed
+ * @param  {string}  name   script name
+ * @param  {string}  script command to execute
+ * @param  {string?}  field  field where the script must be added
+ **/
+function addToPackageJson(name, script, field = DEFAULT_PKG_FIELD) {
+  const pkg = readPackageJson()
+  pkg[field] = pkg[field] || {}
+
+  pkg[field][name] = script
+  log(`Writing "${name}" on "${field}"...`)
+
+  writePackageJson(pkg)
+}
+
+/**
+ * Add script on package.json where command was executed
+ * @param  {string}  name   script name
+ * @param  {string}  field  field where the script is
+ **/
+function removeFromPackageJson(name, field = DEFAULT_PKG_FIELD) {
+  const pkg = readPackageJson()
+  pkg[field] = pkg[field] || {}
+
+  const {[name]: remove, ...rest} = pkg[field]
+  pkg[field] = rest
+  log(`"${name}" removed from "${field}". Writing changes...`)
+
+  writePackageJson(pkg)
+}
+
+/**
+ * Write package.json file where command was executed
+ * @param  {object}  pkg New package content to be write on the file
+ */
+function writePackageJson(pkg) {
   fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2), {encoding: 'utf8'})
 }
 
@@ -44,7 +83,7 @@ function installHuskyIfNotInstalled() {
     log('husky will be installed to allow git hook integration with node')
     return getSpawnPromise('npm', [
       'install',
-      'husky@0.13.4',
+      `husky@${HUSKY_VERSION}`,
       '--save-dev',
       '--save-exact'
     ])
@@ -54,10 +93,11 @@ function installHuskyIfNotInstalled() {
 }
 
 /**
- * Get if husky is already installed
+ * Get if husky is already installed with the expected version
  * @return {Boolean}
  */
 function isHuskyInstalled() {
   const pkg = JSON.parse(fs.readFileSync(pkgPath, {encoding: 'utf8'}))
-  return pkg.devDependencies && pkg.devDependencies.husky
+  const huskyDependency = pkg.devDependencies && pkg.devDependencies.husky
+  return huskyDependency === HUSKY_VERSION
 }

--- a/packages/sui-precommit/bin/sui-precommit-install.js
+++ b/packages/sui-precommit/bin/sui-precommit-install.js
@@ -75,7 +75,7 @@ function removeFromPackageJson(name, field = DEFAULT_PKG_FIELD) {
 
 /**
  * Write package.json file where command was executed
- * @param  {object}  pkg New package content to be write on the file
+ * @param {object} pkg New package content to be write on the file
  */
 function writePackageJson(pkg) {
   fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2), {encoding: 'utf8'})
@@ -83,7 +83,7 @@ function writePackageJson(pkg) {
 
 /**
  * Install husky on project
- * @return {Promise}
+ * @return {Promise<number>}
  */
 function installHuskyIfNotInstalled() {
   if (!isHuskyInstalled()) {

--- a/packages/sui-precommit/bin/sui-precommit-install.js
+++ b/packages/sui-precommit/bin/sui-precommit-install.js
@@ -3,7 +3,14 @@
 const {getSpawnPromise} = require('@s-ui/helpers/cli')
 const path = require('path')
 const fs = require('fs')
-const pkgPath = path.join(process.cwd(), 'package.json')
+
+/** In order to ensure this could work on postinstall script and also manually
+ * we neet to check if INIT_CWD is available and use it instead cwd
+ * as on postinstall the cwd will change
+ */
+const {INIT_CWD} = process.env
+const cwd = INIT_CWD || process.cwd()
+const pkgPath = path.join(cwd, 'package.json')
 
 const DEFAULT_PKG_FIELD = 'scripts'
 const HUSKY_VERSION = '4.2.5'
@@ -81,12 +88,11 @@ function writePackageJson(pkg) {
 function installHuskyIfNotInstalled() {
   if (!isHuskyInstalled()) {
     log('husky will be installed to allow git hook integration with node')
-    return getSpawnPromise('npm', [
-      'install',
-      `husky@${HUSKY_VERSION}`,
-      '--save-dev',
-      '--save-exact'
-    ])
+    return getSpawnPromise(
+      'npm',
+      ['install', `husky@${HUSKY_VERSION}`, '--save-dev', '--save-exact'],
+      {cwd}
+    )
   } else {
     return Promise.resolve(0)
   }

--- a/packages/sui-precommit/package.json
+++ b/packages/sui-precommit/package.json
@@ -1,20 +1,21 @@
 {
   "name": "@s-ui/precommit",
-  "version": "2.7.0",
+  "version": "2.8.0-beta.6",
   "description": "Effortless SUI precommit rules integration in your project",
   "main": "index.js",
   "bin": {
     "sui-precommit": "./bin/sui-precommit.js"
   },
   "scripts": {
-    "postinstall": "sui-precommit install"
+    "postinstall": "node ./bin/sui-precommit.js install"
   },
   "keywords": [],
   "author": "",
   "dependencies": {
-    "@s-ui/lint": "3",
     "@s-ui/helpers": "1",
-    "commander": "5.1.0"
+    "@s-ui/lint": "3",
+    "commander": "5.1.0",
+    "dset": "2.0.1"
   },
   "license": "MIT",
   "repository": {

--- a/packages/sui-precommit/package.json
+++ b/packages/sui-precommit/package.json
@@ -1,17 +1,20 @@
 {
   "name": "@s-ui/precommit",
-  "version": "2.7.0",
+  "version": "2.8.0-beta.0",
   "description": "Effortless SUI precommit rules integration in your project",
   "main": "index.js",
   "bin": {
     "sui-precommit": "./bin/sui-precommit.js"
+  },
+  "scripts": {
+    "postinstall": "sui-precommit install"
   },
   "keywords": [],
   "author": "",
   "dependencies": {
     "@s-ui/lint": "3",
     "@s-ui/helpers": "1",
-    "commander": "2.9.0"
+    "commander": "5.1.0"
   },
   "license": "MIT",
   "repository": {

--- a/packages/sui-precommit/package.json
+++ b/packages/sui-precommit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/precommit",
-  "version": "2.8.0-beta.3",
+  "version": "2.7.0",
   "description": "Effortless SUI precommit rules integration in your project",
   "main": "index.js",
   "bin": {

--- a/packages/sui-precommit/package.json
+++ b/packages/sui-precommit/package.json
@@ -15,7 +15,7 @@
     "@s-ui/helpers": "1",
     "@s-ui/lint": "3",
     "commander": "5.1.0",
-    "dlv": "^1.1.3",
+    "dlv": "1.1.3",
     "dset": "2.0.1"
   },
   "license": "MIT",

--- a/packages/sui-precommit/package.json
+++ b/packages/sui-precommit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/precommit",
-  "version": "2.8.0-beta.0",
+  "version": "2.8.0-beta.3",
   "description": "Effortless SUI precommit rules integration in your project",
   "main": "index.js",
   "bin": {

--- a/packages/sui-precommit/package.json
+++ b/packages/sui-precommit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/precommit",
-  "version": "2.8.0-beta.6",
+  "version": "2.7.0",
   "description": "Effortless SUI precommit rules integration in your project",
   "main": "index.js",
   "bin": {
@@ -15,6 +15,7 @@
     "@s-ui/helpers": "1",
     "@s-ui/lint": "3",
     "commander": "5.1.0",
+    "dlv": "^1.1.3",
     "dset": "2.0.1"
   },
   "license": "MIT",


### PR DESCRIPTION
## Description
- [x] Upgrade husky version to latest to fix problem that's getting the default node version.
- [x] 🆕 feature: Now precommit is installed automatically on install.
- [x] 🆕 feature: Now on `install` migrate the old config to the new one.
- [x] ✍️ docs: some fixes to the README and documentation

## Related Issue
https://github.com/SUI-Components/sui/issues/895

## Example
With `nvm` using as default `14` but in the session using `10` us causing this:
```
Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: /Users/francisco.ruiz/Code/sui/node_modules/@babel/runtime/helpers/esm/asyncToGenerator.js
require() of ES modules is not supported.
require() of /Users/francisco.ruiz/Code/sui/node_modules/@babel/runtime/helpers/esm/asyncToGenerator.js from /Users/francisco.ruiz/Code/sui/packages/sui-decorators/test/server/cacheSpec.js is an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope as ES modules.
Instead rename asyncToGenerator.js to end in .cjs, change the requiring code to use import(), or remove "type": "module" from /Users/francisco.ruiz/Code/sui/node_modules/@babel/runtime/helpers/esm/package.json.
```
