### PR TITLE
fix(packages/sui-mono): remove root node_modules when using phoenix

### DIFF
--- a/packages/sui-mono/bin/sui-mono-phoenix.js
+++ b/packages/sui-mono/bin/sui-mono-phoenix.js
@@ -71,6 +71,7 @@ const NPM_CMD = [
   [
     'install',
     '--loglevel=error',
+    '--no-fund',
     audit ? '' : '--no-audit',
     production ? '--production' : '',
     progress ? '' : '--no-progress'
@@ -106,14 +107,22 @@ const createInstallPackagesCommand = (cwd = process.cwd()) => {
  * Install root packages
  * @return {Promise}
  */
-const installRootPackages = () => {
+const installRootPackages = async () => {
   if (!root) return Promise.resolve()
 
+  console.log(`[sui-mono] Removing previous root packages...`)
+  const [removeBin, removeArgs] = RIMRAF_CMD
+  await getSpawnPromise(removeBin, removeArgs, {cwd: process.cwd()})
+
   console.log(`[sui-mono] Installing root packages...`)
-  const [bin, args, executionParams] = createInstallPackagesCommand()
-  return getSpawnPromise(bin, args, executionParams).then(() => {
-    console.log('Installed root packages')
-  })
+  const [
+    installBin,
+    installArgs,
+    installExecutionParams
+  ] = createInstallPackagesCommand()
+  await getSpawnPromise(installBin, installArgs, installExecutionParams)
+
+  console.log('[sui-mono] Installed root packages')
 }
 
 const executePhoenixOnPackages = () => {


### PR DESCRIPTION
- [x] Fix problem that made previous node_modules on root not being removed.
- [x] Remove fund flag for npm install.
- [x] Better logging of the proccess.