### PR TITLE
fix(packages/sui-test): add option to patch CJS loader in node v12.21.0

### DIFF
--- a/packages/sui-test/README.md
+++ b/packages/sui-test/README.md
@@ -176,12 +176,14 @@ If defined, any error on your tests will create a screenshot of that moment in t
 
 - `server`: Config for `@s-ui/test server` binary:
   - `forceTranspilation`: List of regexs (string based, later will be transformed with `new Regex`) of modules to transpile. This is useful in case you're using server tests for modules that are ESModules based and need to be transpiled with `@babel/plugin-transform-modules-commonjs`.
+  - `esmOverride`: Boolean flag (defaults to `false`), enable patching the Node's CJS loader when facing ESM errors, like `ERR_REQUIRE_ESM` in `node > v12.12.0`. 
 
 ```json
 "config": {
   "sui-test": {
     "server": {
-      "forceTranspilation": ["@adv-ui/vendor-by-consents-loader"]
+      "forceTranspilation": ["@adv-ui/vendor-by-consents-loader"],
+      "esmOverride": true
     }
   }
 }

--- a/packages/sui-test/bin/mocha/applyEsmOverride.js
+++ b/packages/sui-test/bin/mocha/applyEsmOverride.js
@@ -1,0 +1,4 @@
+const _module = require('module')
+const fs = require('fs')
+_module.Module._extensions['.js'] = (module, filename) =>
+  module._compile(fs.readFileSync(filename, 'utf8'), filename)

--- a/packages/sui-test/bin/mocha/register.js
+++ b/packages/sui-test/bin/mocha/register.js
@@ -1,9 +1,13 @@
 const {serverConfig} = require('../../src/config')
-const {forceTranspilation = []} = serverConfig
+const {forceTranspilation = [], esmOverride = false} = serverConfig
 
 const regexToAdd = forceTranspilation.map(
   regexString => new RegExp(regexString)
 )
+
+if (esmOverride) {
+  require('./applyEsmOverride')
+}
 
 require('@babel/register')({
   ignore: [],


### PR DESCRIPTION
ISSUES CLOSED: #1068

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

According to the description of issue #1068 this adds an optional config attribute for the `sui-test server` command in order to patch the CJS Loader in `node > v12.16`.

Now, we'll be able to enable this patch by the `esmOverride` config like:

```
    "sui-test": {
      "server": {
        "forceTranspilation": ["@adv-ui"],
        "esmOverride": true
      }
    }
```

And server tests will be able to transpile patched files:
![image](https://user-images.githubusercontent.com/20399660/109906761-60c47a00-7ca1-11eb-8efb-d0ef5bd6c957.png)


## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
#1068
