### PR TITLE
fix(sui-hoc): add safety check before disconnecting intersection observer

### DIFF
--- a/packages/sui-hoc/src/withIntersectionObserver.js
+++ b/packages/sui-hoc/src/withIntersectionObserver.js
@@ -44,7 +44,9 @@ export const hocIntersectionObserverWithOptions = (
     }
 
     componentWillUnmount() {
-      this.state.intersectionObserver.disconnect()
+      if (this.state.intersectionObserver) {
+        this.state.intersectionObserver.disconnect()
+      }
     }
 
     render() {


### PR DESCRIPTION
It adds a safety check before disconnecting the intersection observer for those components where the unmount happens before the intersectionObserver can be saved in the state.

## Description
Control with an if statement if the intersection observer already exists.
<img width="956" alt="Screenshot 2021-01-28 at 15 02 58" src="https://user-images.githubusercontent.com/34506779/106151024-34867c80-617c-11eb-8305-de7bdca12ee5.png">
