### PR TITLE
fix(sui-studio): studio workspace area scolling behavior workaround.

### DIFF
--- a/packages/sui-studio/src/components/demo/_style.scss
+++ b/packages/sui-studio/src/components/demo/_style.scss
@@ -6,8 +6,13 @@
   flex: 1;
   flex-direction: column;
 
-  &-codeButton {
+  &-codeButton,
+  &-fullScreenButton {
     @include floating-button($c-primary, 56px, 72px);
+    box-sizing: border-box;
+  }
+
+  &-codeButton {
     @include breakpoint-from(s) {
       bottom: auto;
       top: 8px;
@@ -15,7 +20,6 @@
   }
 
   &-fullScreenButton {
-    @include floating-button($c-primary, 56px, 72px);
     @include breakpoint-from(s) {
       bottom: auto;
       top: 65px;

--- a/packages/sui-studio/src/components/layout/_style.scss
+++ b/packages/sui-studio/src/components/layout/_style.scss
@@ -1,7 +1,5 @@
 .sui-Studio {
   display: flex;
-  height: 100vh;
-  overflow: hidden;
 
   &-logo {
     & > svg {
@@ -13,26 +11,24 @@
   &-sidebar {
     @include breakpoint-from(s) {
       flex: 0 0 $w-sidebar;
-      position: relative;
       transform: translate3d(0, 0, 0);
     }
 
     background-color: $c-white;
     border-right: 1px solid $c-gray-lightest;
     box-sizing: border-box;
-    display: block;
-    height: 100%;
+    height: 100vh;
     overflow-x: hidden;
-    overflow-y: auto;
-    position: absolute;
+    overflow-y: scroll;
+    position: fixed;
     transform: translate3d(-100%, 0, 0);
     transition: transform 0.5s ease-in-out;
-    width: 100%;
     z-index: 9998;
+    width: $w-sidebar;
 
     &Body {
-      transition: width 0.25s ease-out;
       width: $w-sidebar;
+      transition: width 0.25s ease-out;
     }
 
     &--open {
@@ -43,8 +39,9 @@
 
   &-main {
     background-color: $bgc-main;
-    overflow: auto;
-    width: 100%;
+    width: calc(100% - #{$w-sidebar});
+    margin-left: $w-sidebar;
+    min-height: 100vh;
   }
 
   &.sui-Studio--fullscreen {
@@ -52,6 +49,10 @@
     .sui-StudioWorkbench-navigation,
     .sui-StudioNavBar-secondary {
       display: none;
+    }
+    .sui-Studio-main {
+      margin-left: 0;
+      width: 100%;
     }
   }
 }

--- a/packages/sui-studio/src/components/navigation/_style.scss
+++ b/packages/sui-studio/src/components/navigation/_style.scss
@@ -5,6 +5,7 @@
     height: 65px;
     padding: 16px;
     text-decoration: none;
+    box-sizing: border-box;
   }
 
   &-searchInput {

--- a/packages/sui-studio/src/styles/_default.scss
+++ b/packages/sui-studio/src/styles/_default.scss
@@ -1,17 +1,4 @@
-html {
-  box-sizing: border-box;
-}
-
-*,
-*:before,
-*:after {
-  box-sizing: inherit;
-}
-
 body {
   font-family: $ff-sans-serif;
   font-size: $fz-body;
-  margin: 0;
-  overflow: hidden;
-  padding: 0;
 }

--- a/packages/sui-studio/workbench/src/components/Raw/index.scss
+++ b/packages/sui-studio/workbench/src/components/Raw/index.scss
@@ -1,6 +1,9 @@
 @import '../../../../src/styles/settings';
 
 body {
-  overflow: auto;
   background-color: $bgc-main;
+}
+
+.Raw {
+  padding: 16px;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The workaround to get the sui-studio scrolling effect in the mock component area as much clean and native as possible. At the moment it is giving undesired behaviors to final applications. The main idea is having a working area as much clean as possible.

The inner div scrolling effect is only used in the component navigator menu, giving to the workbench area the native scrolling like most of our verticals. It also removes the `box-sizing: border-box;` global rule

It also adds a 16px padding to the Raw component (dev mode) in order not to see the mocked component spaced with the workspace boundings.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
https://sui-components-51b9cvlxx-schibstedspain.vercel.app/workbench/atom/popover/demo
The current scroll behavior is giving undesired behaviors of popovers