### PR TITLE
feat(sui-studio): use native prepare script instead build

### DIFF
--- a/packages/sui-studio/bin/sui-studio-generate.js
+++ b/packages/sui-studio/bin/sui-studio-generate.js
@@ -112,7 +112,7 @@ assets`
   "description": "",
   "main": "lib/index.js",
   "scripts": {
-    "build": "npx rimraf ./lib && npm run build:js && npm run build:styles",
+    "prepare": "npx rimraf ./lib && npm run build:js && npm run build:styles",
     "build:js": "../../../node_modules/.bin/babel --presets sui ./src --out-dir ./lib",
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },


### PR DESCRIPTION
Use native `prepare` script instead `build` as it will be needed for workspaces.