### PR TITLE
Fix/sui test/e2e docker image to use browsers

### DIFF
--- a/packages/sui-test/Dockerfile
+++ b/packages/sui-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM cypress/browsers:node12.18.3-chrome89-ff86
+FROM cypress/browsers
 
 WORKDIR /usr/src
 

--- a/packages/sui-test/Dockerfile
+++ b/packages/sui-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM cypress/base
+FROM cypress/browsers:node12.18.3-chrome89-ff86
 
 WORKDIR /usr/src
 


### PR DESCRIPTION
## Description

When running Cypress, default browser is Electron, which yeah is Chromium, but our users actually use Chrome. Shouldn't we run our tests in Chrome instead? Well, when using our docker image `suitools/test` we currently **can't run tests in Chrome**.

❌ Our custom docker image is currently based on `cypress/base` which exposes `electron` as the only available browser. If you run tests adding `--browser=chrome` you receive a "can't find chrome" error.

✅ There's another official image called `cypress/browsers` which actually adds Chrome [(see Cypress docker images)](https://github.com/cypress-io/cypress-docker-images#cypress-docker-images-). Existing setups should keep working as usual.