### PR TITLE
fix(sui-bundler): use native ws as sockjs is giving problems with latest Node versions

### DIFF
--- a/packages/sui-bundler/factories/createDevServerConfig.js
+++ b/packages/sui-bundler/factories/createDevServerConfig.js
@@ -6,18 +6,34 @@ const protocol = process.env.HTTPS === 'true' ? 'https' : 'http'
 const host = process.env.HOST || '0.0.0.0'
 
 module.exports = (config, allowedHost) => ({
+  // Enable gzip compression of generated files.
   compress: true,
+  // Silence WebpackDevServer's own logs since they're generally not useful.
+  // It will still show compile warnings and errors with this setting.
   clientLogLevel: 'none',
+  // Tell the server where to serve content from. This is only necessary if you want to serve static files from this folder as normally they come from memory
   contentBase: 'public',
+  // By default files from `contentBase` will not trigger a page reload.
   watchContentBase: true,
+  // Enable hot reloading server.
   hot: true,
+  // Use 'ws' instead of 'sockjs-node' on server since we're using native
+  // websockets in `webpackHotDevClient`.
+  transportMode: 'ws',
+  // Prevent a WS client from getting injected as we're already including
+  // `webpackHotDevClient`.
+  injectClient: false,
+  // Tell the server at what URL to serve devServer.contentBase static content.
   publicPath: config.output.publicPath,
+  // WebpackDevServer is noisy by default so we emit custom message instead
+  // by listening to the compiler events with `compiler.hooks[...].tap` calls above.
   quiet: true,
+  // Reportedly, this avoids CPU overload on some systems.
   watchOptions: {
     ignored: ignoredFiles(config.context)
   },
   https: protocol === 'https',
-  host: host,
+  host,
   overlay: false,
   historyApiFallback: {
     disableDotRule: true

--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -55,7 +55,7 @@
     "source-map-loader": "1.0.1",
     "static-module": "3.0.4",
     "style-loader": "1.2.1",
-    "terser-webpack-plugin": "3.0.6",
+    "terser-webpack-plugin": "3.0.7",
     "thread-loader": "2.1.3",
     "update-check": "1.5.4",
     "webpack": "4.43.0",

--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/bundler",
-  "version": "6.14.0",
+  "version": "6.15.0-beta.0",
   "description": "Config-free bundler for ES6 React apps.",
   "bin": {
     "sui-bundler": "./bin/sui-bundler.js"
@@ -21,11 +21,11 @@
   },
   "homepage": "https://github.com/SUI-Components/sui/tree/master/packages/sui-bundler#readme",
   "dependencies": {
-    "@babel/cli": "7.10.4",
-    "@babel/core": "7.10.4",
+    "@babel/cli": "7.10.5",
+    "@babel/core": "7.10.5",
     "@s-ui/helpers": "1",
     "@s-ui/lint": "3",
-    "autoprefixer": "9.8.4",
+    "autoprefixer": "9.8.5",
     "babel-loader": "8.1.0",
     "babel-preset-sui": "3",
     "bundle-loader": "0.5.6",


### PR DESCRIPTION
Added `transportMode` to `ws` and `injectClient` to false to avoid problem with ECONNRESET.

```
  // Use 'ws' instead of 'sockjs-node' on server since we're using native
  // websockets in `webpackHotDevClient`.
  transportMode: 'ws',
  // Prevent a WS client from getting injected as we're already including
  // `webpackHotDevClient`.
  injectClient: false,
```

The problem:
![image](https://user-images.githubusercontent.com/1561955/88068192-2a057d80-cb70-11ea-83a8-a9ce53aa664e.png)
