### PR TITLE
Feat/setup environment rtl api

### DIFF
--- a/packages/sui-studio/README.md
+++ b/packages/sui-studio/README.md
@@ -141,9 +141,9 @@ describe('AtomButton', () => {
 
 The component will be a global object when running tests, so it is PARAMOUNT NOT to import it. In order to avoid problems with the linter, add relevant comments, as in the example above.
 
-### How works with different contexts
+### How works with different SUI contexts
 
-If there is a `demo/context.js` file where you define several contexts for your components. You have to apply a patch to Mocha to allow setup describe by context. This allows you to have a "contextify" version of your component, for the context selected.
+If there is a `demo/context.js` file where you define several SUI contexts for your components. You have to apply a patch to Mocha to allow setup describe by context. This allows you to have a "contextify" version of your component, for the context selected.
 
 First, you have to import the patcher to create the `context` object, inside the `describe` object
 
@@ -191,6 +191,39 @@ describe.context.other('atom/button', AtomButton => {
   })
 })
 ```
+
+### How works with other context (Not SUI Context)
+
+Each test has a `setupEnvironment` function in global scope. This function works equal to React Testing Library (RTL) `render` method but has two wrapped features:
+
+- It uses a container to isolate the tested component.
+- It has a `contexts` render option in order to pass an array of contexts providers to be wrapped.
+
+An example could be:
+
+```js
+const ComponentWithContext = () => {
+      const value = useContext(ThemeContext)
+      return <p>{value}</p>
+    }
+const setup = customSetupEnvironment(ComponentWithContext, {
+  contexts: [
+    {
+      provider: ThemeContext.Provider,
+      value: 'dark'
+    }
+  ],
+  wrapper: ({children}) => (
+    <div>
+      <p>Hello</p>
+      {children}
+    </div>
+  )
+})
+```
+
+You can see RTL render options documentation [here](https://testing-library.com/docs/react-testing-library/api/#render-options)
+
 
 ### Known issue: Test a memoized component
 

--- a/packages/sui-studio/test/setupEnvironmentSpec.js
+++ b/packages/sui-studio/test/setupEnvironmentSpec.js
@@ -1,0 +1,117 @@
+/* eslint react/prop-types:0 */
+import {createContext, useContext} from 'react'
+import chai, {expect} from 'chai'
+import chaiDOM from 'chai-dom'
+import customSetupEnvironment from '../src/environment-mocha/setupEnvironment'
+
+chai.use(chaiDOM)
+
+describe('setupEnvironment', () => {
+  describe('Default', () => {
+    const SimpleComponent = ({text}) => {
+      return <p>{text}</p>
+    }
+
+    const setup = customSetupEnvironment(SimpleComponent)
+
+    it('Can render a component', () => {
+      // Given
+      const defaultProps = {
+        text: 'Example'
+      }
+
+      // When
+      const {getByText} = setup(defaultProps)
+
+      // Then
+      expect(getByText('Example')).to.be.visible
+    })
+  })
+
+  describe('With contexts', () => {
+    const ThemeContext = createContext('light')
+    const ComponentWithContext = () => {
+      const value = useContext(ThemeContext)
+      return <p>{value}</p>
+    }
+    const setup = customSetupEnvironment(ComponentWithContext, {
+      contexts: [
+        {
+          provider: ThemeContext.Provider,
+          value: 'dark'
+        }
+      ]
+    })
+
+    it('Can render a component', () => {
+      // Given
+      const defaultProps = {}
+
+      // When
+      const {getByText} = setup(defaultProps)
+
+      // Then
+      expect(getByText('dark')).to.be.visible
+    })
+  })
+
+  describe('With wrapper', () => {
+    const Component = () => {
+      return <p>Example</p>
+    }
+    const setup = customSetupEnvironment(Component, {
+      wrapper: ({children}) => (
+        <div>
+          <p>Hello</p>
+          {children}
+        </div>
+      )
+    })
+
+    it('Can render a component', () => {
+      // Given
+      const defaultProps = {}
+
+      // When
+      const {getByText} = setup(defaultProps, {})
+
+      // Then
+      expect(getByText('Hello')).to.be.visible
+      expect(getByText('Example')).to.be.visible
+    })
+  })
+
+  describe('With wrapper and contexts', () => {
+    const ThemeContext = createContext('light')
+    const ComponentWithContext = () => {
+      const value = useContext(ThemeContext)
+      return <p>{value}</p>
+    }
+    const setup = customSetupEnvironment(ComponentWithContext, {
+      contexts: [
+        {
+          provider: ThemeContext.Provider,
+          value: 'dark'
+        }
+      ],
+      wrapper: ({children}) => (
+        <div>
+          <p>Hello</p>
+          {children}
+        </div>
+      )
+    })
+
+    it('Can render a component', () => {
+      // Given
+      const defaultProps = {}
+
+      // When
+      const {getByText} = setup(defaultProps)
+
+      // Then
+      expect(getByText('Hello')).to.be.visible
+      expect(getByText('dark')).to.be.visible
+    })
+  })
+})


### PR DESCRIPTION
## Description
setupEnvironment does not have enabled React Testing Library render options.
Also, the second parameter is not needed because sui-studio injects SUI context to the component and no one is using it.

Developers needs to have enabled RTL render options.
Also, in order not to create a wrapper with multiple context providers and duplicate that code across all test files, we implement a `contexts` option to do it inside setupEnvironment if dev wants. Of course it could be done using only `wrapper` render option.


RTL docs: https://testing-library.com/docs/react-testing-library/api/#render-options
RTL Hooks context docs: https://react-hooks-testing-library.com/usage/advanced-hooks#context

## Example
As an example, a component using SUI Context and other context (sui-react-router context):
```
const setup = setupEnvironment(Component, {
      contexts: [{provider: RouterContext.Provider, value: router}]
    })
```

