### PR TITLE
fix(sui-lint): use it without babel preset sui for node projects

### DIFF
--- a/packages/sui-lint/eslintrc.js
+++ b/packages/sui-lint/eslintrc.js
@@ -185,7 +185,12 @@ const TESTING_RULES = {
   'no-only-tests/no-only-tests': RULES.ERROR
 }
 
-const resolvedBabelPresetSui = require.resolve('babel-preset-sui')
+let resolvedBabelPresetSui = false
+try {
+  require.resolve('babel-preset-sui')
+  resolvedBabelPresetSui = true
+} catch {}
+
 const parser = resolvedBabelPresetSui ? '@babel/eslint-parser' : undefined
 
 module.exports = {


### PR DESCRIPTION
Checking for `babel-preset-sui` should be done with a `try/catch` to avoid this problem:

![image](https://user-images.githubusercontent.com/1561955/100094820-e2fb0200-2e59-11eb-9b8d-deb995af0c9d.png)

With that fix, `@s-ui/lint` will work on pure node projects without `babel-preset-sui` installed.