### PR TITLE
[fix] change studio build flag name

### DIFF
--- a/packages/sui-studio/README.md
+++ b/packages/sui-studio/README.md
@@ -93,7 +93,19 @@ Build a static version of a web app aimed to be deployed, where you will be able
 #### Options
 
 - **`-O, --only-changes`**: only build changed components or demos
-- **`-B, --before-build <command>`**: command to be executed before the build
+- **`-B, --before-build <command>`**: command to be executed before the build (not working with multiple commands like `npx sui-mono phoenix && npx sui-lint js`, try to group them into just one: `npm run before_build`, for example)
+
+#### Examples
+
+```bash
+# run the build for all components
+npx sui-studio build
+```
+
+```bash
+# run the build just for changed components and also execute whatever you want before the build (phoenix, lint...)
+npx sui-studio build --only-changes --before-build="npx sui-mono phoenix"
+```
 
 ### `$ sui-studio dev`
 

--- a/packages/sui-studio/README.md
+++ b/packages/sui-studio/README.md
@@ -93,7 +93,7 @@ Build a static version of a web app aimed to be deployed, where you will be able
 #### Options
 
 - **`-O, --only-changes`**: only build changed components or demos
-- **`-P, --phoenix-command <command>`**: phoenix command to be executed before the build
+- **`-B, --before-build <command>`**: command to be executed before the build
 
 ### `$ sui-studio dev`
 

--- a/packages/sui-studio/bin/sui-studio-build.js
+++ b/packages/sui-studio/bin/sui-studio-build.js
@@ -11,8 +11,8 @@ const {NO_COMPONENTS_MESSAGE} = require('../config')
 program
   .option('-O, --only-changes', 'only build changed components or demos')
   .option(
-    '-P, --phoenix-command <command>',
-    'phoenix command to be executed before the build'
+    '-B, --before-build <command>',
+    'command to be executed before the build'
   )
   .parse(process.argv)
 
@@ -20,9 +20,9 @@ console.log('\n', process.env.NODE_ENV, '\n')
 process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 
 const bundlerBuildPath = require.resolve('@s-ui/bundler/bin/sui-bundler-build')
-const {onlyChanges, phoenixCommand} = program
+const {onlyChanges, beforeBuild} = program
 let needsBuild = true
-let phoenix = false
+let beforeBuildCommand
 
 if (onlyChanges) {
   const stdout = execSync(
@@ -32,15 +32,15 @@ if (onlyChanges) {
   needsBuild = !stdout.includes(NO_COMPONENTS_MESSAGE)
 }
 
-if (phoenixCommand) {
-  const [command, ...args] = phoenixCommand.split(' ')
-  phoenix = [command, args]
+if (beforeBuild) {
+  const [command, ...args] = beforeBuild.split(' ')
+  beforeBuildCommand = [command, args]
 }
 
 if (needsBuild) {
   serialSpawn(
     [
-      phoenix,
+      beforeBuildCommand,
       [
         bundlerBuildPath,
         ['-C', '--context', join(__dirname, '..', 'src')],


### PR DESCRIPTION
## Description
Better use `--before-build` flag instead of `--phoenix-command` because it's more open to execute whatever you want and even do more things than just a "phoenix".

**_Note_: Since this is a new feature not used anywhere, we are not creating a major version for it.**

### Options

- **`-O, --only-changes`**: only build changed components or demos
- **`-B, --before-build <command>`**: command to be executed before the build (not working with multiple commands like `npx sui-mono phoenix && npx sui-lint js`, try to group them into just one: `npm run before_build`, for example)

### Examples

```bash
# run the build for all components
npx sui-studio build
```

```bash
# run the build just for changed components and also execute whatever you want before the build (phoenix, lint...)
npx sui-studio build --only-changes --before-build="npx sui-mono phoenix"
```