### PR TITLE
feat(sui-ci): add release command

### DIFF
--- a/packages/sui-ci/README.md
+++ b/packages/sui-ci/README.md
@@ -1,19 +1,47 @@
 # sui-ci
 
-> CLI with some useful commands for CI environments
+> CLI with some useful commands for Travis CI
 
 It provides:
-* A way to update a GitHub Commit Status from a CI environment.
+* A way to update a GitHub Commit Status from a CI environment with `update-commit-status` command.
+* A way to publish through CI all packages that used `sui-mono` with `release` command.
 
-## Requirements
+## release
+
+### Requirements
+
+The following environment variables are needed:
+* `GITHUB_TOKEN`: GitHub Personal Access Token of the user that will create the commit with the release.
+* `TRAVIS_PULL_REQUEST`: The pull request number if the current job is a pull request, `false` if it's not a pull request.
+ 
+Other optional enviromnet variables are:
+* `GITHUB_USER`: GitHub username of the user that will create the commit with the release.
+* `GITHUB_EMAIL`: GitHub email of the user that will create the commit with the release.
+
+
+### Usage
+
+```
+Usage: sui-ci release
+```
+
+For example, you could use the CLI directly by using `npx` with that.
+
+```sh
+$ npx @s-ui/ci release
+```
+
+## update-commit-status
+
+### Requirements
 
 Right now, it relies on some environment variables:
-* `GH_TOKEN`: GitHub Personal Access Token of the user that will create the status of the commit.
+* `GITHUB_TOKEN`: GitHub Personal Access Token of the user that will create the status of the commit.
 * `SUI_CI_TOPIC`: *Optional* but useful environment variable to tell the CI which topic the commit is about.
 
 *@s-ui/ci* right now expects it's using *Travis* to execute CI, so the next environment variables are expected: `TRAVIS_BUILD_WEB_URL`, `TRAVIS_COMMIT`, `TRAVIS_PULL_REQUEST_SHA`, `TRAVIS_REPO_SLUG`.
 
-## Usage
+### Usage
 
 ```
 Usage: sui-ci update-commit-status [options]
@@ -31,5 +59,5 @@ For example, you could use the CLI directly by using `npx` with that.
 $ npx @s-ui/ci update-commit-status --state OK --topic build 
 ```
 
