### PR TITLE
Sui studio utils/mock per chunks

### DIFF
--- a/packages/sui-studio-utils/README.md
+++ b/packages/sui-studio-utils/README.md
@@ -44,6 +44,25 @@ domain.get('current_user_use_case').execute().then((products) => {
 })
 ```
 
+#### more than one use case at a time
+
+```js
+import { DomainBuilder } from '@s-ui/studio-tools'
+import myDomain from 'domain'
+
+const domain = DomainBuilder.extend({ myDomain })
+  .mockUseCases([
+    ['get_products_use_case', respondWith: {success: ['pineapple', 'apple', 'strawberry', 'coffee']}],
+    ['get_user_use_case', respondWith: {fail: {code: 500, data: {}}}]
+  ]).build()
+
+// Execute the use case and check if everything works
+domain.get('current_user_use_case').execute().then((products) => {
+  console.log(products) // ['pineapple', 'apple', 'strawberry', 'coffee']
+})
+domain.get('get_user_use_case).execute().catch(error => console.error(error)) // 500
+```
+
 
 ### Forcing an error throw
 

--- a/packages/sui-studio-utils/README.md
+++ b/packages/sui-studio-utils/README.md
@@ -52,8 +52,8 @@ import myDomain from 'domain'
 
 const domain = DomainBuilder.extend({ myDomain })
   .mockUseCases([
-    ['get_products_use_case', respondWith: {success: ['pineapple', 'apple', 'strawberry', 'coffee']}],
-    ['get_user_use_case', respondWith: {fail: {code: 500, data: {}}}]
+    ['get_products_use_case', {success: ['pineapple', 'apple', 'strawberry', 'coffee']}],
+    ['get_user_use_case', {fail: {code: 500, data: {}}}]
   ]).build()
 
 // Execute the use case and check if everything works

--- a/packages/sui-studio-utils/package.json
+++ b/packages/sui-studio-utils/package.json
@@ -5,12 +5,20 @@
   "main": "lib/index.js",
   "scripts": {
     "lib": "npx rimraf ./lib && ../../node_modules/.bin/babel ./src --out-dir ./lib",
-    "prepare": "npm run lib"
+    "prepare": "npm run lib",
+    "test:browser:watch": "NODE_ENV=test npm run test:browser -- --watch",
+    "test:browser": "NODE_ENV=test sui-test browser",
+    "test:server:watch": "npm run test:server -- --watch",
+    "test:server": "NODE_ENV=test sui-test server",
+    "test": "npm run test:server && npm run test:browser"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
     "@s-ui/i18n": "1"
+  },
+  "devDependencies": {
+    "@s-ui/test": "4"
   }
 }

--- a/packages/sui-studio-utils/src/domain-builder/index.js
+++ b/packages/sui-studio-utils/src/domain-builder/index.js
@@ -10,6 +10,13 @@ export default class DomainBuilder {
     this._useCases = {}
   }
 
+  mockUseCases(mocks) {
+    mocks.forEach(
+      ([useCase, respondWith]) => (this._useCases[useCase] = respondWith)
+    )
+    return this
+  }
+
   for({useCase} = {}) {
     if (this._useCase) {
       throw new Error(

--- a/packages/sui-studio-utils/test/browser/browserSpec.js
+++ b/packages/sui-studio-utils/test/browser/browserSpec.js
@@ -1,0 +1,1 @@
+import '../common'

--- a/packages/sui-studio-utils/test/common/domainBuilderSpec.js
+++ b/packages/sui-studio-utils/test/common/domainBuilderSpec.js
@@ -1,0 +1,35 @@
+import {expect} from 'chai'
+import DomainBuilder from '../../src/domain-builder'
+
+describe('domainBuilder', () => {
+  let mockedDomain
+  beforeEach(() => {
+    const fakeDomain = {
+      get: () => {}
+    }
+    mockedDomain = DomainBuilder.extend({
+      domain: fakeDomain
+    })
+      .mockUseCases([
+        ['test_use_case', {success: 'the response'}],
+        ['another_use_case', {fail: {data: {}, code: 500}}]
+      ])
+      .build()
+  })
+
+  it('should add mocked use cases when calling the mockUseCases fn', async () => {
+    const output = await mockedDomain.get('test_use_case').execute()
+    expect(output).to.equal('the response')
+  })
+
+  it('should throw failing mocked use cases', async () => {
+    try {
+      await mockedDomain.get('another_use_case').execute()
+    } catch (rejectedData) {
+      expect(rejectedData).to.deep.equal({
+        data: {},
+        code: 500
+      })
+    }
+  })
+})

--- a/packages/sui-studio-utils/test/common/index.js
+++ b/packages/sui-studio-utils/test/common/index.js
@@ -1,0 +1,1 @@
+import './domainBuilderSpec'

--- a/packages/sui-studio-utils/test/server/serverSpec.js
+++ b/packages/sui-studio-utils/test/server/serverSpec.js
@@ -1,0 +1,1 @@
+import '../common'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Easier way to add multiple use cases at once

## Example


```js
import { DomainBuilder } from '@s-ui/studio-tools'
import myDomain from 'domain'
const domain = DomainBuilder.extend({ myDomain })
  .mockUseCases([
    ['get_products_use_case', {success: ['pineapple', 'apple', 'strawberry', 'coffee']}],
    ['get_user_use_case', {fail: {code: 500, data: {}}}]
  ]).build()
```
