### PR TITLE
feat(sui-bundler): remove dependencies and use newest webpack-manifest-plugin

### DIFF
--- a/packages/sui-bundler/bin/sui-bundler-build.js
+++ b/packages/sui-bundler/bin/sui-bundler-build.js
@@ -121,8 +121,6 @@ webpack(nextConfig).run(async (error, stats) => {
       'utf-8'
     )
 
-    console.log(swTemplate)
-
     // replace all the variables from the template with the actual values
     const swCode = swTemplate
       .replace('// IMPORT_SCRIPTS_HERE', stringImportScripts)
@@ -135,8 +133,6 @@ webpack(nextConfig).run(async (error, stats) => {
         "require('static-statics-cache-only')",
         JSON.stringify(manifestStatics)
       )
-
-    console.log(swCode)
 
     const {code: minifiedSw} = await minify(swCode, {sourceMap: false})
     const swFilePath = path.resolve(

--- a/packages/sui-bundler/bin/sui-bundler-build.js
+++ b/packages/sui-bundler/bin/sui-bundler-build.js
@@ -2,13 +2,12 @@
 /* eslint-disable no-console */
 
 const fs = require('fs')
-const minifyStream = require('minify-stream')
 const path = require('path')
 const program = require('commander')
-const replaceStream = require('replacestream')
 const rimraf = require('rimraf')
-const staticModule = require('static-module')
 const webpack = require('webpack')
+const {minify} = require('terser')
+const {writeFile} = require('@s-ui/helpers/file')
 
 const config = require('../webpack.config.prod')
 const linkLoaderConfigBuilder = require('../loaders/linkLoaderConfigBuilder')
@@ -59,7 +58,7 @@ if (clean) {
 
 log.processing('Generating minified bundle. This will take a moment...')
 
-webpack(nextConfig).run((error, stats) => {
+webpack(nextConfig).run(async (error, stats) => {
   if (error) {
     log.error(error)
     return 1
@@ -116,23 +115,36 @@ webpack(nextConfig).run((error, stats) => {
     Boolean(importScripts.length) &&
       console.log('\nExternal Scripts Added to the SW:\n', stringImportScripts)
 
-    // generates the service worker
-    fs.createReadStream(path.resolve(__dirname, '..', 'service-worker.js'))
-      .pipe(replaceStream('// IMPORT_SCRIPTS_HERE', stringImportScripts))
-      .pipe(
-        staticModule({
-          'static-manifest': () => JSON.stringify(manifestStatics),
-          'static-cache-name': () => JSON.stringify(Date.now().toString()),
-          'static-statics-cache-only': () => JSON.stringify(staticsCacheOnly)
-        })
+    // read the service worker template
+    const swTemplate = fs.readFileSync(
+      path.resolve(__dirname, '..', 'service-worker.js'),
+      'utf-8'
+    )
+
+    console.log(swTemplate)
+
+    // replace all the variables from the template with the actual values
+    const swCode = swTemplate
+      .replace('// IMPORT_SCRIPTS_HERE', stringImportScripts)
+      .replace("require('static-manifest')", JSON.stringify(staticsCacheOnly))
+      .replace(
+        "require('static-cache-name')",
+        JSON.stringify(Date.now().toString())
       )
-      .pipe(minifyStream({sourceMap: false}))
-      .pipe(
-        fs.createWriteStream(
-          path.resolve(process.cwd(), 'public', 'service-worker.js')
-        )
+      .replace(
+        "require('static-statics-cache-only')",
+        JSON.stringify(manifestStatics)
       )
 
+    console.log(swCode)
+
+    const {code: minifiedSw} = await minify(swCode, {sourceMap: false})
+    const swFilePath = path.resolve(
+      process.cwd(),
+      'public',
+      'service-worker.js'
+    )
+    await writeFile(swFilePath, minifiedSw)
     console.log('\nService worker generated succesfully!\n')
   }
 

--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/bundler",
-  "version": "7.12.0-beta.0",
+  "version": "7.11.0",
   "description": "Config-free bundler for ES6 React apps.",
   "bin": {
     "sui-bundler": "./bin/sui-bundler.js"

--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/bundler",
-  "version": "7.11.0",
+  "version": "7.12.0-beta.0",
   "description": "Config-free bundler for ES6 React apps.",
   "bin": {
     "sui-bundler": "./bin/sui-bundler.js"
@@ -34,23 +34,20 @@
     "fast-glob": "3.2.4",
     "fibers": "5.0.0",
     "html-webpack-plugin": "4.5.0",
-    "mini-css-extract-plugin": "1.3.2",
-    "minify-stream": "2.1.0",
+    "mini-css-extract-plugin": "1.3.3",
     "null-loader": "4.0.1",
     "postcss": "7.0.35",
     "postcss-loader": "4.1.0",
     "react-dev-utils": "11.0.1",
-    "replacestream": "4.0.3",
     "rimraf": "3.0.2",
     "sass": "1.30.0",
     "sass-loader": "10.1.0",
-    "static-module": "3.0.4",
     "style-loader": "2.0.0",
     "terser-webpack-plugin": "4.2.2",
     "webpack": "4.44.2",
     "webpack-bundle-analyzer": "4.2.0",
     "webpack-dev-server": "3.11.0",
-    "webpack-manifest-plugin": "2.2.0",
+    "webpack-manifest-plugin": "3.0.0",
     "webpack-node-externals": "2.5.2"
   }
 }

--- a/packages/sui-bundler/service-worker.js
+++ b/packages/sui-bundler/service-worker.js
@@ -4,11 +4,11 @@
 // IMPORT_SCRIPTS_HERE
 
 // will be replaced in build time by the real manifest.json content
-const manifestStatics = require('static-manifest')()
+const manifestStatics = require('static-manifest')
 // will be replaced in build time by the current timestamp
-const cacheName = require('static-cache-name')()
+const cacheName = require('static-cache-name')
 // will be replaced in build time and set to true if offline.staticsCacheOnly flag activated
-const staticsCacheOnly = require('static-statics-cache-only')()
+const staticsCacheOnly = require('static-statics-cache-only')
 
 const OFFLINE_PAGE = 'offline.html'
 let supportsResponseBodyStream

--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -3,7 +3,7 @@ const webpack = require('webpack')
 const path = require('path')
 
 const HtmlWebpackPlugin = require('html-webpack-plugin')
-const ManifestPlugin = require('webpack-manifest-plugin')
+const {WebpackManifestPlugin} = require('webpack-manifest-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const InlineChunkHtmlPlugin = require('react-dev-utils/InlineChunkHtmlPlugin')
 
@@ -88,7 +88,7 @@ module.exports = {
       template: './index.html'
     }),
     new InlineChunkHtmlPlugin(HtmlWebpackPlugin, [/runtime/]),
-    new ManifestPlugin({fileName: 'asset-manifest.json'})
+    new WebpackManifestPlugin({fileName: 'asset-manifest.json'})
   ]),
   module: {
     rules: cleanList([


### PR DESCRIPTION
- [x] Upgrade `webpack-manifest-plugin` with `webpack@5` compatibility and smaller.
- [x] Remove not needed dependencies by making simpler (not shorter 😆) the service-worker creation and reusing `terser`.

Package goes from 85MB to 79MB with these changes. ~8% less.