-## In Action
+### In Action
 ![image](https://user-images.githubusercontent.com/1561955/88173732-5d551480-cc23-11ea-986f-9073c188c2db.png)

--- a/packages/sui-ci/README.md
+++ b/packages/sui-ci/README.md
@@ -21,15 +21,14 @@ Other optional enviromnet variables are:
 
 ### Usage
 
-```
-Usage: sui-ci release
+The **recommended way** to use this is adding in your `travis.yml` as latest step of the `script` lifecycle the next command `npx @s-ui/ci@beta release`:
+
+```yaml
+script:
+  - npx @s-ui/ci release
 ```
 
-For example, you could use the CLI directly by using `npx` with that.
-
-```sh
-$ npx @s-ui/ci release
-```
+The reason why we need to use the `script` lifecycle is because is the last step in Travis to determine if a build is failing. You could safely use in next job cycles like `after_success` but keep in mind that if the release fails the build won't change. 
 
 ## update-commit-status
 

--- a/packages/sui-ci/README.md
+++ b/packages/sui-ci/README.md
@@ -21,7 +21,7 @@ Other optional enviromnet variables are:
 
 ### Usage
 
-The **recommended way** to use this is adding in your `travis.yml` as latest step of the `script` lifecycle the next command `npx @s-ui/ci@beta release`:
+The **recommended way** to use this is adding in your `travis.yml` as latest step of the `script` lifecycle the next command `npx @s-ui/ci release`:
 
 ```yaml
 script:

--- a/packages/sui-ci/bin/sui-ci-release.js
+++ b/packages/sui-ci/bin/sui-ci-release.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+const program = require('commander')
+
+const {release} = require('../src/index')
+
+const {
+  GH_TOKEN,
+  GITHUB_EMAIL: gitHubEmail,
+  GITHUB_TOKEN,
+  GITHUB_USER: gitHubUser,
+  TRAVIS_PULL_REQUEST: pullRequestNumber
+} = process.env
+
+// to keep compatibility with previous environment variable
+// GITHUB_TOKEN usage is preferred
+const gitHubToken = GITHUB_TOKEN || GH_TOKEN
+
+program.parse(process.argv)
+
+release({
+  gitHubEmail,
+  gitHubToken,
+  gitHubUser,
+  pullRequestNumber
+})

--- a/packages/sui-ci/bin/sui-ci-update-commit-status.js
+++ b/packages/sui-ci/bin/sui-ci-update-commit-status.js
@@ -4,26 +4,43 @@ const program = require('commander')
 const {updateCommitStatus} = require('../src/index')
 
 const {
-  GH_TOKEN: auth,
+  GH_TOKEN,
+  GITHUB_TOKEN,
   SUI_CI_TOPIC: topicFromEnv,
   TRAVIS_BUILD_WEB_URL: buildUrl,
   TRAVIS_COMMIT,
   TRAVIS_PULL_REQUEST_SHA,
-  TRAVIS_REPO_SLUG: repoSlug,
+  TRAVIS_REPO_SLUG: repoSlug
 } = process.env
 
+// to keep compatibility with previous environment variable
+// GITHUB_TOKEN usage is preferred
+const gitHubToken = GITHUB_TOKEN || GH_TOKEN
+
 program
-  .option('-s, --state <stateKey>', 'State of the commit. Accepted values:"OK", "KO", "RUN"', 'KO')
-  .option('-u, --url <targetUrl>', 'Url where the details link navigates to', buildUrl)
-  .option('-t, --topic <ciTopic>', 'Topic telling what is the commit about', topicFromEnv)
+  .option(
+    '-s, --state <stateKey>',
+    'State of the commit. Accepted values:"OK", "KO", "RUN"',
+    'KO'
+  )
+  .option(
+    '-u, --url <targetUrl>',
+    'Url where the details link navigates to',
+    buildUrl
+  )
+  .option(
+    '-t, --topic <ciTopic>',
+    'Topic telling what is the commit about',
+    topicFromEnv
+  )
   .parse(process.argv)
 
 const commit = TRAVIS_PULL_REQUEST_SHA || TRAVIS_COMMIT
 const {state: stateKey, topic, url: targetUrl} = program
 
 updateCommitStatus({
-  auth,
   commit,
+  gitHubToken,
   stateKey,
   targetUrl,
   topic,

--- a/packages/sui-ci/bin/sui-ci.js
+++ b/packages/sui-ci/bin/sui-ci.js
@@ -6,5 +6,6 @@ const {version} = require('../package.json')
 program
   .version(version)
   .command('update-commit-status', 'update a GitHub Commit Status')
+  .command('release', 'release packages on Travis CI')
 
 program.parse(process.argv)

--- a/packages/sui-ci/package.json
+++ b/packages/sui-ci/package.json
@@ -11,7 +11,7 @@
     "commander": "6.1.0",
     "execa": "4.0.3",
     "git-remote-origin-url": "3.1.0",
-    "git-url-parse": "11.1.3"
+    "git-url-parse": "11.2.0"
   },
   "devDependencies": {
     "nock": "13.0.4"

--- a/packages/sui-ci/package.json
+++ b/packages/sui-ci/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@octokit/core": "3.1.2",
     "commander": "6.1.0",
+    "execa": "4.0.3",
     "git-remote-origin-url": "3.1.0",
     "git-url-parse": "11.1.3"
   },

--- a/packages/sui-ci/src/index.js
+++ b/packages/sui-ci/src/index.js
@@ -1,3 +1,4 @@
 const updateCommitStatus = require('./updateCommitStatus')
+const release = require('./release')
 
-module.exports = {updateCommitStatus}
+module.exports = {release, updateCommitStatus}

--- a/packages/sui-ci/src/release.js
+++ b/packages/sui-ci/src/release.js
@@ -1,0 +1,31 @@
+const {command: execute} = require('execa')
+
+/**
+ * Release packages of the repository on CI
+ * @param {object}  params
+ * @param {string=} params.gitHubEmail Github Email to be used when commiting
+ * @param {string}  params.gitHubToken Personal token from GitHub or GitHub Enterprise
+ * @param {string=} params.gitHubUser Github Username to be used when commiting
+ * @param {string}  params.pullRequestNumber Number of Pull Request
+ * @returns {Promise}
+ */
+module.exports = async function release({
+  gitHubEmail = 'srv.scms.git-enb@adevinta.com',
+  gitHubToken,
+  gitHubUser = 'Adevinta',
+  pullRequestNumber
+}) {
+  if (!gitHubToken) {
+    console.error('[sui-ci release] GitHub Token not provided')
+    process.exit(1)
+  }
+
+  if (!pullRequestNumber) {
+    console.info("[sui-ci release] Nothing to release, we're in a Pull Request")
+    return process.exit(0)
+  }
+
+  return execute(
+    `sui-mono release --github-email "${gitHubEmail}" --github-user "${gitHubUser}" --github-token ${gitHubToken}`
+  )
+}

--- a/packages/sui-ci/src/release.js
+++ b/packages/sui-ci/src/release.js
@@ -27,7 +27,7 @@ module.exports = async function release({
 
   try {
     const {stdout} = await execute(
-      `sui-mono release --github-email "${gitHubEmail}" --github-user "${gitHubUser}" --github-token ${gitHubToken}`
+      `npx @sui/mono@1 release --github-email "${gitHubEmail}" --github-user "${gitHubUser}" --github-token ${gitHubToken}`
     )
     console.info(stdout)
     console.info('[sui-ci release] Success!')

--- a/packages/sui-ci/src/release.js
+++ b/packages/sui-ci/src/release.js
@@ -27,7 +27,7 @@ module.exports = async function release({
 
   try {
     const {stdout} = await execute(
-      `npx @s-ui/mono@1 release --github-email "${gitHubEmail}" --github-user "${gitHubUser}" --github-token ${gitHubToken}`
+      `sui-mono release --github-email "${gitHubEmail}" --github-user "${gitHubUser}" --github-token ${gitHubToken}`
     )
     console.info(stdout)
     console.info('[sui-ci release] Success!')

--- a/packages/sui-ci/src/release.js
+++ b/packages/sui-ci/src/release.js
@@ -27,7 +27,7 @@ module.exports = async function release({
 
   try {
     const {stdout} = await execute(
-      `npx @sui/mono@1 release --github-email "${gitHubEmail}" --github-user "${gitHubUser}" --github-token ${gitHubToken}`
+      `npx @s-ui/mono@1 release --github-email "${gitHubEmail}" --github-user "${gitHubUser}" --github-token ${gitHubToken}`
     )
     console.info(stdout)
     console.info('[sui-ci release] Success!')

--- a/packages/sui-ci/src/release.js
+++ b/packages/sui-ci/src/release.js
@@ -34,6 +34,6 @@ module.exports = async function release({
   } catch (e) {
     console.error('[sui-ci release] Something went wrong:')
     console.error(e.message)
-    process.exit(1)
+    return process.exit(1)
   }
 }

--- a/packages/sui-ci/src/release.js
+++ b/packages/sui-ci/src/release.js
@@ -25,7 +25,15 @@ module.exports = async function release({
     return process.exit(0)
   }
 
-  return execute(
-    `sui-mono release --github-email "${gitHubEmail}" --github-user "${gitHubUser}" --github-token ${gitHubToken}`
-  )
+  try {
+    const {stdout} = await execute(
+      `sui-mono release --github-email "${gitHubEmail}" --github-user "${gitHubUser}" --github-token ${gitHubToken}`
+    )
+    console.info(stdout)
+    console.info('[sui-ci release] Success!')
+  } catch (e) {
+    console.error('[sui-ci release] Something went wrong:')
+    console.error(e.message)
+    process.exit(1)
+  }
 }

--- a/packages/sui-ci/src/updateCommitStatus.js
+++ b/packages/sui-ci/src/updateCommitStatus.js
@@ -25,8 +25,8 @@ async function getApiBaseUrl() {
 /**
  * Update GitHub commit status
  * @param {object} params
- * @param {string} params.auth Personal token from GitHub or GitHub Enterprise
  * @param {string} params.commit Commit SHA to update its status
+ * @param {string} params.gitHubToken Personal token from GitHub or GitHub Enterprise
  * @param {string} params.stateKey Key to grab the state info
  * @param {string} params.targetUrl Url where the `Details` link on the status will navigate to
  * @param {string} params.topic It indicates what the commit new status is about
@@ -34,12 +34,12 @@ async function getApiBaseUrl() {
  * @returns {Promise}
  */
 module.exports = async function updateCommitStatus({
-  auth,
   commit,
+  gitHubToken,
+  repoSlug,
   stateKey,
   targetUrl,
-  topic,
-  repoSlug
+  topic
 }) {
   const [owner, repo] = repoSlug.split('/')
   const state = STATUS_STATES[stateKey]
@@ -57,7 +57,7 @@ module.exports = async function updateCommitStatus({
     target_url: targetUrl
   }
 
-  const octokit = new Octokit({auth})
+  const octokit = new Octokit({auth: gitHubToken})
   return octokit.request(
     'POST /repos/{owner}/{repo}/statuses/{sha}',
     requestParams

--- a/packages/sui-mono/bin/sui-mono-release.js
+++ b/packages/sui-mono/bin/sui-mono-release.js
@@ -69,9 +69,6 @@ const singlePackageRelease = ({status, packageScope}) =>
 
 const releaseEachPkg = ({pkg, code} = {}) => {
   return new Promise((resolve, reject) => {
-    return reject(new Error('Error beta'))
-
-    /* eslint-disable */
     if (code === 0) {
       return resolve()
     }
@@ -218,6 +215,7 @@ checker
       )
   )
   .catch(err => {
+    console.error('[sui-mono release] ERROR:')
     console.error(err)
     process.exit(1)
   })

--- a/packages/sui-mono/bin/sui-mono-release.js
+++ b/packages/sui-mono/bin/sui-mono-release.js
@@ -2,7 +2,6 @@
 require('util.promisify/shim')()
 const program = require('commander')
 const path = require('path')
-const {shell} = require('@tunnckocore/execa')
 const config = require('../src/config')
 const checker = require('../src/check')
 const {serialSpawn, showError} = require('@s-ui/helpers/cli')
@@ -129,11 +128,11 @@ const releaseMode = packageScope ? singlePackageRelease : releasesByPackages
 
 const checkIsMasterBranchActive = async ({status, cwd}) => {
   try {
-    const output = await exec(`git rev-parse --abbrev-ref HEAD`, {
+    const {stdout} = await exec(`git rev-parse --abbrev-ref HEAD`, {
       cwd
     })
 
-    if (output.stdout.trim() === 'master') {
+    if (stdout.trim() === 'master') {
       return Promise.resolve(status)
     } else {
       throw new Error(
@@ -147,27 +146,14 @@ const checkIsMasterBranchActive = async ({status, cwd}) => {
   }
 }
 
-const execute = async (cmd, full) => {
-  try {
-    console.log('--->', cmd)
-    const [resp] = await shell(cmd)
-    const output = full ? resp : resp.stdout
-    console.log(output)
-    return output
-  } catch (e) {
-    const output = full ? e : e.stderr
-    console.log(output)
-    return e
-  }
-}
-
 const automaticRelease = async ({
   githubToken,
   githubUser,
   githubEmail,
   cwd
 }) => {
-  const repoURL = await execute('git config --get remote.origin.url')
+  const {stdout} = await exec('git config --get remote.origin.url', {cwd})
+  const repoURL = stdout.trim()
   const gitURL = gitUrlParse(repoURL).toString('https')
   const authURL = new URL(gitURL)
   authURL.username = githubToken

--- a/packages/sui-mono/bin/sui-mono-release.js
+++ b/packages/sui-mono/bin/sui-mono-release.js
@@ -69,6 +69,9 @@ const singlePackageRelease = ({status, packageScope}) =>
 
 const releaseEachPkg = ({pkg, code} = {}) => {
   return new Promise((resolve, reject) => {
+    return reject(new Error('Error beta'))
+
+    /* eslint-disable */
     if (code === 0) {
       return resolve()
     }
@@ -188,7 +191,7 @@ const isAutomaticRelease = ({githubToken, githubUser, githubEmail}) => {
 checker
   .check()
   .then(async status => {
-   const {githubEmail, githubToken, githubUser} = program
+    const {githubEmail, githubToken, githubUser} = program
     isAutomaticRelease({
       githubEmail,
       githubToken,
@@ -214,4 +217,7 @@ checker
         Promise.resolve([])
       )
   )
-  .catch(console.log.bind(console))
+  .catch(err => {
+    console.error(err)
+    process.exit(1)
+  })

--- a/packages/sui-mono/package.json
+++ b/packages/sui-mono/package.json
@@ -7,7 +7,6 @@
     "sui-mono": "./bin/sui-mono.js"
   },
   "keywords": [
-    "schibsted",
     "commitizen",
     "release"
   ],
@@ -16,13 +15,12 @@
   "dependencies": {
     "@s-ui/cz": "1",
     "@s-ui/helpers": "1",
-    "@tunnckocore/execa": "5.2.7",
     "colors": "1.4.0",
     "commander": "4.1.0",
     "commitizen": "4.0.3",
     "conventional-changelog": "3.1.18",
-    "execa": "3.4.0",
-    "figures": "3.1.0",
+    "execa": "4.0.3",
+    "figures": "3.2.0",
     "git-url-parse": "11.1.2",
     "log-update": "3.3.0",
     "p-queue": "6.2.1",


### PR DESCRIPTION
- [x] feat: Add a `release` command in order to simplify how to release packages through Travis CI.
- [x] refactor: Use `GITHUB_TOKEN` instead `GH_TOKEN` environment variable (but keep compatibility).
- [x] feat: Improve @s-ui/mono handling of errors.
- [x] feat: Remove `@tunnckocore/execa` not needed on @s-ui/mono.