### PR TITLE
fix(packages/sui-bundler): prevent creation wrong webpack rule when l…

### DIFF
--- a/packages/sui-bundler/loaders/linkLoaderConfigBuilder.js
+++ b/packages/sui-bundler/loaders/linkLoaderConfigBuilder.js
@@ -80,7 +80,7 @@ module.exports = ({config, packagesToLink, linkAll}) => {
   const {rules} = config.module
   const rulesWithLink = rules.map(rule => {
     const {use, test: regex} = rule
-    if (!regex.test('.css')) return rule
+    if (!regex.test('.css') || use === 'null-loader') return rule
 
     return {
       ...rule,


### PR DESCRIPTION
Prevent creation wrong Webpack rule when link packages on in server mode. It causes style dynamic import errors

Before:
![Captura de pantalla 2021-04-16 a las 10 14 52](https://user-images.githubusercontent.com/5390428/115012919-b0a57c00-9eb0-11eb-8ba3-a7b03f2b9643.png)

After:
![Captura de pantalla 2021-04-16 a las 10 14 58](https://user-images.githubusercontent.com/5390428/115012936-b4d19980-9eb0-11eb-9e87-46779af2f737.png)