### PR TITLE
Feat/add no return await warning lint

### DIFF
--- a/packages/sui-lint/eslintrc.js
+++ b/packages/sui-lint/eslintrc.js
@@ -218,6 +218,7 @@ module.exports = {
     'no-debugger': RULES.ERROR,
     'no-nested-ternary': RULES.WARNING,
     'no-prototype-builtins': RULES.OFF,
+    'no-return-await': RULES.WARNING,
     'no-unused-expressions': RULES.OFF,
     'babel/no-unused-expressions': RULES.OFF,
     strict: RULES.OFF,


### PR DESCRIPTION
**Disallows unnecessary return await (no-return-await)**

Short explanation: Avoid using `return await` when is not necessary as it has some performance cost.

Long explanation:
```
Using return await inside an async function keeps the current function in the call stack until the Promise that is being awaited has resolved, at the cost of an extra microtask before resolving the outer Promise. return await can also be used in a try/catch statement to catch errors from another function that returns a Promise.

You can avoid the extra microtask by not awaiting the return value, with the trade off of the function no longer being a part of the stack trace if an error is thrown asynchronously from the Promise being returned.

Also, if we're using Babel, all the async/await will be wrapped unnecesary with a bunch of code.
```