### PR TITLE
fix(sui-studio): theme not charged when changing between components despite of presenting it selected in theme selector

### DIFF
--- a/packages/sui-studio/src/components/demo/index.js
+++ b/packages/sui-studio/src/components/demo/index.js
@@ -40,14 +40,14 @@ export default class Demo extends Component {
     themeSelectedIndex: 0
   }
 
-  _init({category, component}) {
+  _init({category, component, theme}) {
     this.setState({
       // clean state in case we're moving from another component
       exports: {default: null}
     })
 
     Promise.all([
-      stylesFor({category, component}),
+      stylesFor({category, component, withTheme: theme}),
       importMainModules({category, component}),
       fetchPlayground({category, component})
     ]).then(async ([style, requiredModules, playground]) => {
@@ -73,7 +73,7 @@ export default class Demo extends Component {
 
   // eslint-disable-next-line
   UNSAFE_componentWillReceiveProps(nextProps) {
-    this._init(nextProps.params)
+    this._init({...nextProps.params, theme: this.state.theme})
   }
 
   componentWillUnmount() {
@@ -149,7 +149,7 @@ export default class Demo extends Component {
 
     return (
       <div className="sui-StudioDemo">
-        <Style>{style}</Style>
+        <Style id="sui-studio-demo-style">{style}</Style>
         <div className="sui-StudioNavBar-secondary">
           <ContextButtons
             ctxt={ctxt || {}}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Acceptance criteria:
1.- Go to a component demo
2.- Select any theme
3.- Select another different component demo
4.- It looks like your demo is returning the theme selected cuz your theme selector menu is displaying it, but the style loaded is the default one.
5.- Go to the first Displayed component (step one).
6.- Select any other theme, and select again the theme selected 4 the bug (step 2). Thats the right style might be presented.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
