### PR TITLE
fix(sui-studio): fix prop types warning for Style

### DIFF
--- a/packages/sui-studio/src/components/style/index.js
+++ b/packages/sui-studio/src/components/style/index.js
@@ -29,5 +29,5 @@ export default function Style({children, id}) {
 }
 
 Style.propTypes = {
-  children: PropTypes.array
+  children: PropTypes.node
 }


### PR DESCRIPTION
## Description
This fix should remove the console warning present in each demo.

## Example
<img width="1049" alt="Screenshot 2021-03-17 at 12 19 04" src="https://user-images.githubusercontent.com/34506779/111459465-fdaffa00-871a-11eb-99d8-f38f04e60560.png">

