### PR TITLE
feat(sui-test): add rewire plugin for monkey patch server tests dependencies

### DIFF
--- a/packages/sui-test/bin/mocha/register.js
+++ b/packages/sui-test/bin/mocha/register.js
@@ -1,6 +1,5 @@
 const {serverConfig} = require('../../src/config')
 const {forceTranspilation = []} = serverConfig
-
 const regexToAdd = forceTranspilation.map(
   regexString => new RegExp(regexString)
 )
@@ -17,6 +16,7 @@ require('@babel/register')({
     ]
   ],
   plugins: [
+    'babel-plugin-rewire',
     'babel-plugin-dynamic-import-node',
     '@babel/plugin-transform-modules-commonjs'
   ]

--- a/packages/sui-test/package.json
+++ b/packages/sui-test/package.json
@@ -24,6 +24,7 @@
     "babel-loader": "8.2.2",
     "babel-plugin-dynamic-import-node": "2.3.3",
     "babel-plugin-istanbul": "6.0.0",
+    "babel-plugin-rewire": "1.2.0",
     "babel-preset-sui": "3",
     "chalk": "4.1.0",
     "commander": "6.2.1",


### PR DESCRIPTION
Specially, if we want to do some server tests in `sui-ssr` package we should be able to mock static configurations from the project `package.json`, this plugin allows us to do it in the tests runtime.