### PR TITLE
feat(sui-lint): add no-var rule warning

### DIFF
--- a/packages/sui-lint/eslintrc.js
+++ b/packages/sui-lint/eslintrc.js
@@ -237,6 +237,7 @@ module.exports = {
       RULES.ERROR,
       {args: 'none', ignoreRestSiblings: true, varsIgnorePattern: 'React'}
     ],
+    'no-var': RULES.WARNING,
     strict: RULES.OFF,
     'prettier/prettier': [RULES.ERROR, prettierOptions]
   }


### PR DESCRIPTION
Add `no-var` rule to warning so we avoid using `var` instead `let` or `const`.