### PR TITLE
Feat/add new test folder structure for studio

### DIFF
--- a/packages/sui-studio/bin/sui-studio-generate.js
+++ b/packages/sui-studio/bin/sui-studio-generate.js
@@ -32,12 +32,8 @@ program
 const BASE_DIR = process.cwd()
 const [category, component] = program.args
 
-if (!component) {
-  showError('component must be defined')
-}
-if (!category) {
-  showError('category must be defined')
-}
+if (!component) showError('component must be defined')
+if (!category) showError('category must be defined')
 
 const wordsOnlyRegex = /^[\w]+$/
 
@@ -66,7 +62,7 @@ const COMPONENT_PLAYGROUND_FILE = `${DEMO_DIR}playground`
 const COMPONENT_CONTEXT_FILE = `${DEMO_DIR}context.js`
 const COMPONENT_ROUTES_FILE = `${DEMO_DIR}routes.js`
 
-const TEST_DIR = `${BASE_DIR}/test/${category}/${component}/`
+const TEST_DIR = `${COMPONENT_PATH}/test/`
 const COMPONENT_TEST_FILE = `${TEST_DIR}index.js`
 
 const {context, router, scope, prefix = 'sui'} = program
@@ -82,13 +78,6 @@ const {repository, homepage} = packageInfo
 if (fs.existsSync(COMPONENT_PATH)) {
   showError(`[${packageName}] This component already exist in the path:
   ${COMPONENT_PATH}`)
-}
-
-if (!repository.url || !homepage) {
-  console.log(
-    `Missing repository and/or homepage field in monorepo package.json
-Component is created without those fields.`.yellow
-  )
 }
 
 Promise.all([
@@ -238,11 +227,11 @@ import ReactDOM from 'react-dom'
 
 import chai, {expect} from 'chai'
 import chaiDOM from 'chai-dom'
+import Component from '../src/index'
 
 chai.use(chaiDOM)
 
 describe('${componentInPascal}', () => {
-  const Component = ${componentInPascal}
   const setup = setupEnvironment(Component)
 
   it('should render without crashing', () => {
@@ -268,20 +257,6 @@ describe('${componentInPascal}', () => {
     // Then
     expect(container.innerHTML).to.be.a('string')
     expect(container.innerHTML).to.not.have.lengthOf(0)
-  })
-
-  it('example to be deleted', () => {
-    // Example TO BE DELETED!!!!
-
-    // Given
-    // const props = {}
-
-    // When
-    // const {getByRole} = setup(props)
-
-    // Then
-    // expect(getByRole('button')).to.have.text('HOLA')
-    expect(true).to.be.eql(false)
   })
 })
 `

--- a/packages/sui-studio/bin/sui-studio-test-migrate.js
+++ b/packages/sui-studio/bin/sui-studio-test-migrate.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+const program = require('commander')
+const glob = require('fast-glob')
+const fs = require('fs-extra')
+
+program.on('--help', () => {
+  console.log('Migrate to new test folder structure')
+  console.log('  Examples:')
+  console.log('')
+  console.log('    $ sui-studio test-migrate')
+  console.log('')
+})
+
+const files = glob.sync(['test/*/*/index.js'])
+
+files.forEach(file => {
+  const [category, component] = file
+    .replace('/index.js', '')
+    .replace('test/', '')
+    .split('/')
+
+  const newFilePath = `./components/${category}/${component}/test`
+
+  fs.ensureDirSync(newFilePath)
+  console.log('Created or already exist dest folder')
+
+  const newFile = `${newFilePath}/index.js`
+
+  fs.copyFileSync(file, newFile)
+  console.log(`Created file: ${newFile}`)
+
+  fs.removeSync(`./test/${category}/${component}`)
+  console.log(`Removed file: ${file}`)
+})
+
+fs.removeSync('./test')
+console.log('Removed test folder not needed anymore')

--- a/packages/sui-studio/bin/sui-studio.js
+++ b/packages/sui-studio/bin/sui-studio.js
@@ -70,4 +70,8 @@ program.command('init <project>', 'Create a new project').alias('i')
 
 program.command('test', 'Run studio tests').alias('t')
 
+program
+  .command('test-migrate', 'Migrate test to new folder structure')
+  .alias('tm')
+
 program.parse(process.argv)

--- a/packages/sui-studio/src/runtime-mocha/index.js
+++ b/packages/sui-studio/src/runtime-mocha/index.js
@@ -9,21 +9,36 @@ window.__STUDIO_CONTEXTS__ = {}
 window.__STUDIO_COMPONENT__ = {}
 
 // Require all the files from a context
-const importAll = r => r.keys().forEach(r)
+const importAll = request => request.keys().forEach(request)
 
 // Avoid running Karma until all components tests are loaded
 const originalKarmaLoader = window.__karma__.loaded
 window.__karma__.loaded = () => {}
 
 // get all tests files available using a regex
-const allTestsFiles = require.context(
+const testsFiles = require.context(
   `${__BASE_DIR__}/test/`,
   true,
   /\.\/(\w+)\/(\w+)\/index.(js|jsx)$/
 )
+
+const testsFromComponentsFiles = require.context(
+  `${__BASE_DIR__}/components/`,
+  true,
+  /\.\/(\w+)\/(\w+)\/test\/(.*).(js|jsx)/
+)
+
+const allTestsFiles = testsFiles.keys().concat(testsFromComponentsFiles.keys())
+
+if (testsFiles.keys().length) {
+  console.warn(
+    '[deprecated] Using `test` root folder for testing components is deprecated. Please, consider using the new way by putting a `test` folder inside the /components/[category]/[component]/test'
+  )
+}
+
 // get all the needed components from the available tests
 Promise.all(
-  allTestsFiles.keys().map(async key => {
+  allTestsFiles.map(async key => {
     // get the category component from the segments of the path
     // ex: ./card/property/index.js -> card property
     const [, category, component] = key.split('/')
@@ -64,7 +79,8 @@ Promise.all(
 )
   .then(() => {
     // in order to force all tests, we're importing all the files that matches the pattern
-    importAll(allTestsFiles)
+    importAll(testsFiles)
+    importAll(testsFromComponentsFiles)
     // we're ready to go
     originalKarmaLoader.call(window.__karma__)
   })


### PR DESCRIPTION
- [x] Use new `test` folder structure inside `components` instead on root.
- [x] Command to easily migrate to new test folder structure.
- [x] Keep compatibility with old test structure.