### PR TITLE
feat(sui-test): add a config to force transpilation of modules via config

### DIFF
--- a/packages/sui-test/README.md
+++ b/packages/sui-test/README.md
@@ -167,7 +167,22 @@ Cypress can be detected as a robot if your server has that kind of protection or
 
 If defined, any error on your tests will create a screenshot of that moment in the `./.tmp/test-e2e/screenshots` folder of your project.
 
+# Config
 
+`@s-ui/test` could use a `config` in your `package.json` to tweak some behaviors. These are
+
+- `server`: Config for `@s-ui/test server` binary:
+  - `forceTranspilation`: List of regexs (string based, later will be transformed with `new Regex`) of modules to transpile. This is useful in case you're using server tests for modules that are ESModules based and need to be transpiled with `@babel/plugin-transform-modules-commonjs`.
+
+```json
+"config": {
+  "sui-test": {
+    "server": {
+      "forceTranspilation": ["@adv-ui/vendor-by-consents-loader"]
+    }
+  }
+}
+```
 
 # Tools
 

--- a/packages/sui-test/bin/mocha/register.js
+++ b/packages/sui-test/bin/mocha/register.js
@@ -1,5 +1,12 @@
+const {serverConfig} = require('../../src/config')
+const {forceTranspilation = []} = serverConfig
+
+const regexToAdd = forceTranspilation.map(
+  regexString => new RegExp(regexString)
+)
+
 require('@babel/register')({
-  only: [/test/, /src/, /@s-ui/, /@babel\/runtime/],
+  only: [/test/, /src/, /@s-ui/, /@babel\/runtime/, ...regexToAdd],
   presets: ['babel-preset-sui'],
   plugins: [
     'babel-plugin-dynamic-import-node',

--- a/packages/sui-test/src/config.js
+++ b/packages/sui-test/src/config.js
@@ -1,0 +1,11 @@
+const {getPackageJson} = require('@s-ui/helpers/packages')
+const {config = {}} = getPackageJson(process.cwd())
+const {'sui-test': suiTestConfig = {}} = config
+
+const {
+  client: clientConfig = {},
+  e2e: e2eConfig = {},
+  server: serverConfig = {}
+} = suiTestConfig
+
+module.exports = {clientConfig, e2eConfig, serverConfig}


### PR DESCRIPTION
🆕 Config to add to the package.json the modules that need to be transpiled for `sui-test server`.

This will simplify and fix all the problems we're facing on different projects where some external modules need to be transpilated because are using ESModules.