### PR TITLE
fix(packages/sui-studio): add test folder to npmignore file on genera…

### DIFF
--- a/packages/sui-studio/bin/sui-studio-generate.js
+++ b/packages/sui-studio/bin/sui-studio-generate.js
@@ -90,6 +90,7 @@ node_modules`
   writeFile(
     COMPONENT_PACKAGE_NPMIGNORE_FILE,
     `src
+test
 assets`
   ),
 


### PR DESCRIPTION
…te new component

<!--- Provide a general summary of your changes in the Title above -->

## Description
Given the new sui-studio feature
https://github.com/SUI-Components/sui/pull/1058

We should not publish the component test folder to npm
