### PR TITLE
feat(sui-test): add support to parallelization

### DIFF
--- a/packages/sui-test/README.md
+++ b/packages/sui-test/README.md
@@ -139,6 +139,9 @@ Then you can use in your specs `cy.login()`
     -h, --help                               output usage information
     -b, --browser <browser>                  Select a different browser (chrome|edge|firefox)
     -N, --noWebSecurity                      Disable all web securities (CORS)
+    -K, --key                                It is used to authenticate the project into the Dashboard Service
+    -P, --parallel                           Run tests on parallel
+    -R, --record                             Record tests and send result to Dashboard Service
 ```
 
 #### `sui-test e2e --gui`

--- a/packages/sui-test/bin/sui-test-e2e.js
+++ b/packages/sui-test/bin/sui-test-e2e.js
@@ -106,8 +106,6 @@ if (ci) {
 }
 
 if (key) cypressConfig.key = key
-if (parallel) cypressConfig.parallel = true
-if (record) cypressConfig.record = true
 if (group) cypressConfig.group = group
 
 let projectURI = CYPRESS_FOLDER_PATH
@@ -134,7 +132,10 @@ resolveLazyNPMBin('cypress/bin/cypress', `cypress@${CYPRESS_VERSION}`)
       gui ? 'open' : 'run',
       '--config=' + objectToCommaString(cypressConfig),
       '--project=' + projectURI,
-      browser && '--browser=' + browser
+      key && '--key=' + key,
+      browser && '--browser=' + browser,
+      parallel && '--parallel',
+      record && '--record'
     ])
   )
   .catch(showError)

--- a/packages/sui-test/bin/sui-test-e2e.js
+++ b/packages/sui-test/bin/sui-test-e2e.js
@@ -53,12 +53,14 @@ program
   )
   .option('-N, --noWebSecurity', 'Disable all web securities')
   .option('-G, --gui', 'Run the tests in GUI mode.')
+  .option('-P, --parallel', 'Run tests on parallelRun tests on parallel')
   .option('-R, --record', 'Record tests and send result to Dashboard Service')
-  .option('-C, --ci', 'Continuos integration mode, reduces memory consumption')
+  .option('-C, --ci', 'Continuous integration mode, reduces memory consumption')
   .option(
     '-K, --key <key>',
     'It is used to authenticate the project into the Dashboard Service'
   )
+  .option('--group', 'Combines tests in different groups')
   .on('--help', () => console.log(HELP_MESSAGE))
   .parse(process.argv)
 
@@ -66,9 +68,11 @@ const {
   baseUrl,
   browser,
   ci,
+  group,
   gui,
   key,
   noWebSecurity,
+  parallel,
   record,
   scope,
   screenshotsOnError,
@@ -101,6 +105,11 @@ if (ci) {
   cypressConfig.numSnapshotsKeptInMemory = 1
 }
 
+if (key) cypressConfig.key = key
+if (parallel) cypressConfig.parallel = true
+if (record) cypressConfig.record = true
+if (group) cypressConfig.group = group
+
 let projectURI = CYPRESS_FOLDER_PATH
 if (noWebSecurity) {
   const defaultConfig = require(path.join(CYPRESS_FOLDER_PATH, 'cypress.json'))
@@ -124,10 +133,8 @@ resolveLazyNPMBin('cypress/bin/cypress', `cypress@${CYPRESS_VERSION}`)
     getSpawnPromise(cypressBinPath, [
       gui ? 'open' : 'run',
       '--config=' + objectToCommaString(cypressConfig),
-      '--project=' + projectURI,
-      browser && '--browser=' + browser,
-      record && '--record',
-      key && '--key=' + key
+      '--project=' + (process.env.CYPRESS_PROJECT_ID || projectURI),
+      browser && '--browser=' + browser
     ])
   )
   .catch(showError)

--- a/packages/sui-test/bin/sui-test-e2e.js
+++ b/packages/sui-test/bin/sui-test-e2e.js
@@ -133,7 +133,7 @@ resolveLazyNPMBin('cypress/bin/cypress', `cypress@${CYPRESS_VERSION}`)
     getSpawnPromise(cypressBinPath, [
       gui ? 'open' : 'run',
       '--config=' + objectToCommaString(cypressConfig),
-      '--project=' + (process.env.CYPRESS_PROJECT_ID || projectURI),
+      '--project=' + projectURI,
       browser && '--browser=' + browser
     ])
   )

--- a/packages/sui-test/package.json
+++ b/packages/sui-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/test",
-  "version": "4.9.0",
+  "version": "4.9.1-beta.4",
   "cypressVersion": "4.12.1",
   "description": "",
   "bin": {

--- a/packages/sui-test/package.json
+++ b/packages/sui-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/test",
-  "version": "4.9.1-beta.4",
+  "version": "4.9.0",
   "cypressVersion": "4.12.1",
   "description": "",
   "bin": {

--- a/packages/sui-test/package.json
+++ b/packages/sui-test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@s-ui/test",
   "version": "4.9.0",
-  "cypressVersion": "4.3.0",
+  "cypressVersion": "4.12.1",
   "description": "",
   "bin": {
     "sui-test": "bin/sui-test.js"


### PR DESCRIPTION
Add parallelization support to sui-test via cypress.

Example of usage (private link, sorry OSS):
https://github.mpi-internal.com/scmspain/frontend-re--ut-web-app/pull/288