### PR TITLE
feat(sui-ci): pull changes before running release command

### DIFF
--- a/packages/sui-ci/src/release.js
+++ b/packages/sui-ci/src/release.js
@@ -26,6 +26,8 @@ module.exports = async function release({
   }
 
   try {
+    await execute('git pull origin master')
+
     const {stdout} = await execute(
       `sui-mono release --github-email "${gitHubEmail}" --github-user "${gitHubUser}" --github-token ${gitHubToken} --skip-ci`
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updates master branch before starting release process

## Related Issue
We've got this error message in our component's repo

```
To https://github.mpi-internal.com/scmspain/frontend-jobs--uilib-components.git
 * [new tag]           candidate/searchIJ-1.43.0 -> candidate/searchIJ-1.43.0
 ! [rejected]          HEAD -> master (fetch first)
error: failed to push some refs to 'https://github.mpi-internal.com/scmspain/frontend-jobs--uilib-components.git'
hint: Updates were rejected because the remote contains work that you do
hint: not have locally. This is usually caused by another repository pushing
hint: to the same ref. You may want to first integrate the remote changes
hint: (e.g., 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
[sui-mono release] ERROR:
Error: push --tags origin HEAD
    at ChildProcess.<anonymous> (/home/travis/build/scmspain/frontend-jobs--uilib-components/node_modules/@s-ui/helpers/cli.js:99:13)
    at ChildProcess.emit (events.js:315:20)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:275:12)
```
