### PR TITLE
feat(sui-test): add support to svg import on null-loader

### DIFF
--- a/packages/sui-test/bin/karma/config.js
+++ b/packages/sui-test/bin/karma/config.js
@@ -80,9 +80,9 @@ const config = {
         },
         {
           // ignore css/scss require/imports files in the server
-          test: /\.s?css$/,
+          test: [/\.s?css$/, /\.svg$/],
           use: ['null-loader']
-        },
+        }
       ]
     }
   },

--- a/packages/sui-test/package.json
+++ b/packages/sui-test/package.json
@@ -39,14 +39,5 @@
     "mocha": "6.2.2",
     "null-loader": "4.0.0",
     "webpack": "4.41.5"
-  },
-  "eslintConfig": {
-    "extends": [
-      "./node_modules/@s-ui/lint/eslintrc.js"
-    ]
-  },
-  "prettier": "./node_modules/@s-ui/lint/.prettierrc.js",
-  "stylelint": {
-    "extends": "./node_modules/@s-ui/lint/stylelint.config.js"
   }
 }


### PR DESCRIPTION
Some 3rd party seems to be trying to load some svg. On sui-test we're adding the possibility to import svg but keeping it as null.

![image](https://user-images.githubusercontent.com/1561955/91954234-d4d99180-ed01-11ea-902c-20e9d03a4c10.png)
