### PR TITLE
fix(sui-studio): some api doc tabs not working fine

### DIFF
--- a/packages/sui-studio/src/components/documentation/Api.js
+++ b/packages/sui-studio/src/components/documentation/Api.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, {useEffect, useState} from 'react'
+import React, {Fragment, useEffect, useState} from 'react'
 import {fetchComponentSrcRawFile} from '../tryRequire'
 
 export default function Api({params}) {
@@ -10,7 +10,10 @@ export default function Api({params}) {
       const reactDocs = await import('react-docgen')
       const {category, component} = params
       const rawSource = await fetchComponentSrcRawFile({category, component})
-      const docs = reactDocs.parse(rawSource)
+      const docs = reactDocs.parse(
+        rawSource,
+        reactDocs.resolver.findAllComponentDefinitions
+      )
       setDocs(docs)
     }
     getDocs()
@@ -62,14 +65,21 @@ export default function Api({params}) {
     })
   }
 
-  if (docs) {
-    const {props} = docs
+  const renderComponentDoc = (componentDoc, index = 0) => {
+    const {props} = componentDoc
     return (
-      <>
+      <Fragment key={index}>
+        <h1>{componentDoc.displayName}</h1>
         <h2>Props</h2>
         {renderPropsApi({props})}
-      </>
+      </Fragment>
     )
+  }
+
+  if (docs) {
+    return Array.isArray(docs)
+      ? docs.map(renderComponentDoc)
+      : renderComponentDoc(docs)
   }
 
   return null


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In some cases the api tab is not working due to a multiple exports incidence detected by react-docgen

## Description
<!--- Describe your changes in detail -->
react-docgen provides a resolver solution called `resolver.findAllComponentDefinitions` which analyzes all the module exports in its AST analyzer returning an array of exported elements.
[react-docgen parser resolver](https://github.com/reactjs/react-docgen#resolver)

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
the tooltip API for sui-components it's broken
[sui-components-tooltip](https://sui-components-kjcnxnuko.vercel.app/workbench/atom/tooltip/documentation/api)
and thats the new solution
![image](https://user-images.githubusercontent.com/1674036/96236790-c20ed980-0f9c-11eb-9143-222498d901d1.png)
