### PR TITLE
feat(packages/sui-mono): use less context for commits

### DIFF
--- a/packages/sui-mono/bin/sui-mono-release.js
+++ b/packages/sui-mono/bin/sui-mono-release.js
@@ -73,7 +73,7 @@ const releasesByPackages = ({status}) => {
 const releasePackage = async ({pkg, code, skipCI} = {}) => {
   const isMonoPackage = checkIsMonoPackage()
   const tagPrefix = isMonoPackage ? '' : `${pkg}-`
-  const packageScope = isMonoPackage ? 'META' : pkg.replace(path.sep, '/')
+  const packageScope = isMonoPackage ? 'Root' : pkg.replace(path.sep, '/')
 
   const cwd = isMonoPackage ? BASE_DIR : path.join(process.cwd(), pkg)
   const {private: isPrivatePackage} = getPackageJson(cwd, true)

--- a/packages/sui-mono/src/PrompterManager.js
+++ b/packages/sui-mono/src/PrompterManager.js
@@ -22,7 +22,7 @@ const scopes = config.getWorkspaces().map(name => ({name}))
 
 const allowedBreakingChanges = ['feat', 'fix']
 const typesWithOtherScopes = ['feat', 'fix', 'release', 'test', 'docs', 'chore']
-const defaultScopes = [{name: 'META'}, {name: 'Root'}, {name: 'examples'}]
+const defaultScopes = [{name: 'Root'}]
 const otherScopes = defaultScopes
 
 const getCommitTypesMapped = () =>

--- a/packages/sui-mono/src/commitTypes.json
+++ b/packages/sui-mono/src/commitTypes.json
@@ -13,13 +13,13 @@
       "description": "refactor: A code change that neither fixes a bug nor adds a feature. Includes code style changes."
     },
     "perf": {
-      "description": "perf: A code change that improves performance"
+      "description": "perf: A code change that improves performance."
     },
     "test": {
-      "description": "test: Add tests or modify tests only"
+      "description": "test: Add tests or modify tests only."
     },
     "chore": {
-      "description": "chore: Changes to the build process or auxiliary tools and libraries such as documentation generation. META only."
+      "description": "chore: Changes to the build process or auxiliary tools and libraries such as documentation generation."
     },
     "release": {
       "description": "release: Publish a new version of a package."


### PR DESCRIPTION
Remove META and examples context in order to stick to better meaningful context for commits