### PR TITLE
Feat/add new extract comments config

### DIFF
--- a/packages/sui-bundler/README.md
+++ b/packages/sui-bundler/README.md
@@ -146,6 +146,8 @@ This tool works with zero configuration out the box but you could use some confi
 
 `manualCompression`: Compress files manually to gzip and brotli (if supported). Useful to use along with a S3 and Lambda@Edge in order to send the best content for the userAgent. (default: `false`)
 
+`extractComments`: Determine whether comments shall be extracted to a separate file or not. Like LICENSE comments. (default: `false`)
+
 `targets`: Object with information about the browser and version supported. (default: `see the next example`)
 
 ```json

--- a/packages/sui-bundler/shared/config.js
+++ b/packages/sui-bundler/shared/config.js
@@ -1,5 +1,6 @@
 const {config} = require('./')
 
-const {sourcemaps} = config
+const {extractComments, sourcemaps} = config
 
+exports.extractComments = extractComments || true
 exports.sourceMap = sourcemaps && sourcemaps.prod ? sourcemaps.prod : 'none'

--- a/packages/sui-bundler/shared/minify-js.js
+++ b/packages/sui-bundler/shared/minify-js.js
@@ -2,8 +2,9 @@ const TerserPlugin = require('terser-webpack-plugin')
 const {CI = false} = process.env
 const CI_PARALLEL_CORES = 2
 
-module.exports = sourceMap =>
+module.exports = ({extractComments, sourceMap}) =>
   new TerserPlugin({
+    extractComments,
     terserOptions: {
       parse: {
         // we want terser to parse ecma 8 code. However, we don't want it
@@ -39,7 +40,7 @@ module.exports = sourceMap =>
       }
     },
     // Use multi-process parallel running to improve the build speed
-    // For CI: Use only 4 fixed cores as it gives incorrect info and could cause troubles
+    // For CI: Use only fixed cores as it gives incorrect info and could cause troubles
     // Related: https://github.com/webpack-contrib/terser-webpack-plugin/issues/202
     // If not CI then use os.cpus().length - 1
     parallel: CI ? CI_PARALLEL_CORES : true,

--- a/packages/sui-bundler/webpack.config.lib.js
+++ b/packages/sui-bundler/webpack.config.lib.js
@@ -3,7 +3,7 @@ const {cleanList, envVars, MAIN_ENTRY_POINT, config} = require('./shared')
 const minifyJs = require('./shared/minify-js')
 const definePlugin = require('./shared/define')
 const babelRules = require('./shared/module-rules-babel')
-const {sourceMap} = require('./shared/config')
+const {extractComments, sourceMap} = require('./shared/config')
 const parseAlias = require('./shared/parse-alias')
 
 module.exports = {
@@ -25,7 +25,9 @@ module.exports = {
     filename: 'index.js'
   },
   optimization: {
-    minimizer: [minifyJs(sourceMap)]
+    // avoid looping over all the modules after the compilation
+    checkWasmTypes: false,
+    minimizer: [minifyJs({extractComments, sourceMap})]
   },
   plugins: cleanList([
     new webpack.HashedModuleIdsPlugin(),

--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -22,7 +22,7 @@ const {
   navigateFallback,
   runtimeCaching
 } = require('./shared/precache')
-const {sourceMap} = require('./shared/config')
+const {extractComments, sourceMap} = require('./shared/config')
 const parseAlias = require('./shared/parse-alias')
 
 const Externals = require('./plugins/externals')
@@ -57,8 +57,10 @@ module.exports = {
     publicPath: PUBLIC_PATH
   },
   optimization: {
+    // avoid looping over all the modules after the compilation
+    checkWasmTypes: false,
     minimize: true,
-    minimizer: [minifyJs(sourceMap), minifyCss()],
+    minimizer: [minifyJs({extractComments, sourceMap}), minifyCss()],
     runtimeChunk: true,
     splitChunks
   },


### PR DESCRIPTION
- 🆕  `extractComments` config to extract comments, like LICENSE, to a new chunk.
- ⚡ Avoid looping over all the modules after the compilation by disabling `checkWasmTypes`.