### PR TITLE
feat(sui-ssr): use GITHUB_TOKEN instead GH_TOKEN to normalize but keep compatibility

### DIFF
--- a/packages/sui-ssr/README.md
+++ b/packages/sui-ssr/README.md
@@ -94,7 +94,7 @@ If you want release your server to a branch (generate a clean package-lock file 
 $ npx sui-ssr release --email bot@email.com --name BotName
 ```
 
-To use this command you have to define a `GH_TOKEN` env var in your CI server. This token must be associate to the user and email passing by flags to the command
+To use this command you have to define a `GITHUB_TOKEN` env var in your CI server. This token must be associate to the user and email passing by flags to the command
 
 Example of a `.travis.yml`:
 

--- a/packages/sui-ssr/bin/sui-ssr-release.js
+++ b/packages/sui-ssr/bin/sui-ssr-release.js
@@ -16,7 +16,7 @@ program
       ' Release a server version. Create a git tag and update a minor version in the package.json'
     )
     console.log(
-      ' It is mandatory setup a $GH_TOKEN envVar to execute this command'
+      ' It is mandatory setup a $GITHUB_TOKEN envVar to execute this command'
     )
     console.log('')
     console.log('  Examples:')
@@ -43,11 +43,11 @@ const execute = async (cmd, full) => {
 }
 ;(async () => {
   const cwd = process.cwd()
-  const {GH_TOKEN} = process.env
+  const {GITHUB_TOKEN, GH_TOKEN} = process.env
 
-  if (!GH_TOKEN) {
-    throw new Error('Missing GH_TOKEN var')
-  }
+  const gitHubToken = GITHUB_TOKEN || GH_TOKEN
+
+  if (!gitHubToken) throw new Error('Missing GITHUB_TOKEN environment variable')
 
   try {
     await execute(`git checkout ${branch}`)
@@ -63,7 +63,7 @@ const execute = async (cmd, full) => {
     const repoURL = await execute('git config --get remote.origin.url')
     const gitURL = GitUrlParse(repoURL).toString('https')
     const authURL = new URL(gitURL)
-    authURL.username = GH_TOKEN
+    authURL.username = gitHubToken
 
     await execute(`git config --global user.email "${email}"`)
     await execute(`git config --global user.name "${name}"`)


### PR DESCRIPTION
Start using `GITHUB_TOKEN` instead `GH_TOKEN` to normalize this environment variable across systems.

Keep `GH_TOKEN` as a fallback to avoid breaking compatibility.