### PR TITLE
fix(sui-studio): fix themes on dev mode

### DIFF
--- a/packages/sui-studio/workbench/src/app.js
+++ b/packages/sui-studio/workbench/src/app.js
@@ -24,9 +24,10 @@ const params = queryStringToJSON(window.location.href)
 const importAll = requireContext => requireContext.keys().map(requireContext)
 
 ;(async () => {
-  const defaultStyle = await import(
+  const {default: defaultStyle} = await import(
     '!css-loader!sass-loader!component/index.scss'
   )
+
   let styles = []
   let requireContextThemesKeys = []
   try {
@@ -58,7 +59,9 @@ const importAll = requireContext => requireContext.keys().map(requireContext)
 
   const contexts = isFunction(ctxt) ? await ctxt() : ctxt
   const themes = requireContextThemesKeys.reduce((acc, path, index) => {
-    acc[path.replace('./', '').replace('.scss', '')] = styles[index]
+    const style = styles[index]
+    const themeName = path.replace('./', '').replace('.scss', '')
+    acc[themeName] = style.default || style
     return acc
   }, {})
 
@@ -67,11 +70,11 @@ const importAll = requireContext => requireContext.keys().map(requireContext)
 
   ReactDOM.render(
     <ComponentToRender
-      contexts={contexts}
-      themes={{...themes, default: defaultStyle.default}}
       componentID={__COMPONENT_ID__}
+      contexts={contexts}
       demo={DemoComponent}
       demoStyles={demoStyles}
+      themes={{...themes, default: defaultStyle}}
       {...params}
     />,
     document.getElementById('app')


### PR DESCRIPTION
Use `default` on all styles as `ESModules` are not used by default on new @s-ui/bundler.

This fixes missing styles on dev mode for components using demo.js playground.