### PR TITLE
feat(babel-preset-sui): avoid removing propTypes and wrap with NODE_ENV static check

### DIFF
--- a/packages/babel-preset-sui/src/index.js
+++ b/packages/babel-preset-sui/src/index.js
@@ -14,7 +14,7 @@ const plugins = (api, {useESModules = true} = {}) => [
   [
     require('babel-plugin-transform-react-remove-prop-types').default,
     {
-      removeImport: true
+      mode: 'wrap'
     }
   ],
   [


### PR DESCRIPTION
Use wrap mode instead removing them directly so dev environments still has prop types.

Anyway propTypes will be removed by terser on Production.