### PR TITLE
feat(sui-decorators): add cache invalidation proposal

### DIFF
--- a/packages/sui-decorators/src/decorators/cache/algorithms/Cache.js
+++ b/packages/sui-decorators/src/decorators/cache/algorithms/Cache.js
@@ -10,4 +10,8 @@ export default class Cache {
   del() {
     throw new Error('[Cache#del] must be implemented')
   }
+
+  clear() {
+    throw new Error('[Cache#clear] must be implemented')
+  }
 }

--- a/packages/sui-decorators/src/decorators/cache/algorithms/LRU.js
+++ b/packages/sui-decorators/src/decorators/cache/algorithms/LRU.js
@@ -18,4 +18,8 @@ export default class LRU extends Cache {
   del(key) {
     this._lru.delete(key)
   }
+
+  clear() {
+    this._lru.clear()
+  }
 }

--- a/packages/sui-decorators/src/decorators/cache/algorithms/Redis.js
+++ b/packages/sui-decorators/src/decorators/cache/algorithms/Redis.js
@@ -66,4 +66,8 @@ export default class Redis extends Cache {
       )
     }
   }
+
+  clear() {
+    this._lruRedis.reset()
+  }
 }

--- a/packages/sui-decorators/src/decorators/cache/index.js
+++ b/packages/sui-decorators/src/decorators/cache/index.js
@@ -57,7 +57,11 @@ const _cache = ({
 }
 
 const _invalidateCache = ({original, instance, cacheKeyString}) => {
-  delete caches[cacheKeyString]
+  const cache = caches[cacheKeyString]
+
+  if (cache) {
+    cache.clear()
+  }
 
   return (...args) => {
     return original.apply(instance, args)

--- a/packages/sui-decorators/src/index.js
+++ b/packages/sui-decorators/src/index.js
@@ -1,6 +1,6 @@
-import cache from './decorators/cache'
+import {cache, invalidateCache} from './decorators/cache'
 import streamify from './decorators/streamify'
 import inlineError from './decorators/error'
 import tracer from './decorators/tracer'
 
-export {cache, streamify, inlineError, tracer}
+export {cache, invalidateCache, streamify, inlineError, tracer}


### PR DESCRIPTION
This PR attempts to add cache invalidation. The need of this feature is explained below with an example:

The `GetCurrentSessionUseCase` method provides information of the active session and it's being called in several places in a same page, `cache` decorator was added to avoid duplicated calls.
```js
@cache({
  ttl: '1 minute',
  cacheKeyString: 'HTTPUserRepository#currentSession'
})
@inlineError
currentSession() {
  // stuff
}
```
However if the user logouts there is no way to invalidate this cache. I thought about two options to avoid this issue.
-  A new decorator `invalidateCache`, which receives the key and invalidates the cache
- A new decorator `injectCache`, which receives the key and returns the cache. Then `clear` method could be called (see [docs](https://www.npmjs.com/package/tiny-lru#clear))

I would like to know your thoughts about it and if you know a better way or a workaround to solve it. Thanks in advance!

## Description
- Added `invalidateCache` decorator

## Related Issue
None

## Example
- Decorator `invalidateCache` (the one is added in this PR for now)
```js
@invalidateCache({
  cacheKeyString: 'HTTPUserRepository#currentSession'
})
@inlineError
logout() {
  // stuff
}
```
- Decorator `injectCache` (another option)
```js
@injectCache({
  cacheKeyString: 'HTTPUserRepository#currentSession'
})
@inlineError
logout() {
  // stuff
  cache.clear()
}
```
