### PR TITLE
fix(sui-react-router): fixed Routes below a Route that use regexp

### DIFF
--- a/packages/sui-react-router/src/internal/createTransitionManager.js
+++ b/packages/sui-react-router/src/internal/createTransitionManager.js
@@ -98,9 +98,8 @@ const createReducerRoutesTree = location => (acc, node) => {
       if (acc.remainingPathname === '') {
         acc.isFinished = checkIntegrity(acc.nodes)
       }
-
-      return acc
     }
+    return acc
   }
 
   if (pattern.charAt(0) === '/') {

--- a/packages/sui-react-router/test/common/RouteSpec.js
+++ b/packages/sui-react-router/test/common/RouteSpec.js
@@ -152,6 +152,23 @@ describe('<Route>', () => {
       expect(renderedString).to.equal('<div><p>es</p><p>123</p></div>')
     })
 
+    it('Routes below a regex work properly', async () => {
+      const regexp = /\/user\/(?<userId>[0-9]+)$/
+      const withRoutes = (
+        <Route>
+          <Route regexp={regexp} component={null} />
+          <Route path="/search/:keyword" component={Search} />
+        </Route>
+      )
+      const renderedString = await getRenderedString({
+        location: '/search/works',
+        withRoutes
+      })
+      expect(renderedString)
+        .to.contain('Search Results')
+        .to.contain('works')
+    })
+
     it('works with static paths', async () => {
       const withRoutes = (
         <>


### PR DESCRIPTION
Routes that were placed below a Route with a regexp, were not working

ISSUES CLOSED: #946

<!--- Provide a general summary of your changes in the Title above -->

## Description
After adding the `regexp` feature to `sui-router`, routes that were placed below that one were not working.

For example:
```
<Route path='/static' component={...} />
<Route regexp={...} component={...} />
<Route path='/static2' component={...} />
```
When visiting `/static` we would have no problem. On the other hand, when visiting `/static2` it would not work.

## Related Issue
fix #946 

