### PR TITLE
feat(sui-i18n): add currency symbol support

### DIFF
--- a/packages/sui-i18n/README.md
+++ b/packages/sui-i18n/README.md
@@ -117,7 +117,9 @@ if (global.Intl) {
 }
 ```
 
-### Setting a currency
+### Currency
+
+#### Setting a currency
 
 We can format price numbers by setting a currency in our app. Number will be formatted regarding culture and currency set.
 
@@ -136,6 +138,25 @@ i18n.culture = 'en-GB';
 i18n.currency = 'GBP';
 i18n.c(1000) //=> £1,000
 i18n.c(1000000) //=> £1,000,000
+```
+
+#### Currency symbol
+
+Get the currency symbol.
+
+```javascript
+import I18n from '@s-ui/i18n';
+import Polyglot from '@s-ui/i18n/lib/adapters/polyglot';
+
+const i18n = new I18n({adapter: new Polyglot()});
+
+i18n.culture = 'es-ES';
+i18n.currency = 'EUR';
+i18n.currencySymbol //=> €
+
+i18n.culture = 'en-GB';
+i18n.currency = 'GBP';
+i18n.currencySymbol //=> £
 ```
 
 ### Formatting minor types

--- a/packages/sui-i18n/src/i18n.js
+++ b/packages/sui-i18n/src/i18n.js
@@ -40,6 +40,21 @@ export default class Rosetta {
     return this._currency
   }
 
+  get currencySymbol() {
+    const value = this.n(0, {
+      style: 'currency',
+      currency: this.currency,
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0
+    })
+
+    if (typeof value !== 'string') {
+      return
+    }
+
+    return value.replace(/\d/g, '').trim()
+  }
+
   get languages() {
     return this._languages
   }

--- a/packages/sui-i18n/test/i18nSpec.js
+++ b/packages/sui-i18n/test/i18nSpec.js
@@ -97,6 +97,10 @@ describe('I18N', () => {
         it('formats number 1000000 properly', () => {
           expect(i18n.c(1000000)).to.eql('£1,000,000')
         })
+
+        it('gets currency symbol', () => {
+          expect(i18n.currencySymbol).to.eql('£')
+        })
       })
 
       describe('with euro (EUR) as currency type', () => {
@@ -113,6 +117,10 @@ describe('I18N', () => {
 
         it('formats number 1000000 properly', () => {
           expect(i18n.c(1000000)).to.eql('€1,000,000')
+        })
+
+        it('gets currency symbol', () => {
+          expect(i18n.currencySymbol).to.eql('€')
         })
       })
     })


### PR DESCRIPTION
Currency symbol 💲

## Description
This PR adds currency symbol support

## Related Issue
None

## Example
```js
i18n.currency = 'USD';
console.log(i18n.currencySymbol) // $
```