### PR TITLE
fix(sui-hoc): define default state with prop

### DIFF
--- a/packages/sui-hoc/src/withOpenToggle.js
+++ b/packages/sui-hoc/src/withOpenToggle.js
@@ -5,7 +5,7 @@ export default BaseComponent => {
 
   return class WithOpenToggle extends Component {
     state = {
-      isOpen: !!this.props.isOpen // eslint-disable-line
+      isOpen: !!this.props.isOpen // eslint-disable-line react/prop-types
     }
 
     static displayName = `WithOpenToggle(${displayName})`

--- a/packages/sui-hoc/src/withOpenToggle.js
+++ b/packages/sui-hoc/src/withOpenToggle.js
@@ -1,14 +1,20 @@
 import React, {Component} from 'react'
+import PropTypes from 'prop-types'
 
 export default BaseComponent => {
   const displayName = BaseComponent.displayName
 
   return class WithOpenToggle extends Component {
     state = {
-      isOpen: !!this.props.isOpen // eslint-disable-line react/prop-types
+      isOpen: !!this.props.isOpen
     }
 
     static displayName = `WithOpenToggle(${displayName})`
+
+    static propTypes = {
+      /** isOpen */
+      isOpen: PropTypes.boolean
+    }
 
     handleToggle = (_, {isOpen} = {}) => {
       this.setState(prevState => ({

--- a/packages/sui-hoc/src/withOpenToggle.js
+++ b/packages/sui-hoc/src/withOpenToggle.js
@@ -5,7 +5,7 @@ export default BaseComponent => {
 
   return class WithOpenToggle extends Component {
     state = {
-      isOpen: Boolean(this.props.isOpen) // eslint-disable-line
+      isOpen: !!this.props.isOpen // eslint-disable-line
     }
 
     static displayName = `WithOpenToggle(${displayName})`

--- a/packages/sui-hoc/src/withOpenToggle.js
+++ b/packages/sui-hoc/src/withOpenToggle.js
@@ -5,7 +5,7 @@ export default BaseComponent => {
 
   return class WithOpenToggle extends Component {
     state = {
-      isOpen: false
+      isOpen: Boolean(this.props.isOpen) // eslint-disable-line
     }
 
     static displayName = `WithOpenToggle(${displayName})`


### PR DESCRIPTION
## Description

We use this HOC to add Toggle behavior in components, such as `MoleculeAutosuggest`, and the default state to `isOpen` is **false**, ignoring the prop `isOpen`.

We have a use case to load the Autosuggest showing the options, so we need to use the `isOpen` prop to do it.

## Demo

<img width="1913" alt="Contacts Labels" src="https://user-images.githubusercontent.com/1307927/100447819-8a25a680-30b1-11eb-85b2-855916f54bdf.png">



