### PR TITLE
chore(sui-studio): update react-docgen to ad support to optional chaining

### DIFF
--- a/packages/sui-studio/package.json
+++ b/packages/sui-studio/package.json
@@ -43,7 +43,7 @@
     "just-pascal-case": "1.1.0",
     "normalize.css": "8.0.1",
     "raw-loader": "4.0.1",
-    "react-docgen": "5.3.0"
+    "react-docgen": "5.3.1"
   },
   "sui-bundler": {
     "vendor": [


### PR DESCRIPTION
## Description

The current `react-docgen` version 5.3.0 in the project doesn't have the optional chaining feature support and SUI Studio can't generate de API documentation in few components, like [Autosuggest](https://sui-components.now.sh/workbench/molecule/autosuggest/documentation/api) and show the next error:

```
Uncaught (in promise) Error: did not recognize object of type "ChainExpression"
```

This problem is fixed in the 5.3.1 version after update `ast-types` to [the last version](https://github.com/reactjs/react-docgen/releases/tag/v5.3.1) *(9 days ago)*

### FYI

`react-docgen` solve it in [this commit](https://github.com/reactjs/react-docgen/pull/468/files) 

## Solution

Update the dependency to 5.3.1 😊
