### PR TITLE
feat(packages/sui-ssr): inline dynamic import styles on demand

### DIFF
--- a/packages/sui-ssr/README.md
+++ b/packages/sui-ssr/README.md
@@ -277,6 +277,13 @@ Configs accepted:
 
 - **`serverContentType`** (`undefined`): A valid Content-Type string to be set in response header Content-Type. If not defined, it will use the regular html type with utf-8 charset encoding.
 
+- **`createStylesFor`** (`undefined`): Define how the server should manage style imports. When separate styles per page, by default those imports will load css asynchronously but maybe we want that server to add them as an `<link>` in app head and be async or not depends on criticalCSS.
+
+  - **`appStyles`** (`string`): Define the webpackChunkName of app styles. These styles usually are imported in `app.js`.
+  - **`createPagesStyles`** (`false`): Define if pages have style imports that should be managed by the server. The server will get these files from the `asset-manifest.json` file, which should be created by sui-ssr.
+
+> ⚠️ `createStylesFor` does not works as expected when sui-bundler configuration has `onlyHash` defined to `true`.
+
 ## Dynamic Rendering
 
 If you want to apply this new technique proposal by Google to improve your SEO and your site's performance you have to set up the entry _dynamicsURLS_ in the config of the package json with an array of allowed urls. Each entry in this array must be a string and follow the structure of a RegExp constructor.

--- a/packages/sui-ssr/server/config.js
+++ b/packages/sui-ssr/server/config.js
@@ -17,4 +17,16 @@ try {
   ssrConfig = {}
 }
 
-export default {...DEFAULT_VALUES, ...ssrConfig}
+let assetsManifest
+try {
+  assetsManifest = JSON.parse(
+    fs.readFileSync(
+      path.join(process.cwd(), '/public/asset-manifest.json'),
+      'utf8'
+    )
+  )
+} catch (error) {
+  assetsManifest = null
+}
+
+export default {...DEFAULT_VALUES, ...ssrConfig, assetsManifest}

--- a/packages/sui-ssr/server/config.js
+++ b/packages/sui-ssr/server/config.js
@@ -6,6 +6,9 @@ const DEFAULT_VALUES = {
   useLegacyContext: true
 }
 
