### PR TITLE
fix(sui-bundler): avoid removing magic comments from index html

### DIFF
--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -68,7 +68,17 @@ module.exports = {
     new HtmlWebpackPlugin({
       env: process.env,
       inject: 'head',
-      template: './index.html'
+      template: './index.html',
+      minify: {
+        collapseWhitespace: true,
+        keepClosingSlash: true,
+        minifyCSS: true,
+        minifyURLs: true,
+        removeEmptyAttributes: true,
+        removeRedundantAttributes: true,
+        removeStyleLinkTypeAttributes: true,
+        useShortDoctype: true
+      }
     }),
     new ScriptExtHtmlWebpackPlugin({
       defaultAttribute: 'defer',


### PR DESCRIPTION
We must keep comments from HTML in order to keep using magic comments in our apps.