### PR TITLE
fix(sui-ssr): fix critical css config object

### DIFF
--- a/packages/sui-ssr/server/utils/factory.js
+++ b/packages/sui-ssr/server/utils/factory.js
@@ -102,7 +102,7 @@ export default ({path, fs, config: ssrConf = {}}) => {
   }
 
   const buildRequestUrl = req => {
-    const config = ssrConf.criticalCss || {}
+    const config = ssrConf.criticalCSS || {}
     const {CRITICAL_CSS_PROTOCOL, CRITICAL_CSS_HOST} = process.env
     const protocol = CRITICAL_CSS_PROTOCOL || config.protocol || req.protocol
     const host =

--- a/packages/sui-ssr/test/server/fixtures/index.js
+++ b/packages/sui-ssr/test/server/fixtures/index.js
@@ -6,14 +6,14 @@ export const getMockedRequest = hostname => ({
 })
 
 export const ssrConfig = {
-  criticalCss: {
+  criticalCSS: {
     protocol: 'https',
     host: 'www.bikes.com'
   }
 }
 
 export const ssrMultiSiteConfig = {
-  criticalCss: {
+  criticalCSS: {
     protocol: 'https',
     host: {
       bikes: 'www.bikes.com',


### PR DESCRIPTION
This PR fixes an issue when defining the request url for the Critical CSS service because of an object reference mistake .