### PR TITLE
feat(sui-studio): separate big app chunk in smaller ones to improve build and avoid crash

### DIFF
--- a/packages/sui-studio/src/components/demo/fetch-styles.js
+++ b/packages/sui-studio/src/components/demo/fetch-styles.js
@@ -4,12 +4,14 @@
 const reqThemePlayGround = require.context(
   `!css-loader!sass-loader!${__BASE_DIR__}/demo`,
   true,
-  /^.*\/themes\/.*\.scss/
+  /^.*\/themes\/.*\.scss/,
+  'lazy'
 )
 const reqComponentsSCSS = require.context(
   `!css-loader!sass-loader!${__BASE_DIR__}/components`,
   true,
-  /^\.\/\w+\/\w+\/src\/index\.scss/
+  /^\.\/\w+\/\w+\/src\/index\.scss/,
+  'lazy'
 )
 
 export const themesFor = ({category, component}) =>


### PR DESCRIPTION
It seems that the `app` chunk, that's the problematic one: 
![image](https://user-images.githubusercontent.com/1561955/94959719-ed4fee00-04f1-11eb-9e59-270c281e1b17.png)

So, we're generating all styles in the same chunk. Instead, we're going to be sure the chunks for styles are lazy and thus separated in different chunks. This should benefit terser in order to avoid crashing.

Before (app is 25MB):
![image](https://user-images.githubusercontent.com/1561955/94959998-69e2cc80-04f2-11eb-830a-87ab86ff155a.png)

After (app is 5MB):
![image](https://user-images.githubusercontent.com/1561955/94959419-70bd0f80-04f1-11eb-8973-dfb16f37d519.png)
