### PR TITLE
fix(packages/sui-pde): wait for tracking lib to be ready

### DIFF
--- a/packages/sui-pde/src/hooks/useExperiment.js
+++ b/packages/sui-pde/src/hooks/useExperiment.js
@@ -30,9 +30,11 @@ const browserStrategy = {
       return
     }
 
-    window.analytics.track('Experiment Viewed', {
-      experimentName,
-      variationName
+    window.analytics.ready(() => {
+      window.analytics.track('Experiment Viewed', {
+        experimentName,
+        variationName
+      })
     })
   }
 }

--- a/packages/sui-pde/test/common/useExperimentSpec.js
+++ b/packages/sui-pde/test/common/useExperimentSpec.js
@@ -37,6 +37,7 @@ describe('useExperiment hook', () => {
       describe('and window.analytics.track exists', () => {
         before(() => {
           window.analytics = {
+            ready: cb => cb(),
             track: sinon.spy()
           }
           sinon.spy(console, 'error')


### PR DESCRIPTION
## Description
we cannot send Experiment Viewed before the tracking library is ready otherwise it wouldn't include our wrapper stuff
