### PR TITLE
Feat/sui pde experiment custom track

### DIFF
--- a/packages/sui-pde/.npmignore
+++ b/packages/sui-pde/.npmignore
@@ -1,0 +1,2 @@
+src
+test

--- a/packages/sui-pde/README.md
+++ b/packages/sui-pde/README.md
@@ -77,7 +77,7 @@ Cause: `Experiment Viewed` won't be sent.
 - Root: `Experiment Viewed` should has a different name or properties.
 Cause: Send a track with wrong values.
 
-In order to have a higher controll about that, useExperiment accepts a `browserTrackExperiment` callback to customize it
+In order to have a higher controll about that, useExperiment accepts a `trackExperimentViewed` callback to customize it
 
 ```js
 import {useExperiment} from '@s-ui/pde'
@@ -95,7 +95,7 @@ const trackExperiment = () => {
 const MyComponent = () => {
   const {variation} = useExperiment({
     experimentName: EXPERIMENT_NAME,
-    browserTrackExperiment: trackExperiment
+    trackExperimentViewed: trackExperiment
   })
 
   if (variation === 'variationB') return <MyVariationB />

--- a/packages/sui-pde/README.md
+++ b/packages/sui-pde/README.md
@@ -50,17 +50,53 @@ When client-side rendering, sui-pde will load the datafile saved as `window.__IN
 
 Given experiment `experimentX` with 2 variations `variationA` and `variationB` render `MyVariationA` or `MyVariationB` component depending on the variation the user has being assigned. Render `MyVariationA` by default
 
-⚠️ if the user did not consent to or if optimizely decides that the user will not be part of the experiment of something goes wrong, `useExperiment` will return as variation value `null`
+⚠️ If the user did not consent to or if optimizely decides that the user will not be part of the experiment of something goes wrong, `useExperiment` will return as variation value `null`
 
