### PR TITLE
feat(sui-mono): detect if should unshallow

### DIFF
--- a/packages/sui-mono/bin/sui-mono-release.js
+++ b/packages/sui-mono/bin/sui-mono-release.js
@@ -164,7 +164,13 @@ const automaticRelease = async ({
   const authURL = new URL(gitURL)
   authURL.username = githubToken
 
-  await exec(`git pull --unshallow`, {cwd})
+  const {
+    stdout: rawIsShallowRepository
+  } = await exec('git rev-parse --is-shallow-repository', {cwd})
+  const isShallowRepository = rawIsShallowRepository === 'true'
+
+  if (isShallowRepository) await exec(`git pull --unshallow --quiet`, {cwd})
+
   await exec(`git config --global user.email "${githubEmail}"`, {cwd})
   await exec(`git config --global user.name "${githubUser}"`, {cwd})
   await exec('git remote rm origin', {cwd})


### PR DESCRIPTION
Detect if should unshallow before doing it to avoid problems on Travis builds like this one:

![image](https://user-images.githubusercontent.com/1561955/96561059-60fa4500-12bf-11eb-9167-1792454ca17f.png)

This is happening as Travis is cloning repos with a 50 commits depth by default. That means that if the repo has less than 50 commits the clone is not a shallow and thus we should not try to unshallow it.