### PR TITLE
feat(sui-widget-embedder): allow a way to send a general context object

### DIFF
--- a/packages/sui-widget-embedder/README.md
+++ b/packages/sui-widget-embedder/README.md
@@ -113,14 +113,43 @@ import render from '@s-ui/widget-embedder/react/render'
 - `Widgets`: React Component that encapsules all your widgets.
 
 - `Widget`: React Component that renders the children as a new React tree in another place of the page. Available props:
-  * `browser`: Browser object with useful info about the browser of the User Agent.
+  * `browser`: *(deprecated)* Browser object with useful info about the browser of the User Agent. (Note: better use the context object)
   * `children` *(required)*: Content of the Widget. Should be a compatible React Element.
-  * `domain`: Domain library for your widgets
-  * `i18n`: I18n library
+  * `context`: Object with the context object that you want to be available inside the widget. If `context` is provided, then `browser`, `domain` and `i18n` props are ignored.
+  * `domain`: *(deprecated)* Domain library for your widgets
+  * `i18n`: *(deprecated)* I18n library
   * `isVisible` *(default: true)*: Determine if the widget must be shown.
   * `node` *(deprecated)*: css path that indicates where you want create the new React tree. If that node doesnt exist in the current page you will get a warning in the console.
   * `renderMultiple` *(default: false)*: Determine if the Widget must be rendered on every node found using the selector prop (or deprecated `node` prop). If `false` the Widget will be rendered only in the first node found.
   * `selector`: *(required)* CSS Path to select the node (or nodes) where you want to render the Widget.
+
+### Passing a context to a Widget
+
+Sometimes the components you want to render inside a Widget are expecting a React Context to be available. You could use the prop `context` in order to send an object that will be used to create an static context by using *@s-ui/react-context*.
+
+```js
+import React from 'react'
+import Widget from '@s-ui/widget-embedder/react/Widget'
+import Widgets from '@s-ui/widget-embedder/react/Widgets'
+import render from '@s-ui/widget-embedder/react/render'
+import ComponentToRender from 'awesome-component'
+
+import './index.scss'
+
+const context = {
+  cookies: document.cookie,
+  userAgent: navigator.userAgent
+}
+
+render(
+  <Widgets>
+    <Widget node="#widget-to-render" context={context}>
+      <ComponentToRender />
+    </Widget>
+  </Widgets>,
+  'widget-to-render'
+)
+```
 
 ## How to develop
 

--- a/packages/sui-widget-embedder/src-react/Widget.js
+++ b/packages/sui-widget-embedder/src-react/Widget.js
@@ -17,10 +17,11 @@ function renderWidgetOnDOM({children, context, node}) {
 }
 
 export default function Widget({
-  browser,
+  browser, // deprecated
   children,
-  domain,
-  i18n,
+  context: contextFromProps, // use this instead passing browser, domain and i18n
+  domain, // deprecated
+  i18n, // deprecated
   isVisible = true,
   node, // deprecated
   selector,
@@ -43,7 +44,7 @@ export default function Widget({
     // depending on renderMultiple, get the full array or only the first one
     const nodesToRender = renderMultiple ? [].slice.call(nodes) : [nodes[0]]
     // create the context object
-    const context = {browser, domain, i18n}
+    const context = contextFromProps || {browser, domain, i18n}
 
     isVisible &&
       nodesToRender.map(node => renderWidgetOnDOM({children, context, node}))


### PR DESCRIPTION
Add a way to send a general context object agnostic to:
- Business logic and architecture decisions (as this is open source and context could be something different to what we use in Adevinta).
- Easy to be expanded as it doesn't rely that each prop is a property in the context (so, it's tolerant to future changes).
- Update README and deprecate `browser`, `i18n` and `domain` props intended for the creation of the context (now is more agnostic).