### PR TITLE
Fix/intersection observer hoc

### DIFF
--- a/packages/sui-hoc/src/withIntersectionObserver.js
+++ b/packages/sui-hoc/src/withIntersectionObserver.js
@@ -4,7 +4,8 @@ import React, {Component} from 'react'
 const shouldLoadIntersectionObserver = () =>
   !('IntersectionObserver' in window) ||
   !('IntersectionObserverEntry' in window) ||
-  !('intersectionRatio' in window.IntersectionObserverEntry.prototype)
+  !('intersectionRatio' in window.IntersectionObserverEntry.prototype) ||
+  !('isIntersecting' in window.IntersectionObserverEntry.prototype)
 
 export const hocIntersectionObserverWithOptions = (
   options = {}

--- a/packages/sui-precommit/package.json
+++ b/packages/sui-precommit/package.json
@@ -26,14 +26,5 @@
   "bugs": {
     "url": "https://github.com/SUI-Components/sui/issues"
   },
-  "homepage": "https://github.com/SUI-Components/sui/tree/master/packages/sui-precommit#readme",
-  "eslintConfig": {
-    "extends": [
-      "./node_modules/@s-ui/lint/eslintrc.js"
-    ]
-  },
-  "prettier": "./node_modules/@s-ui/lint/.prettierrc.js",
-  "stylelint": {
-    "extends": "./node_modules/@s-ui/lint/stylelint.config.js"
-  }
+  "homepage": "https://github.com/SUI-Components/sui/tree/master/packages/sui-precommit#readme"
 }

--- a/packages/sui-precommit/package.json
+++ b/packages/sui-precommit/package.json
@@ -26,5 +26,14 @@
   "bugs": {
     "url": "https://github.com/SUI-Components/sui/issues"
   },
-  "homepage": "https://github.com/SUI-Components/sui/tree/master/packages/sui-precommit#readme"
+  "homepage": "https://github.com/SUI-Components/sui/tree/master/packages/sui-precommit#readme",
+  "eslintConfig": {
+    "extends": [
+      "./node_modules/@s-ui/lint/eslintrc.js"
+    ]
+  },
+  "prettier": "./node_modules/@s-ui/lint/.prettierrc.js",
+  "stylelint": {
+    "extends": "./node_modules/@s-ui/lint/stylelint.config.js"
+  }
 }


### PR DESCRIPTION
## Description
Some old browser versions compatible with Intersection observer has bugs and our users can experiment with those if we do not use a polyfill.
See this issue:
https://github.com/w3c/IntersectionObserver/issues/211

In order to fix it, we should make an equal check as polyfill do in order to decide if we require polyfill or not: https://github.com/w3c/IntersectionObserver/blob/main/polyfill/intersection-observer.js#L25


Found thanks to @andresz1 