### PR TITLE
feat(sui-svg): upgrade to latest sui-bundler version

### DIFF
--- a/packages/sui-svg/package.json
+++ b/packages/sui-svg/package.json
@@ -10,15 +10,15 @@
     "sui-svg": "./bin/sui-svg.js"
   },
   "dependencies": {
-    "@babel/core": "7.8.4",
-    "@s-ui/bundler": "5",
+    "@babel/core": "7.11.6",
+    "@s-ui/bundler": "6",
     "@s-ui/component-peer-dependencies": "latest",
     "@s-ui/helpers": "1",
     "@s-ui/react-atom-icon": "1",
     "@svgr/core": "3.1.0",
     "babel-preset-sui": "3",
-    "commander": "4.1.1",
-    "fast-glob": "3.1.1",
+    "commander": "6.1.0",
+    "fast-glob": "3.2.4",
     "just-camel-case": "4.0.2"
   },
   "keywords": [],


### PR DESCRIPTION
Use latest sui-bundler for sui-svg so we could use Node 14 without the need of compile sass binaries.