### PR TITLE
feat(packages/sui-pde): global attributes to be always used

### DIFF
--- a/packages/sui-pde/README.md
+++ b/packages/sui-pde/README.md
@@ -22,13 +22,17 @@ import OptimizelyAdapter from '@s-ui/pde/lib/adapters/optimizely'
 const optimizelyInstance = OptimizelyAdapter.createOptimizelyInstance({
   sdkKey: MY_API_KEY,  // optimizely sdk api key
   options // optional, datafileOptions
-  datafile: // optional
+  datafile // optional
 })
 
 const optimizelyAdapter = new OptimizelyAdapter({
   optimizely: optimizelyInstance,
   userId: // mandatory,
-  hasUserConsents  // if false, the user won't be part of the A/B test
+  hasUserConsents  // if false, the user won't be part of the A/B test,
+  applicationAttributes: {   // optional, global application attributes that must be send on every experiment activation
+    site: 'coches.net',
+    environment: 'development'
+  }
 })
 
 const pde = new PDE({

--- a/packages/sui-pde/src/adapters/optimizely/index.js
+++ b/packages/sui-pde/src/adapters/optimizely/index.js
@@ -22,7 +22,8 @@ export default class OptimizelyAdapter {
     optimizely,
     userId,
     activeIntegrations = {segment: true},
-    hasUserConsents
+    hasUserConsents,
+    applicationAttributes = {}
   }) {
     if (!optimizely) {
       throw new Error(
@@ -33,6 +34,7 @@ export default class OptimizelyAdapter {
     this._optimizely = optimizely
     this._userId = userId?.toString()
     this._activeIntegrations = activeIntegrations
+    this._applicationAttributes = applicationAttributes
     this.updateConsents({hasUserConsents})
   }
 
@@ -103,7 +105,10 @@ export default class OptimizelyAdapter {
    */
   activateExperiment({name, attributes}) {
     if (!this._hasUserConsents) return null
-    return this._optimizely.activate(name, this._userId, attributes)
+    return this._optimizely.activate(name, this._userId, {
+      ...this._applicationAttributes,
+      ...attributes
+    })
   }
 
   /**
@@ -115,7 +120,10 @@ export default class OptimizelyAdapter {
    */
   getVariation({name, attributes}) {
     if (!this._hasUserConsents) return null
-    return this._optimizely.getVariation(name, this._userId, attributes)
+    return this._optimizely.getVariation(name, this._userId, {
+      ...this._applicationAttributes,
+      ...attributes
+    })
   }
 
   onReady() {

--- a/packages/sui-pde/test/common/pdeSpec.js
+++ b/packages/sui-pde/test/common/pdeSpec.js
@@ -106,6 +106,52 @@ describe('@s-ui pde', () => {
     expect(typeof optimizelyAdapter._userId).to.equal('string')
   })
 
+  it('loads attributes set by application on every activate experiment', () => {
+    optimizelyAdapter = new OptimizelyAdapter({
+      optimizely: optimizelyInstanceStub,
+      userId: 'user123',
+      hasUserConsents: true,
+      applicationAttributes: {
+        environment: 'production',
+        site: 'mysite.com'
+      }
+    })
+    optimizelyAdapter.activateExperiment({
+      name: 'fakeTest',
+      attributes: {
+        attr: 'attrValue'
+      }
+    })
+    expect(optimizelyInstanceStub.activate.args[0][2]).to.deep.equal({
+      environment: 'production',
+      site: 'mysite.com',
+      attr: 'attrValue'
+    })
+  })
+
+  it('loads attributes set by application on every get variation', () => {
+    optimizelyAdapter = new OptimizelyAdapter({
+      optimizely: optimizelyInstanceStub,
+      userId: 'user123',
+      hasUserConsents: true,
+      applicationAttributes: {
+        environment: 'production',
+        site: 'mysite.com'
+      }
+    })
+    optimizelyAdapter.getVariation({
+      name: 'fakeTest',
+      attributes: {
+        attr: 'attrValue'
+      }
+    })
+    expect(optimizelyInstanceStub.getVariation.args[0][2]).to.deep.equal({
+      environment: 'production',
+      site: 'mysite.com',
+      attr: 'attrValue'
+    })
+  })
+
   it.client(
     'uses the optimizely adapter by default as global object to integrate with segment',
     () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a way to add global attributes so they are set up once and reused every time. The idea behind this PR is to send the site and environment on every impression event

## Example

```js
const optimizelyAdapter = new OptimizelyAdapter({
  optimizely: optimizelyInstance, // created before
  userId: '1234',
  hasUserConsents: true,
  applicationAttributes: {   // optional, global application attributes that must be send on every experiment activation
    site: 'coches.net',
    environment: 'development'
  }
})
```