-⚠️ the `useExperiment` hook will send call a global window.analytics.track method with `Experiment Viewed` as event name with the experiment properties so you are able to replicate the experiment in your analytics tool
+⚠️ The `useExperiment` hook will send call a global window.analytics.track method with `Experiment Viewed` as event name with the experiment properties so you are able to replicate the experiment in your analytics tool
 
 ```js
 import {useExperiment} from '@s-ui/pde'
 
-const EXPERIMENT = 'experimentX'
+const EXPERIMENT_NAME = 'experimentX'
 
 const MyComponent = () => {
-  const {variation} = useExperiment(EXPERIMENT)
+  const {variation} = useExperiment({experimentName: EXPERIMENT_NAME})
+
+  if (variation === 'variationB') return <MyVariationB />
+  return <MyVariationA>
+}
+```
+
+**Special cases for useExperiment `Experiment Viewed` track**
+
+Given useExperiment sends `Experiment Viewed` on being executed, some facts could happen:
+
+- Root: Analytics SDK is loaded async and loads after useExperiment hook has been called
+Cause: `Experiment Viewed` won't be sent.
+
+- Root: `Experiment Viewed` should has a different name or properties.
+Cause: Send a track with wrong values.
+
+In order to have a higher controll about that, useExperiment accepts a `browserTrackExperiment` callback to customize it
+
+```js
+import {useExperiment} from '@s-ui/pde'
+
+const EXPERIMENT_NAME = 'experimentX'
+
+const trackExperiment = () => {
+  window.analytics.track('Experiment Viewed', {
+      experimentName,
+      variationName,
+      customProperty: 'yay'
+    })
+}
+
+const MyComponent = () => {
+  const {variation} = useExperiment({
+    experimentName: EXPERIMENT_NAME,
+    browserTrackExperiment: trackExperiment
+  })
 
   if (variation === 'variationB') return <MyVariationB />
   return <MyVariationA>

--- a/packages/sui-pde/src/adapters/default.js
+++ b/packages/sui-pde/src/adapters/default.js
@@ -1,6 +1,6 @@
 export default class DefaultAdapter {
   getEnabledFeatures({attributes}) {
-    return Promise.resolve([])
+    return []
   }
 
   getInitialData() {

--- a/packages/sui-pde/src/hooks/useExperiment.js
+++ b/packages/sui-pde/src/hooks/useExperiment.js
@@ -39,11 +39,17 @@ const browserStrategy = {
 
 /**
  * Hook to use a experiment
- * @param {string} experimentName
- * @param {object} attributes
+ * @param {object} param
+ * @param {string} param.experimentName
+ * @param {object} param.attributes
+ * @param {function} param.browserTrackExperiment
  * @return {{variation: string}}
  */
-export default function useExperiment(experimentName, attributes) {
+export default function useExperiment({
+  experimentName,
+  attributes,
+  browserTrackExperiment
+} = {}) {
   const {pde} = useContext(PdeContext)
   if (pde === null)
     throw new Error(
@@ -52,7 +58,13 @@ export default function useExperiment(experimentName, attributes) {
 
   const variation = useMemo(() => {
     let variationName
-    const strategy = isNode ? serverStrategy : browserStrategy
+    const clientStrategy = {
+      ...browserStrategy,
+      ...(browserTrackExperiment && {
+        trackExperiment: browserTrackExperiment
+      })
+    }
+    const strategy = isNode ? serverStrategy : clientStrategy
 
     try {
       variationName = strategy.getVariation({pde, experimentName, attributes})
@@ -64,7 +76,7 @@ export default function useExperiment(experimentName, attributes) {
     }
 
     return variationName
-  }, [experimentName, pde, attributes])
+  }, [experimentName, pde, attributes, browserTrackExperiment])
 
   return {variation}
 }

--- a/packages/sui-pde/src/hooks/useExperiment.js
+++ b/packages/sui-pde/src/hooks/useExperiment.js
@@ -42,13 +42,13 @@ const browserStrategy = {
  * @param {object} param
  * @param {string} param.experimentName
  * @param {object} param.attributes
- * @param {function} param.browserTrackExperiment
+ * @param {function} param.trackExperimentViewed
  * @return {{variation: string}}
  */
 export default function useExperiment({
   experimentName,
   attributes,
-  browserTrackExperiment
+  trackExperimentViewed
 } = {}) {
   const {pde} = useContext(PdeContext)
   if (pde === null)
@@ -60,8 +60,8 @@ export default function useExperiment({
     let variationName
     const clientStrategy = {
       ...browserStrategy,
-      ...(browserTrackExperiment && {
-        trackExperiment: browserTrackExperiment
+      ...(trackExperimentViewed && {
+        trackExperiment: trackExperimentViewed
       })
     }
     const strategy = isNode ? serverStrategy : clientStrategy
@@ -76,7 +76,7 @@ export default function useExperiment({
     }
 
     return variationName
-  }, [experimentName, pde, attributes, browserTrackExperiment])
+  }, [experimentName, pde, attributes, trackExperimentViewed])
 
   return {variation}
 }

--- a/packages/sui-pde/test/common/pdeSpec.js
+++ b/packages/sui-pde/test/common/pdeSpec.js
@@ -25,14 +25,14 @@ describe('@s-ui pde', () => {
     })
   })
 
-  it('loads the default adapter features', done => {
+  it('loads the default adapter features', () => {
     const ab = new SuiPDE()
     const features = ab.getEnabledFeatures()
     expect(features).to.be.an('array')
     expect(features.length).to.equal(0)
   })
 
-  it('loads the Optimizely Adapter features', done => {
+  it('loads the Optimizely Adapter features', () => {
     const ab = new SuiPDE({
       adapter: optimizelyAdapter
     })
@@ -40,7 +40,7 @@ describe('@s-ui pde', () => {
     expect(features).to.deep.equal(['a', 'b'])
   })
 
-  it('loads the Optimizely Adapter features even when no test consents', done => {
+  it('loads the Optimizely Adapter features even when no test consents', () => {
     const ab = new SuiPDE({
       adapter: optimizelyAdapter,
       hasUserConsents: false

--- a/packages/sui-pde/test/common/pdeSpec.js
+++ b/packages/sui-pde/test/common/pdeSpec.js
@@ -15,7 +15,7 @@ describe('@s-ui pde', () => {
     optimizelyInstanceStub = {
       activate: sinon.stub().returns('variationA'),
       onReady: async () => true,
-      getEnabledFeatures: async () => ['a', 'b'],
+      getEnabledFeatures: () => ['a', 'b'],
       getVariation: sinon.stub().returns('variationB')
     }
     optimizelyAdapter = new OptimizelyAdapter({
@@ -27,25 +27,17 @@ describe('@s-ui pde', () => {
 
   it('loads the default adapter features', done => {
     const ab = new SuiPDE()
-    ab.getEnabledFeatures()
-      .then(features => {
-        expect(features).to.be.an('array')
-        expect(features.length).to.equal(0)
-        done()
-      })
-      .catch(done)
+    const features = ab.getEnabledFeatures()
+    expect(features).to.be.an('array')
+    expect(features.length).to.equal(0)
   })
 
   it('loads the Optimizely Adapter features', done => {
     const ab = new SuiPDE({
       adapter: optimizelyAdapter
     })
-    ab.getEnabledFeatures()
-      .then(features => {
-        expect(features).to.deep.equal(['a', 'b'])
-        done()
-      })
-      .catch(done)
+    const features = ab.getEnabledFeatures()
+    expect(features).to.deep.equal(['a', 'b'])
   })
 
   it('loads the Optimizely Adapter features even when no test consents', done => {
@@ -53,12 +45,8 @@ describe('@s-ui pde', () => {
       adapter: optimizelyAdapter,
       hasUserConsents: false
     })
-    ab.getEnabledFeatures()
-      .then(features => {
-        expect(features).to.deep.equal(['a', 'b'])
-        done()
-      })
-      .catch(done)
+    const features = ab.getEnabledFeatures()
+    expect(features).to.deep.equal(['a', 'b'])
   })
 
   it('should call optimizelys sdk activate fn', () => {
@@ -126,7 +114,7 @@ describe('@s-ui pde', () => {
       const optimizelyInstanceStub = {
         activate: sinon.stub().returns('variationA'),
         onReady: async () => true,
-        getEnabledFeatures: async () => ['a', 'b']
+        getEnabledFeatures: () => ['a', 'b']
       }
       // only executed to create window.optimizelyClientInstance
       // eslint-disable-next-line no-new

--- a/packages/sui-pde/test/common/useExperimentSpec.js
+++ b/packages/sui-pde/test/common/useExperimentSpec.js
@@ -110,7 +110,7 @@ describe('useExperiment hook', () => {
             () =>
               useExperiment({
                 experimentName: 'test_experiment_id',
-                browserTrackExperiment: customTrack
+                trackExperimentViewed: customTrack
               }),
             {
               wrapper

--- a/packages/sui-pde/test/common/useExperimentSpec.js
+++ b/packages/sui-pde/test/common/useExperimentSpec.js
@@ -49,7 +49,7 @@ describe('useExperiment hook', () => {
 
         it('should return the right variationName and launch the Experiment Viewed event', () => {
           const {result} = renderHook(
-            () => useExperiment('test_experiment_id'),
+            () => useExperiment({experimentName: 'test_experiment_id'}),
             {
               wrapper
             }
@@ -79,7 +79,7 @@ describe('useExperiment hook', () => {
         it('should return the right variationName and log an error', () => {
           delete window.analytics
           const {result} = renderHook(
-            () => useExperiment('test_experiment_id'),
+            () => useExperiment({experimentName: 'test_experiment_id'}),
             {
               wrapper
             }
@@ -89,6 +89,36 @@ describe('useExperiment hook', () => {
           expect(console.error.args[0][0]).to.include(
             'window.analytics.track expected'
           )
+        })
+      })
+
+      describe('and use a custom track function', () => {
+        let customTrack
+
+        before(() => {
+          customTrack = sinon.spy()
+          sinon.spy(console, 'error')
+        })
+
+        after(() => {
+          customTrack = undefined
+          console.error.restore()
+        })
+
+        it('should return the right variationName and execute custom track function', () => {
+          const {result} = renderHook(
+            () =>
+              useExperiment({
+                experimentName: 'test_experiment_id',
+                browserTrackExperiment: customTrack
+              }),
+            {
+              wrapper
+            }
+          )
+          expect(result.current.variation).to.equal('activateExperimentA')
+          sinon.assert.callCount(console.error, 0)
+          sinon.assert.callCount(customTrack, 1)
         })
       })
     })
@@ -103,9 +133,12 @@ describe('useExperiment hook', () => {
       })
 
       it('should return the right variationName and launch the Experiment Viewed event', () => {
-        const {result} = renderHook(() => useExperiment('test_experiment_id'), {
-          wrapper
-        })
+        const {result} = renderHook(
+          () => useExperiment({experimentName: 'test_experiment_id'}),
+          {
+            wrapper
+          }
+        )
         expect(result.current.variation).to.equal('getVariationA')
         sinon.assert.callCount(console.error, 0)
       })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There are some special cases to keep in mind in order to make the `Experiment Viewed` track:

> Root: Analytics SDK is loaded async and loads after useExperiment hook has been called
> Cause: `Experiment Viewed` won't be sent.

> Root: `Experiment Viewed` should has a different name or properties.
> Cause: Send a track with wrong values.

In order to ensure or customize the experiment track we have added a new `trackExperimentViewed` param to useExperiment hook.

[See docs](https://github.com/SUI-Components/sui/blob/a21abcf00252ba3b973a835f35f4cb1ad9701252/packages/sui-pde/README.md#experiments)

**Hotfixes**
Given optimizely full stack `getEnabledFeatures` method is not async,  default adapter `getEnabledFeatures` must not be async. Code & tests fixed.

## Breaking change
useExperiment hook now uses named parameters
[commit](https://github.com/SUI-Components/sui/pull/1089/commits/81c8f8f28296ea58b9128961aba8da98f7d4fc10)

## Example
```js
import {useExperiment} from '@s-ui/pde'
const EXPERIMENT_NAME = 'experimentX'
const trackExperiment = () => {
  window.analytics.track('Experiment Viewed', {
      experimentName,
      variationName,
      customProperty: 'yay'
    })
}
const MyComponent = () => {
  const {variation} = useExperiment({
    experimentName: EXPERIMENT_NAME,
    trackExperimentViewed: trackExperiment
  })
  if (variation === 'variationB') return <MyVariationB />
  return <MyVariationA>
}
```
