### PR TITLE
fix(packages/sui-ssr): prevent remove already deleted node

### DIFF
--- a/packages/sui-ssr/server/config.js
+++ b/packages/sui-ssr/server/config.js
@@ -7,7 +7,7 @@ const DEFAULT_VALUES = {
 }
 
 const ASYNC_CSS_ATTRS =
-  'rel="stylesheet" media="only x" as="style" onload="this.media=\'all\';var e=document.getElementById(\'critical\');e.parentNode.removeChild(e);"'
+  'rel="stylesheet" media="only x" as="style" onload="this.media=\'all\';var e=document.getElementById(\'critical\');if(e){e.parentNode.removeChild(e);}"'
 
 let ssrConfig
 try {


### PR DESCRIPTION
## Description
Hotfix: For more than one async scripts it fails because first is deleting the critical element and others throws an error because can not find parent node of undefined

Ready for test under `@s-ui/ssr@7.22.0-beta.0`