### PR TITLE
fix(sui-domain): avoid transforming with Babel to avoid problems with @s-ui/test

### DIFF
--- a/packages/sui-domain/src/Entity.js
+++ b/packages/sui-domain/src/Entity.js
@@ -1,3 +1,14 @@
+import inherits from './inherits'
 import AnemicModel from './AnemicModel'
 
-export default class Entity extends AnemicModel {}
+const Entity = (function(_AnemicModel) {
+  inherits(Entity, _AnemicModel)
+
+  function Entity() {
+    return _AnemicModel.apply(this, arguments) || this
+  }
+
+  return Entity
+})(AnemicModel)
+
+export {Entity as default}

--- a/packages/sui-domain/src/ValueObject.js
+++ b/packages/sui-domain/src/ValueObject.js
@@ -1,3 +1,14 @@
+import inherits from './inherits'
 import AnemicModel from './AnemicModel'
 
-export default class ValueObject extends AnemicModel {}
+const ValueObject = (function(_AnemicModel) {
+  inherits(ValueObject, _AnemicModel)
+
+  function ValueObject() {
+    return _AnemicModel.apply(this, arguments) || this
+  }
+
+  return ValueObject
+})(AnemicModel)
+
+export {ValueObject as default}

--- a/packages/sui-domain/src/inherits.js
+++ b/packages/sui-domain/src/inherits.js
@@ -1,5 +1,5 @@
 export default function inheritsLoose(subClass, superClass) {
   subClass.prototype = Object.create(superClass.prototype)
   subClass.prototype.constructor = subClass
-  subClass.__proto__ = superClass
+  subClass.__proto__ = superClass // eslint-disable-line no-proto
 }

--- a/packages/sui-domain/src/inherits.js
+++ b/packages/sui-domain/src/inherits.js
@@ -1,0 +1,5 @@
+export default function inheritsLoose(subClass, superClass) {
+  subClass.prototype = Object.create(superClass.prototype)
+  subClass.prototype.constructor = subClass
+  subClass.__proto__ = superClass
+}


### PR DESCRIPTION
Avoid the transformation of the Babel. So we move the ugly transformation to deal with ESModules on node.js for now. 
Not ideal solution but solving the problem for now.