### PR TITLE
Feat/launch experiment viewed

### DIFF
--- a/packages/sui-pde/README.md
+++ b/packages/sui-pde/README.md
@@ -52,6 +52,8 @@ Given experiment `experimentX` with 2 variations `variationA` and `variationB` r
 
 ⚠️ if the user did not consent to or if optimizely decides that the user will not be part of the experiment of something goes wrong, `useExperiment` will return as variation value `null`
 
+⚠️ the `useExperiment` hook will send call a global window.analytics.track method with `Experiment Viewed` as event name with the experiment properties so you are able to replicate the experiment in your analytics tool
+
 ```js
 import {useExperiment} from '@s-ui/pde'
 

--- a/packages/sui-pde/src/hooks/useExperiment.js
+++ b/packages/sui-pde/src/hooks/useExperiment.js
@@ -18,11 +18,7 @@ export default function useExperiment(experimentName, attributes) {
     try {
       variationName = pde.activateExperiment({name: experimentName, attributes})
 
-      if (
-        variationName &&
-        typeof window !== 'undefined' &&
-        window.analytics?.track
-      ) {
+      if (variationName && window.analytics?.track) {
         window.analytics.track('Experiment Viewed', {
           experimentName,
           variationName

--- a/packages/sui-pde/src/hooks/useExperiment.js
+++ b/packages/sui-pde/src/hooks/useExperiment.js
@@ -17,6 +17,21 @@ export default function useExperiment(experimentName, attributes) {
 
     try {
       variationName = pde.activateExperiment({name: experimentName, attributes})
+
+      if (
+        variationName &&
+        typeof window !== 'undefined' &&
+        window.analytics?.track
+      ) {
+        window.analytics.track('Experiment Viewed', {
+          experimentName,
+          variationName
+        })
+      } else {
+        console.error(
+          "[useExperiment] sui-pde: window.analytics.track expected to exists but doesn't"
+        )
+      }
     } catch (error) {
       console.error(error)
       return null

--- a/packages/sui-pde/src/hooks/useExperiment.js
+++ b/packages/sui-pde/src/hooks/useExperiment.js
@@ -1,6 +1,42 @@
 import {useContext, useMemo} from 'react'
 import PdeContext from '../contexts/PdeContext'
 
+const isNode = typeof window === 'undefined'
+
+const serverStrategy = {
+  getVariation: ({pde, experimentName, attributes}) => {
+    return pde.getVariation({pde, name: experimentName, attributes})
+  },
+  trackExperiment: () => {}
+}
+
+const browserStrategy = {
+  getVariation: ({pde, experimentName, attributes}) => {
+    const variationName = pde.activateExperiment({
+      name: experimentName,
+      attributes
+    })
+
+    return variationName
+  },
+  trackExperiment: ({variationName, experimentName}) => {
+    // user is not part of the experiment
+    if (!variationName) return
+    if (!window.analytics?.track) {
+      // eslint-disable-next-line no-console
+      console.error(
+        "[sui-pde: useExperiment] window.analytics.track expected to exists but doesn't"
+      )
+      return
+    }
+
+    window.analytics.track('Experiment Viewed', {
+      experimentName,
+      variationName
+    })
+  }
+}
+
 /**
  * Hook to use a experiment
  * @param {string} experimentName
@@ -10,25 +46,19 @@ import PdeContext from '../contexts/PdeContext'
 export default function useExperiment(experimentName, attributes) {
   const {pde} = useContext(PdeContext)
   if (pde === null)
-    throw new Error('[useExperiment] sui-pde provider is required to work')
+    throw new Error(
+      '[sui-pde: useExperiment] sui-pde provider is required to work'
+    )
 
   const variation = useMemo(() => {
     let variationName
+    const strategy = isNode ? serverStrategy : browserStrategy
 
     try {
-      variationName = pde.activateExperiment({name: experimentName, attributes})
-
-      if (variationName && window.analytics?.track) {
-        window.analytics.track('Experiment Viewed', {
-          experimentName,
-          variationName
-        })
-      } else {
-        console.error(
-          "[useExperiment] sui-pde: window.analytics.track expected to exists but doesn't"
-        )
-      }
+      variationName = strategy.getVariation({pde, experimentName, attributes})
+      strategy.trackExperiment({variationName, experimentName})
     } catch (error) {
+      // eslint-disable-next-line no-console
       console.error(error)
       return null
     }

--- a/packages/sui-pde/test/common/useExperimentSpec.js
+++ b/packages/sui-pde/test/common/useExperimentSpec.js
@@ -5,7 +5,7 @@ import PdeContext from '../../src/contexts/PdeContext'
 import useExperiment from '../../src/hooks/useExperiment'
 import sinon from 'sinon'
 
-describe('useExperiment hook', () => {
+describe.client('useExperiment hook', () => {
   beforeEach(() => {
     window.analytics = {
       track: sinon.spy()

--- a/packages/sui-pde/test/common/useExperimentSpec.js
+++ b/packages/sui-pde/test/common/useExperimentSpec.js
@@ -5,17 +5,7 @@ import PdeContext from '../../src/contexts/PdeContext'
 import useExperiment from '../../src/hooks/useExperiment'
 import sinon from 'sinon'
 
-describe.client('useExperiment hook', () => {
-  beforeEach(() => {
-    window.analytics = {
-      track: sinon.spy()
-    }
-  })
-
-  afterEach(() => {
-    delete window.analytics
-  })
-
+describe('useExperiment hook', () => {
   afterEach(cleanup)
 
   describe('when no pde context is set', () => {
@@ -28,18 +18,82 @@ describe.client('useExperiment hook', () => {
   describe('when pde context is set', () => {
     let activateExperiment
     let wrapper
+    let getVariation
 
     before(() => {
-      activateExperiment = sinon.stub().returns('variationA')
+      activateExperiment = sinon.stub().returns('activateExperimentA')
+      getVariation = sinon.stub().returns('getVariationA')
       // eslint-disable-next-line react/prop-types
       wrapper = ({children}) => (
-        <PdeContext.Provider value={{features: [], pde: {activateExperiment}}}>
+        <PdeContext.Provider
+          value={{features: [], pde: {activateExperiment, getVariation}}}
+        >
           {children}
         </PdeContext.Provider>
       )
     })
 
-    describe('and window.analytics.track exists', () => {
+    describe.client('and the hook is executed by the browser', () => {
+      describe('and window.analytics.track exists', () => {
+        before(() => {
+          window.analytics = {
+            track: sinon.spy()
+          }
+          sinon.spy(console, 'error')
+        })
+
+        after(() => {
+          delete window.analytics
+          console.error.restore()
+        })
+
+        it('should return the right variationName and launch the Experiment Viewed event', () => {
+          const {result} = renderHook(
+            () => useExperiment('test_experiment_id'),
+            {
+              wrapper
+            }
+          )
+          expect(result.current.variation).to.equal('activateExperimentA')
+          sinon.assert.callCount(console.error, 0)
+          sinon.assert.callCount(window.analytics.track, 1)
+          expect(window.analytics.track.args[0][0]).to.equal(
+            'Experiment Viewed'
+          )
+          expect(window.analytics.track.args[0][1]).to.deep.equal({
+            variationName: 'activateExperimentA',
+            experimentName: 'test_experiment_id'
+          })
+        })
+      })
+
+      describe('and window.analytics.track does not exist', () => {
+        beforeEach(() => {
+          sinon.spy(console, 'error')
+        })
+
+        afterEach(() => {
+          console.error.restore()
+        })
+
+        it('should return the right variationName and log an error', () => {
+          delete window.analytics
+          const {result} = renderHook(
+            () => useExperiment('test_experiment_id'),
+            {
+              wrapper
+            }
+          )
+          expect(result.current.variation).to.equal('activateExperimentA')
+          sinon.assert.callCount(console.error, 1)
+          expect(console.error.args[0][0]).to.include(
+            'window.analytics.track expected'
+          )
+        })
+      })
+    })
+
+    describe.server('and the hook is executed by the server', () => {
       before(() => {
         sinon.spy(console, 'error')
       })
@@ -52,36 +106,8 @@ describe.client('useExperiment hook', () => {
         const {result} = renderHook(() => useExperiment('test_experiment_id'), {
           wrapper
         })
-        expect(result.current.variation).to.equal('variationA')
+        expect(result.current.variation).to.equal('getVariationA')
         sinon.assert.callCount(console.error, 0)
-        sinon.assert.callCount(window.analytics.track, 1)
-        expect(window.analytics.track.args[0][0]).to.equal('Experiment Viewed')
-        expect(window.analytics.track.args[0][1]).to.deep.equal({
-          variationName: 'variationA',
-          experimentName: 'test_experiment_id'
-        })
-      })
-    })
-
-    describe('and window.analytics.track does not exist', () => {
-      beforeEach(() => {
-        sinon.spy(console, 'error')
-      })
-
-      afterEach(() => {
-        console.error.restore()
-      })
-
-      it('should return the right variationName and log an error', () => {
-        delete window.analytics
-        const {result} = renderHook(() => useExperiment('test_experiment_id'), {
-          wrapper
-        })
-        expect(result.current.variation).to.equal('variationA')
-        sinon.assert.callCount(console.error, 1)
-        expect(console.error.args[0][0]).to.include(
-          'window.analytics.track expected'
-        )
       })
     })
   })


### PR DESCRIPTION
in order to be able to replicate the experiment in our analytics tool we need to send the Experiment Viewed event. This event will only be launched when the adapter returned a variation (aka optimizely already launched its impression event)

As the experiment viewed should only be launched from client side, I implemented different strategies for server/client, making server side stop activating an experiment but just getting the variation