### PR TITLE
chore(packages/sui-studio): add react-test-renderer dependency

### DIFF
--- a/packages/sui-studio/package.json
+++ b/packages/sui-studio/package.json
@@ -45,7 +45,8 @@
     "raw-loader": "4.0.2",
     "react": "17",
     "react-dom": "17",
-    "react-docgen": "5.3.1"
+    "react-docgen": "5.3.1",
+    "react-test-renderer": "17.0.1"
   },
   "config": {
     "sui-bundler": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- [X] Add react-test-renderer dependency

## Description
<!--- Describe your changes in detail -->
In MA we started to use `@testing-library/react-hooks`, but seems doesn't exists the needed dependency. 

We're recieving this error: 
`npm WARN @testing-library/react-hooks@4.0.1 requires a peer of react-test-renderer@>=16.9.0 but none is installed. You must install peer dependencies yourself.`
