### PR TITLE
feat(packages/sui-test): add @testing-library/cypress lib

### DIFF
--- a/packages/sui-test/package.json
+++ b/packages/sui-test/package.json
@@ -21,6 +21,7 @@
     "@babel/polyfill": "7.12.1",
     "@babel/register": "7.13.0",
     "@s-ui/helpers": "1",
+    "@testing-library/cypress": "^7.0.4",
     "babel-loader": "8.2.2",
     "babel-plugin-dynamic-import-node": "2.3.3",
     "babel-plugin-istanbul": "6.0.0",

--- a/packages/sui-test/package.json
+++ b/packages/sui-test/package.json
@@ -21,7 +21,7 @@
     "@babel/polyfill": "7.12.1",
     "@babel/register": "7.13.0",
     "@s-ui/helpers": "1",
-    "@testing-library/cypress": "^7.0.4",
+    "@testing-library/cypress": "7.0.4",
     "babel-loader": "8.2.2",
     "babel-plugin-dynamic-import-node": "2.3.3",
     "babel-plugin-istanbul": "6.0.0",


### PR DESCRIPTION
add `@testing-library/cypress` lib. 

## Description
With this [lib](https://testing-library.com/docs/cypress-testing-library/intro/) we will be able to use the selectors that we use in the test components in our e2e tests.




