### PR TITLE
feat(packages/sui-test): add headless and default command timeout options

### DIFF
--- a/packages/sui-test/README.md
+++ b/packages/sui-test/README.md
@@ -155,6 +155,7 @@ module.exports = (on, config) => {
   Options:
 
     -B, --baseUrl <baseUrl>                  URL of the site to execute tests (in ./test/e2e/) on.
+    -dct, --defaultCommandTimeout <ms>       Time, in milliseconds, to wait until most DOM based commands are considered timed out.
     -S, --screenshotsOnError                 Take screenshots of page on any failure.
     -U, --userAgentAppend <userAgentAppend>  Append string to UserAgent header.
     -UA, --userAgent <userAgent>             Overwrite string to UserAgent header.
@@ -162,6 +163,7 @@ module.exports = (on, config) => {
     -C, --ci                                 CI Mode, reduces memory consumption
     -h, --help                               output usage information
     -b, --browser <browser>                  Select a different browser (chrome|edge|firefox)
+    -H, --headless                           Hide the browser instead of running headed (default for Electron)
     -N, --noWebSecurity                      Disable all web securities (CORS)
     -K, --key                                It is used to authenticate the project into the Dashboard Service
     -P, --parallel                           Run tests on parallel

--- a/packages/sui-test/README.md
+++ b/packages/sui-test/README.md
@@ -155,7 +155,7 @@ module.exports = (on, config) => {
   Options:
 
     -B, --baseUrl <baseUrl>                  URL of the site to execute tests (in ./test/e2e/) on.
-    -dct, --defaultCommandTimeout <ms>       Time, in milliseconds, to wait until most DOM based commands are considered timed out.
+    -T, --defaultCommandTimeout <ms>         Time, in milliseconds, to wait until most DOM based commands are considered timed out.
     -S, --screenshotsOnError                 Take screenshots of page on any failure.
     -U, --userAgentAppend <userAgentAppend>  Append string to UserAgent header.
     -UA, --userAgent <userAgent>             Overwrite string to UserAgent header.

--- a/packages/sui-test/bin/sui-test-e2e.js
+++ b/packages/sui-test/bin/sui-test-e2e.js
@@ -36,6 +36,10 @@ program
     'URL of the site to execute tests (in ./test-e2e/) on.'
   )
   .option(
+    '-dct, --defaultCommandTimeout <ms>',
+    'Time, in milliseconds, to wait until most DOM based commands are considered timed out.'
+  )
+  .option(
     '-S, --screenshotsOnError',
     'Take screenshots of page on any failure.'
   )
@@ -52,6 +56,10 @@ program
     '-b, --browser <browser>',
     'Select a different browser (chrome|edge|firefox)'
   )
+  .option(
+    '-H, --headless',
+    'Hide the browser instead of running headed (default for Electron)'
+  )
   .option('-N, --noWebSecurity', 'Disable all web securities')
   .option('-G, --gui', 'Run the tests in GUI mode.')
   .option('-P, --parallel', 'Run tests on parallelRun tests on parallel')
@@ -67,11 +75,13 @@ program
 
 const {
   baseUrl,
+  defaultCommandTimeout,
   browser,
   ci,
   group,
   gui,
   key,
+  headless,
   noWebSecurity,
   parallel,
   record,
@@ -84,6 +94,10 @@ const cypressConfig = {
   integrationFolder: path.join(TESTS_FOLDER, scope || ''),
   baseUrl,
   fixturesFolder: path.join(TESTS_FOLDER, 'fixtures')
+}
+
+if (defaultCommandTimeout) {
+  cypressConfig.defaultCommandTimeout = defaultCommandTimeout
 }
 
 if (fs.existsSync(supportFilesFolderPath)) {
@@ -138,6 +152,7 @@ resolveLazyNPMBin('cypress/bin/cypress', `cypress@${CYPRESS_VERSION}`)
       '--project=' + projectURI,
       key && '--key=' + key,
       browser && '--browser=' + browser,
+      headless && '--headless',
       parallel && '--parallel',
       record && '--record'
     ])

--- a/packages/sui-test/bin/sui-test-e2e.js
+++ b/packages/sui-test/bin/sui-test-e2e.js
@@ -36,7 +36,7 @@ program
     'URL of the site to execute tests (in ./test-e2e/) on.'
   )
   .option(
-    '-dct, --defaultCommandTimeout <ms>',
+    '-T, --defaultCommandTimeout <ms>',
     'Time, in milliseconds, to wait until most DOM based commands are considered timed out.'
   )
   .option(


### PR DESCRIPTION
## Description

Adds some options for e2e command:

- **headless**: if you set a different browser by using `--browser` option, can't be headless unless you specify it.
- **defaultCommandTimeout**: since default is 4s, we need to set a higher value in order to ensure some tests pass in CI, because CI processes are sometimes slower than local.