### PR TITLE
feat(packages/sui-test): add plugins support on e2e

### DIFF
--- a/packages/sui-test/README.md
+++ b/packages/sui-test/README.md
@@ -122,6 +122,30 @@ Cypress.Commands.add('login', () => {
 
 Then you can use in your specs `cy.login()`
 
+### Plugin files
+
+If you need to have plugins, then create a `./test-e2e/plugins` directory, it will be detected and added to the `cypress.json` configuration.
+
+Plugins enable you to tap into, modify, or extend the internal behavior of Cypress.
+
+Example:
+
+`./test-e2e/plugins/index.js`
+
+```js
+module.exports = (on, config) => {
+  /**
+   * @see https://docs.cypress.io/api/plugins/browser-launch-api.html#Usage
+   */
+  on('before:browser:launch', (browser, launchOptions) => {
+    if (browser.name === 'chrome') {
+      launchOptions.args.push('--disable-dev-shm-usage')
+    }
+    return launchOptions
+  })
+}
+```
+
 ### Options
 
 ```sh

--- a/packages/sui-test/bin/sui-test-e2e.js
+++ b/packages/sui-test/bin/sui-test-e2e.js
@@ -28,6 +28,7 @@ const objectToCommaString = obj =>
     .join(',')
 
 const supportFilesFolderPath = path.join(TESTS_FOLDER, 'support')
+const pluginsFilesFolderPath = path.join(TESTS_FOLDER, 'plugins')
 
 program
   .option(
@@ -87,6 +88,9 @@ const cypressConfig = {
 
 if (fs.existsSync(supportFilesFolderPath)) {
   cypressConfig.supportFile = supportFilesFolderPath
+}
+if (fs.existsSync(pluginsFilesFolderPath)) {
+  cypressConfig.pluginsFile = pluginsFilesFolderPath
 }
 
 if (userAgent) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add plugins support on e2e sui-test command so we can customize, for example, the browser's launching flags.

See: https://docs.cypress.io/guides/tooling/plugins-guide.html