### PR TITLE
fix(sui-widget-embedder): widgets not loading in dev mode

### DIFF
--- a/packages/sui-widget-embedder/compiler/development.js
+++ b/packages/sui-widget-embedder/compiler/development.js
@@ -8,6 +8,10 @@ module.exports = ({address, page, port}) =>
     ...devConfig,
     context: path.resolve(process.cwd(), 'pages', page),
     entry: [`./index.js`],
+    optimization: {
+      ...devConfig.optimization,
+      runtimeChunk: false
+    },
     output: {
       path: '/',
       publicPath: `http://${address}:${port}/`,


### PR DESCRIPTION
## Description
Widget are not working in dev mode, the bundle.js file is without the transpiled code 