+const ASYNC_CSS_ATTRS =
+  'rel="stylesheet" media="only x" as="style" onload="this.media=\'all\';var e=document.getElementById(\'critical\');e.parentNode.removeChild(e);"'
+
 let ssrConfig
 try {
   const spaConfig = JSON.parse(
@@ -29,4 +32,9 @@ try {
   assetsManifest = null
 }
 
-export default {...DEFAULT_VALUES, ...ssrConfig, assetsManifest}
+export default {
+  ASYNC_CSS_ATTRS,
+  ...DEFAULT_VALUES,
+  ...ssrConfig,
+  assetsManifest
+}

--- a/packages/sui-ssr/server/utils/factory.js
+++ b/packages/sui-ssr/server/utils/factory.js
@@ -112,14 +112,38 @@ export default ({path, fs, config: ssrConf = {}}) => {
     return url
   }
 
+  const getStyleHrefBy = ({pageName}) => {
+    const assetsFile = ssrConf.assetsManifest
+
+    return assetsFile && assetsFile[`${pageName}.css`]
+  }
+
+  const createStylesFor = ({pageName, async = false}) => {
+    const appStyles = ssrConf.createStylesFor.appStyles
+    const shouldCreatePageStyles = ssrConf.createStylesFor.createPagesStyles
+
+    const stylesheets = [
+      appStyles && getStyleHrefBy({pageName: appStyles}),
+      shouldCreatePageStyles && getStyleHrefBy({pageName})
+    ].filter(Boolean)
+
+    const attributes = async ? ssrConf.ASYNC_CSS_ATTRS : ''
+    const stylesHTML = stylesheets
+      .map(style => `<link rel="stylesheet" href="${style}" ${attributes}>`)
+      .join('')
+
+    return stylesHTML
+  }
+
   return {
-    isMultiSite,
-    hostFromReq,
-    siteByHost,
-    useStaticsByHost,
-    readHtmlTemplate,
     buildRequestUrl,
+    createStylesFor,
+    hostFromReq,
+    hrTimeToMs,
+    isMultiSite,
     publicFolder,
-    hrTimeToMs
+    readHtmlTemplate,
+    siteByHost,
+    useStaticsByHost
   }
 }

--- a/packages/sui-ssr/server/utils/factory.js
+++ b/packages/sui-ssr/server/utils/factory.js
@@ -118,7 +118,9 @@ export default ({path, fs, config: ssrConf = {}}) => {
     return assetsFile && assetsFile[`${pageName}.css`]
   }
 
-  const createStylesFor = ({pageName, async = false}) => {
+  const createStylesFor = ({pageName, async = false} = {}) => {
+    if (!ssrConf.createStylesFor) return ''
+
     const appStyles = ssrConf.createStylesFor.appStyles
     const shouldCreatePageStyles = ssrConf.createStylesFor.createPagesStyles
 

--- a/packages/sui-ssr/server/utils/index.js
+++ b/packages/sui-ssr/server/utils/index.js
@@ -4,23 +4,25 @@ import config from '../config'
 import utilsFactory from './factory'
 
 const {
-  isMultiSite,
+  buildRequestUrl,
+  createStylesFor,
   hostFromReq,
-  publicFolder,
-  siteByHost,
-  useStaticsByHost,
-  readHtmlTemplate,
   hrTimeToMs,
-  buildRequestUrl
+  isMultiSite,
+  publicFolder,
+  readHtmlTemplate,
+  siteByHost,
+  useStaticsByHost
 } = utilsFactory({path, fs, config})
 
 export {
-  isMultiSite,
+  buildRequestUrl,
+  createStylesFor,
   hostFromReq,
-  publicFolder,
-  siteByHost,
-  useStaticsByHost,
-  readHtmlTemplate,
   hrTimeToMs,
-  buildRequestUrl
+  isMultiSite,
+  publicFolder,
+  readHtmlTemplate,
+  siteByHost,
+  useStaticsByHost
 }

--- a/packages/sui-ssr/test/server/utilsSpec.js
+++ b/packages/sui-ssr/test/server/utilsSpec.js
@@ -1,8 +1,12 @@
+import path from 'path'
+import fs from 'fs'
 import {expect} from 'chai'
 import {publicFolder} from '../../server/utils'
+import utilsFactory from '../../server/utils/factory'
 import {getMockedRequest} from './fixtures'
 import {publicFolderWithMultiSiteConfig} from './fixtures/utils'
-
+const ASYNC_CSS_ATTRS =
+  'rel="stylesheet" media="only x" as="style" onload="this.media=\'all\';var e=document.getElementById(\'critical\');e.parentNode.removeChild(e);"'
 describe('[sui-ssr] Utils', () => {
   describe('Public folder', () => {
     describe('In a multi site project', () => {
@@ -19,6 +23,131 @@ describe('[sui-ssr] Utils', () => {
         const folderName = publicFolder(getMockedRequest('www.bikes.com'))
         expect(folderName).to.equal('public')
       })
+    })
+  })
+
+  describe('Create styles for', () => {
+    it('Should do nothing if has no config', () => {
+      const {createStylesFor} = utilsFactory({fs, path})
+
+      const styles = createStylesFor()
+      expect(styles).to.equal('')
+    })
+
+    it('Should not create styles without manifest', () => {
+      const {createStylesFor} = utilsFactory({
+        fs,
+        path,
+        config: {
+          createStylesFor: {
+            appStyles: 'AppStyles'
+          }
+        }
+      })
+
+      const styles = createStylesFor()
+      expect(styles).to.equal('')
+    })
+
+    it('Should create app styles', () => {
+      const {createStylesFor} = utilsFactory({
+        fs,
+        path,
+        config: {
+          assetsManifest: {
+            'AppStyles.css': 'file.css'
+          },
+          createStylesFor: {
+            appStyles: 'AppStyles'
+          }
+        }
+      })
+
+      const styles = createStylesFor()
+      expect(styles).to.equal('<link rel="stylesheet" href="file.css" >')
+    })
+
+    it('Should create an async app styles', () => {
+      const {createStylesFor} = utilsFactory({
+        fs,
+        path,
+        config: {
+          ASYNC_CSS_ATTRS,
+          assetsManifest: {
+            'AppStyles.css': 'file.css'
+          },
+          createStylesFor: {
+            appStyles: 'AppStyles'
+          }
+        }
+      })
+
+      const styles = createStylesFor({async: true})
+      expect(styles).to.equal(
+        `<link rel="stylesheet" href="file.css" ${ASYNC_CSS_ATTRS}>`
+      )
+    })
+
+    it('Should create page styles', () => {
+      const {createStylesFor} = utilsFactory({
+        fs,
+        path,
+        config: {
+          assetsManifest: {
+            'Home.css': 'home.123.css'
+          },
+          createStylesFor: {
+            createPagesStyles: true
+          }
+        }
+      })
+
+      const styles = createStylesFor({pageName: 'Home'})
+      expect(styles).to.equal('<link rel="stylesheet" href="home.123.css" >')
+    })
+
+    it('Should create an async page styles', () => {
+      const {createStylesFor} = utilsFactory({
+        fs,
+        path,
+        config: {
+          ASYNC_CSS_ATTRS,
+          assetsManifest: {
+            'Home.css': 'home.css'
+          },
+          createStylesFor: {
+            createPagesStyles: true
+          }
+        }
+      })
+
+      const styles = createStylesFor({pageName: 'Home', async: true})
+      expect(styles).to.equal(
+        `<link rel="stylesheet" href="home.css" ${ASYNC_CSS_ATTRS}>`
+      )
+    })
+
+    it('Should create an async page styles and app styles', () => {
+      const {createStylesFor} = utilsFactory({
+        fs,
+        path,
+        config: {
+          ASYNC_CSS_ATTRS,
+          assetsManifest: {
+            'AppStyles.css': 'file.css',
+            'Home.css': 'home.css'
+          },
+          createStylesFor: {
+            appStyles: 'AppStyles',
+            createPagesStyles: true
+          }
+        }
+      })
+
+      const styles = createStylesFor({pageName: 'Home', async: true})
+      expect(styles).to.equal(
+        `<link rel="stylesheet" href="file.css" ${ASYNC_CSS_ATTRS}><link rel="stylesheet" href="home.css" ${ASYNC_CSS_ATTRS}>`
+      )
     })
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- **`createStylesFor`** (`undefined`): Define how the server should manage style imports. When separate styles per page, by default those imports will load css asynchronously but maybe we want that server to add them as an `<link>` in app head and be async or not depends on criticalCSS.

  - **`appStyles`** (`string`): Define the webpackChunkName of app styles. These styles usually are imported in `app.js`.
  - **`createPagesStyles`** (`false`): Define if pages have style imports that should be managed by the server. The server will get these files from the `asset-manifest.json` file, which should be created by sui-ssr.

> ⚠️ `createStylesFor` does not works as expected when sui-bundler configuration has `onlyHash` defined to `true`.

Published as a beta: `7.21.0-beta.2`

This code is based on FC custom server and has been tested in MA with beta version.

## Example
```
"sui-ssr": {
      "createStylesFor": {
        "appStyles": "AppStyles",
        "createPagesStyles": true
      }
    }
```
