### PR TITLE
feat(sui-react-router): use new React jsx import from babel

### DIFF
--- a/packages/sui-react-router/README.md
+++ b/packages/sui-react-router/README.md
@@ -240,7 +240,6 @@ Returns the current location object. This is useful any time you need to know al
 For example, you could create a hook to send a page view to your analytics tracker:
 
 ```js
-import React from 'react'
 import {useLocation} from '@s-ui/react-router'
 
 function usePageViewToGoogleAnalytics() {
@@ -303,7 +302,6 @@ Extract the matched params in a `path` in any place of your tree, in order
 
 
 ```js
-import React from 'react'
 import {useParams} from '@s-ui/react-router'
 
 function BlogPost() {

--- a/packages/sui-react-router/src/Link.js
+++ b/packages/sui-react-router/src/Link.js
@@ -1,6 +1,6 @@
 // from: https://github.com/ReactTraining/react-router/blob/v3/modules/Link.js
 
-import React, {useCallback} from 'react'
+import {useCallback} from 'react'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 

--- a/packages/sui-react-router/src/Router.js
+++ b/packages/sui-react-router/src/Router.js
@@ -1,4 +1,4 @@
-import React, {createElement as h, useState, useEffect} from 'react'
+import {createElement as h, useState, useEffect} from 'react'
 import PropTypes from 'prop-types'
 
 import {routes, components} from './internal/PropTypes'

--- a/packages/sui-react-router/src/internal/ReactUtils.js
+++ b/packages/sui-react-router/src/internal/ReactUtils.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import {Children as ReactChildren, isValidElement} from 'react'
 
 import IndexRoute from '../IndexRoute'
 import Redirect from '../Redirect'
@@ -12,7 +12,7 @@ import Redirect from '../Redirect'
 export const fromReactTreeToJSON = (root, parent = {}, level = 1) => {
   // Ignore non-elements. This allows people to more
   // easily inline conditionals in their route config.
-  if (!React.isValidElement(root)) return
+  if (!isValidElement(root)) return
 
   const {props, type} = root
   const {component, path, children, getComponent, id, from, to, regexp} = props
@@ -44,7 +44,7 @@ export const fromReactTreeToJSON = (root, parent = {}, level = 1) => {
   if (getComponent) node.getComponent = getComponent
   if (path) node.path = path
   if (children)
-    node.children = React.Children.toArray(children).map(child =>
+    node.children = ReactChildren.toArray(children).map(child =>
       fromReactTreeToJSON(child, node, level + 1)
     )
 

--- a/packages/sui-react-router/src/withRouter.js
+++ b/packages/sui-react-router/src/withRouter.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import {useRouter} from './hooks'
 import hoistNonReactStatics from 'hoist-non-react-statics'
 

--- a/packages/sui-react-router/test/browser/LinkSpec.js
+++ b/packages/sui-react-router/test/browser/LinkSpec.js
@@ -1,5 +1,4 @@
 import {expect} from 'chai'
-import React from 'react'
 import {Router, Route, Link} from '../../src/index'
 import {render, fireEvent, screen} from '@testing-library/react'
 import sinon from 'sinon'

--- a/packages/sui-react-router/test/common/IndexRouteSpec.js
+++ b/packages/sui-react-router/test/common/IndexRouteSpec.js
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 
 import {expect} from 'chai'
-import React from 'react'
 import {renderToString} from 'react-dom/server'
 import {Router, Route, IndexRoute, match} from '../../src/index'
 

--- a/packages/sui-react-router/test/common/LinkSpec.js
+++ b/packages/sui-react-router/test/common/LinkSpec.js
@@ -1,5 +1,4 @@
 import {expect} from 'chai'
-import React from 'react'
 import {renderToString} from 'react-dom/server'
 import {Router, Route, Link, match} from '../../src/index'
 

--- a/packages/sui-react-router/test/common/RedirectSpec.js
+++ b/packages/sui-react-router/test/common/RedirectSpec.js
@@ -1,5 +1,4 @@
 import {expect} from 'chai'
-import React from 'react'
 import {Route, Redirect, match} from '../../src'
 
 const getRedirectLocationFor = ({path = '/', withRoutes}) => {

--- a/packages/sui-react-router/test/common/RouteSpec.js
+++ b/packages/sui-react-router/test/common/RouteSpec.js
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 
 import {expect} from 'chai'
-import React from 'react'
 import {renderToString} from 'react-dom/server'
 import {IndexRoute, Router, Route, match} from '../../src/index'
 

--- a/packages/sui-react-router/test/common/hooksSpec.js
+++ b/packages/sui-react-router/test/common/hooksSpec.js
@@ -1,5 +1,4 @@
 import {expect} from 'chai'
-import React from 'react'
 import {renderToString} from 'react-dom/server'
 import {
   Route,

--- a/packages/sui-react-router/test/common/matchSpec.js
+++ b/packages/sui-react-router/test/common/matchSpec.js
@@ -1,5 +1,4 @@
 import {expect} from 'chai'
-import React from 'react'
 import {Redirect, Route, match} from '../../src/index'
 
 const matchPromise = ({location = '/', withRoutes}) => {

--- a/packages/sui-react-router/test/common/withRouterSpec.js
+++ b/packages/sui-react-router/test/common/withRouterSpec.js
@@ -1,5 +1,4 @@
 import {expect} from 'chai'
-import React from 'react'
 import {renderToString} from 'react-dom/server'
 import {withRouter, Router, Route, match} from '../../src/index'
 


### PR DESCRIPTION
Use new JSX by avoiding importing React manually.