### PR TITLE
feat(babel-preset-sui): add babel-plugin-preval plugin to unlock some further optimizations

### DIFF
--- a/packages/babel-preset-sui/package.json
+++ b/packages/babel-preset-sui/package.json
@@ -15,6 +15,7 @@
     "@babel/preset-env": "7.11.5",
     "@babel/preset-react": "7.10.4",
     "@babel/runtime": "7.11.2",
+    "babel-plugin-preval": "5.0.0",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24",
     "babel-runtime": "6.26.0"
   },

--- a/packages/babel-preset-sui/src/index.js
+++ b/packages/babel-preset-sui/src/index.js
@@ -6,6 +6,7 @@ const getTargets = ({targets = {}}) => {
 }
 
 const plugins = (api, opts = {}) => [
+  require('babel-plugin-preval'),
   require('@babel/plugin-syntax-export-default-from').default,
   require('@babel/plugin-syntax-export-namespace-from').default,
   [require('@babel/plugin-proposal-decorators').default, {legacy: true}],


### PR DESCRIPTION
Add babel-plugin-preval plugin. This plugin allow us to use code to be evaluated in Babel. Useful to read folder and files content instead of bundling them. Not only could be useful for sui-studio problems but, for example, for configurations or to improve code performance buy pre evaluating some things instead doing them in runtime.