### PR TITLE
feat(packages/sui-mono): check isMaster before creating scopes

### DIFF
--- a/packages/sui-mono/bin/sui-mono-release.js
+++ b/packages/sui-mono/bin/sui-mono-release.js
@@ -165,9 +165,7 @@ const checkIsAutomaticRelease = ({githubToken, githubUser, githubEmail}) =>
 
 checkIsMasterBranchActive().then(isMaster => {
   if (!isMaster) {
-    console.warn(
-      'Active branch is not master, please make releases only in master branch'
-    )
+    console.warn('Active branch is not main. No releases to do.')
     return
   }
 


### PR DESCRIPTION
- [x] Check if we're in master before creating scopes.
- [x] Don't kill the process if is master. Do nothing instead.

This will allow us to call this command on PR without the noise and the hassle to check if we're on PRs.