### PR TITLE
Feat/generate components with new adoptions

### DIFF
--- a/packages/sui-studio-create/package.json
+++ b/packages/sui-studio-create/package.json
@@ -9,15 +9,12 @@
   "preferGlobal": true,
   "keywords": [
     "SUIComponents",
-    "schibsted",
-    "reactjs"
+    "SUI Studio",
+    "SUI Studio Create"
   ],
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@s-ui/helpers": "1",
-    "colors": "1.4.0",
-    "commander": "6.1.0",
     "fs-extra": "9.0.1"
   },
   "repository": {

--- a/packages/sui-studio-create/src/index.js
+++ b/packages/sui-studio-create/src/index.js
@@ -1,60 +1,39 @@
 #!/usr/bin/env node
 /* eslint no-console:0 */
 
-const colors = require('colors')
-const program = require('commander')
 const BASE_DIR = process.cwd()
 const fse = require('fs-extra')
-const {getSpawnPromise} = require('@s-ui/helpers/cli')
+const {spawn} = require('child_process')
 
-program
-  .on('--help', () => {
-    console.log('  Examples:')
-    console.log('')
-    console.log('    $ sui-studio-create <project-name>')
-    console.log('    $ sui-studio-create sui-studio')
-    console.log('    $ sui-studio-create --help')
-    console.log('    $ sui-studio-create -h')
-    console.log('')
-  })
-  .parse(process.argv)
+const [, , param] = process.argv
+const HELP_PARAM = ['--help', '-h']
 
-const [PROJECT_NAME] = program.args
-const PROJECT_PATH = `${BASE_DIR}/${PROJECT_NAME}`
+const createDir = path => fse.mkdirp(path)
+const writeFile = (path, body) => fse.outputFile(path, body)
 
 const showError = msg => {
-  program.outputHelp(txt => colors.red(txt))
-  console.error(colors.red(msg))
+  console.error('Error:')
+  console.error(msg)
   process.exit(1)
 }
 
-const writeFile = (path, body) => {
-  return fse
-    .outputFile(path, body)
-    .then(() => {
-      console.log(colors.gray(`Modified ${path}`))
-    })
-    .catch(err => {
-      showError(`Fail modifying ${path}`)
-      throw err
-    })
+const showHelp = () => {
+  console.log('  Examples:')
+  console.log('')
+  console.log('    $ sui-studio-create <project-name>')
+  console.log('    $ sui-studio-create sui-studio')
+  console.log('    $ sui-studio-create --help')
+  console.log('    $ sui-studio-create -h')
+  console.log('')
+  process.exit(0)
 }
 
-const createDir = path => {
-  fse
-    .mkdirp(path)
-    .then(() => {
-      console.log(colors.gray(`Created ${path}`))
-    })
-    .catch(err => {
-      showError(`Fail creating ${path}`)
-      throw err
-    })
+if (HELP_PARAM.includes(param) || !param) {
+  showHelp()
 }
 
-if (!PROJECT_NAME) {
-  showError('the project name must be defined')
-}
+const PROJECT_NAME = param
+const PROJECT_PATH = `${BASE_DIR}/${PROJECT_NAME}`
 
 Promise.all([
   createDir(`${PROJECT_PATH}/components`),
@@ -80,7 +59,6 @@ Promise.all([
     "build": "sui-studio build",
     "check:release": "sui-studio check-release",
     "co": "sui-studio commit",
-    "commitmsg": "validate-commit-msg",
     "dev": "sui-studio dev",
     "generate": "sui-studio generate --prefix sui --scope ${PROJECT_NAME}",
     "lint:js": "sui-lint js",
@@ -88,7 +66,6 @@ Promise.all([
     "lint": "npm run lint:js && npm run lint:sass",
     "phoenix:ci": "npx @s-ui/mono phoenix --ci && (cd demo && npx @s-ui/mono phoenix --ci)",
     "phoenix": "npx @s-ui/mono phoenix && (cd demo && npx @s-ui/mono phoenix)",
-    "precommit": "sui-precommit run",
     "release": "sui-studio release",
     "start": "sui-studio start"
   },
@@ -98,11 +75,13 @@ Promise.all([
   "license": "MIT",
   "devDependencies": {
     "@s-ui/precommit": "2",
-    "@s-ui/studio": "7",
-    "husky": "0.14.3",
+    "@s-ui/studio": "9",
+    "husky": "4.2.5",
     "validate-commit-msg": "2.14.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@s-ui/component-dependencies": "1"
+  },
   "config": {
     "sui-mono": {
       "packagesFolder": "./components",
@@ -117,11 +96,24 @@ Promise.all([
   },
   "stylelint": {
     "extends": "./node_modules/@s-ui/lint/stylelint.config.js"
+  },
+  "husky": {
+    "hooks": {
+      "commit-msg": "validate-commit-msg",
+      "pre-commit": "sui-precommit run"
+    }
   }
 }
 `
     )
   )
-  .then(() => getSpawnPromise('npm', ['i'], {cwd: PROJECT_PATH}))
-  .then(process.exit)
-  .catch(process.exit)
+  .then(() => {
+    console.log(
+      '[sui-studio-create] Created folder structure. Installing dependencies...'
+    )
+    spawn('npm', ['install', '--no-fund', '--no-audit'], {
+      cwd: PROJECT_PATH,
+      stdio: 'inherit'
+    })
+  })
+  .catch(showError)

--- a/packages/sui-studio-create/src/index.js
+++ b/packages/sui-studio-create/src/index.js
@@ -11,12 +11,6 @@ const HELP_PARAM = ['--help', '-h']
 const createDir = path => fse.mkdirp(path)
 const writeFile = (path, body) => fse.outputFile(path, body)
 
-const showError = msg => {
-  console.error('Error:')
-  console.error(msg)
-  process.exit(1)
-}
-
 const showHelp = () => {
   console.log('  Examples:')
   console.log('')
@@ -116,4 +110,8 @@ Promise.all([
       stdio: 'inherit'
     })
   })
-  .catch(showError)
+  .catch(err => {
+    console.error('Error:')
+    console.error(err)
+    process.exit(1)
+  })

--- a/packages/sui-studio/bin/sui-studio-generate.js
+++ b/packages/sui-studio/bin/sui-studio-generate.js
@@ -116,7 +116,7 @@ assets`
     "build:js": "../../../node_modules/.bin/babel --presets sui ./src --out-dir ./lib",
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@s-ui/component-dependencies": "1"
   },${
     repository.url
@@ -140,8 +140,7 @@ assets`
 
   writeFile(
     COMPONENT_ENTRY_JS_POINT_FILE,
-    `import React from 'react'
-// import PropTypes from 'prop-types'
+    `// import PropTypes from 'prop-types'
 
 export default function ${componentInPascal}() {
   return (
@@ -235,7 +234,6 @@ return (<${componentInPascal} />)
 /* eslint react/jsx-no-undef:0 */
 /* eslint no-undef:0 */
 
-import React from 'react'
 import ReactDOM from 'react-dom'
 
 import chai, {expect} from 'chai'


### PR DESCRIPTION
@s-ui/studio-create:
- Remove not needed dependencies. From 45s of install to 2s.
- Upgrade created studio with correct version dependencies and tools.
- Use new jsx import.

@s-ui/studio:
- On generating a new component, put @s-ui/component-dependencies as peer instead dependency.
