### PR TITLE
feat(packages/sui-pde): null instead of default and increase update i…

### DIFF
--- a/packages/sui-pde/README.md
+++ b/packages/sui-pde/README.md
@@ -49,7 +49,7 @@ When client-side rendering, sui-pde will load the datafile saved as `window.__IN
 
 Given experiment `experimentX` with 2 variations `variationA` and `variationB` render `MyVariationA` or `MyVariationB` component depending on the variation the user has being assigned. Render `MyVariationA` by default
 
-⚠️ if the user did not consent to or if optimizely decides that the user will not be part of the experiment of something goes wrong, `useExperiment` will return as variation value `default`
+⚠️ if the user did not consent to or if optimizely decides that the user will not be part of the experiment of something goes wrong, `useExperiment` will return as variation value `null`
 
 ```js
 import {useExperiment} from '@s-ui/pde'

--- a/packages/sui-pde/src/adapters/optimizely/index.js
+++ b/packages/sui-pde/src/adapters/optimizely/index.js
@@ -3,7 +3,7 @@ import integrations from './integrations'
 
 const DEFAULT_OPTIONS = {
   autoUpdate: true,
-  updateInterval: 60 * 1000, // 60 seconds
+  updateInterval: 5 * 60 * 1000, // 5 minutes
   logLevel: 'info'
 }
 
@@ -100,10 +100,10 @@ export default class OptimizelyAdapter {
    * @param {Object} params
    * @param {string} params.name
    * @param {object} [params.attributes]
-   * @returns {string} variation name
+   * @returns {string=} variation name
    */
   activateExperiment({name, attributes}) {
-    if (!this._hasUser()) return 'default'
+    if (!this._hasUser()) return null
     return this._optimizely.activate(name, this._userId, attributes)
   }
 

--- a/packages/sui-pde/src/hooks/useExperiment.js
+++ b/packages/sui-pde/src/hooks/useExperiment.js
@@ -19,7 +19,7 @@ export default function useExperiment(experimentName, attributes) {
       variationName = pde.activateExperiment({name: experimentName, attributes})
     } catch (error) {
       console.error(error)
-      return 'default'
+      return null
     }
 
     return variationName

--- a/packages/sui-pde/test/common/pdeSpec.js
+++ b/packages/sui-pde/test/common/pdeSpec.js
@@ -65,7 +65,7 @@ describe('@s-ui pde', () => {
     })
 
     expect(optimizelyAdapter.activateExperiment({name: 'fakeTest'})).to.equal(
-      'default'
+      null
     )
     expect(optimizelyInstanceStub.activate.notCalled).to.equal(true)
   })

--- a/packages/sui-pde/test/common/useExperimentSpec.js
+++ b/packages/sui-pde/test/common/useExperimentSpec.js
@@ -40,7 +40,7 @@ describe('useExperiment hook', () => {
 
     it('should return the default variation', () => {
       const {result} = renderHook(() => useExperiment(), {wrapper})
-      expect(result.current.variation).to.equal('default')
+      expect(result.current.variation).to.equal(null)
     })
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- sui-pde will start returning null instead of default variation in order to make it easier to handle anything that does not return a variation
- increases the default datafile update interval to 5 minutes
