### PR TITLE
feat(sui-js): update bowser version

### DIFF
--- a/packages/sui-js/package.json
+++ b/packages/sui-js/package.json
@@ -9,7 +9,7 @@
   "keywords": [],
   "author": "",
   "dependencies": {
-    "bowser": "1.8.1",
+    "bowser": "2.11.0",
     "cookie": "0.3.1",
     "htmr": "0.8.8",
     "js-cookie": "2.1.4",

--- a/packages/sui-js/src/ua-parser/index.js
+++ b/packages/sui-js/src/ua-parser/index.js
@@ -1,13 +1,13 @@
-import bowser from 'bowser'
+import bowser, {PLATFORMS_MAP} from 'bowser'
 
 export const stats = userAgent => {
-  const ua = bowser._detect(userAgent)
+  const ua = bowser.parse(userAgent)
 
   return {
-    isMobile: Boolean(ua.mobile),
-    osName: ua.osname,
-    browserName: ua.name,
-    browserVersion: ua.version,
-    isTablet: Boolean(ua.tablet)
+    isMobile: ua.platform.type === PLATFORMS_MAP.mobile,
+    osName: ua.os.name,
+    browserName: ua.browser.name,
+    browserVersion: ua.browser.version,
+    isTablet: ua.platform.type === PLATFORMS_MAP.tablet
   }
 }


### PR DESCRIPTION
 Update bowser version

## Description
Update the latest version of the bowser library that includes the latest updates of the google bot user agents.

With the current version, it is not returning the user agent correctly when it is a google bot. Example:
"Mozilla / 5.0 (Linux; Android 6.0.1; Nexus 5X Build / MMB29P) AppleWebKit / 537.36 (KHTML, like Gecko) Chrome / 87.0.4280.88 Mobile Safari / 537.36 (compatible; Googlebot / 2.1; + http: // www. google.com/bot.html) ", it is returning us as browserName" Chrome "instead of" Google bot"

https://github.com/lancedikson/bowser/blob/master/README.md