### PR TITLE
chore(packages/sui-pde): react as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "test:server:watch": "npm run test:server -- --watch",
     "test:e2e": "node ./packages/sui-studio/test/server/integration/static-server.js ./packages/sui-studio/test/server/integration/sample-studio/public && npx sui-test e2e --baseUrl=http://localhost:1234"
   },
+  "dependencies": {
+    "react": "17"
+  },
   "devDependencies": {
     "@babel/cli": "7.12.1",
     "@s-ui/lint": "3",

--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
     "test:server:watch": "npm run test:server -- --watch",
     "test:e2e": "node ./packages/sui-studio/test/server/integration/static-server.js ./packages/sui-studio/test/server/integration/sample-studio/public && npx sui-test e2e --baseUrl=http://localhost:1234"
   },
-  "dependencies": {
-    "react": "17"
-  },
   "devDependencies": {
     "@babel/cli": "7.12.1",
     "@s-ui/lint": "3",

--- a/packages/sui-pde/package.json
+++ b/packages/sui-pde/package.json
@@ -18,11 +18,14 @@
   "dependencies": {
     "@optimizely/optimizely-sdk": "4.4.3"
   },
+  "peerDependencies": {
+    "react": "16 || 17"
+  },
   "devDependencies": {
     "@s-ui/test": "4",
     "@testing-library/react": "11.2.3",
     "@testing-library/react-hooks": "4.0.1",
-    "react": "16",
+    "react": "17",
     "react-test-renderer": "17.0.1"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
sui-pde exports hooks which need react and therefore need it as dependency although the exact version should be set by the package which uses those hooks
