### PR TITLE
Fix/async styles critical remove

### DIFF
--- a/packages/sui-ssr/package.json
+++ b/packages/sui-ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/ssr",
-  "version": "7.22",
+  "version": "7.22.0",
   "description": "> Plug SSR to you SUI SPA.",
   "main": "index.js",
   "bin": {

--- a/packages/sui-ssr/package.json
+++ b/packages/sui-ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/ssr",
-  "version": "7.22.0",
+  "version": "7.22",
   "description": "> Plug SSR to you SUI SPA.",
   "main": "index.js",
   "bin": {

--- a/packages/sui-ssr/server/config.js
+++ b/packages/sui-ssr/server/config.js
@@ -7,7 +7,7 @@ const DEFAULT_VALUES = {
 }
 
 const ASYNC_CSS_ATTRS =
-  'rel="stylesheet" media="only x" as="style" onload="this.media=\'all\';"'
+  'rel="stylesheet" media="print" as="style" onload="this.media=\'all\'"'
 
 let ssrConfig
 try {

--- a/packages/sui-ssr/server/config.js
+++ b/packages/sui-ssr/server/config.js
@@ -7,7 +7,7 @@ const DEFAULT_VALUES = {
 }
 
 const ASYNC_CSS_ATTRS =
-  'rel="stylesheet" media="only x" as="style" onload="this.media=\'all\';var e=document.getElementById(\'critical\');if(e){e.parentNode.removeChild(e);}"'
+  'rel="stylesheet" media="only x" as="style" onload="this.media=\'all\';"'
 
 let ssrConfig
 try {

--- a/packages/sui-ssr/test/server/utilsSpec.js
+++ b/packages/sui-ssr/test/server/utilsSpec.js
@@ -6,7 +6,7 @@ import utilsFactory from '../../server/utils/factory'
 import {getMockedRequest} from './fixtures'
 import {publicFolderWithMultiSiteConfig} from './fixtures/utils'
 const ASYNC_CSS_ATTRS =
-  'rel="stylesheet" media="only x" as="style" onload="this.media=\'all\';var e=document.getElementById(\'critical\');e.parentNode.removeChild(e);"'
+  'rel="stylesheet" media="only x" as="style" onload="this.media=\'all\';'
 describe('[sui-ssr] Utils', () => {
   describe('Public folder', () => {
     describe('In a multi site project', () => {


### PR DESCRIPTION
## Description
Do not remove critical CSS `<style>` when CSS files `onload`
If our app has more than one CSS file, the first file loaded will remove the critical CSS node and we will see a FOUC.

![Captura de pantalla 2021-04-20 a las 8 01 41](https://user-images.githubusercontent.com/5390428/115504885-ea8fcd00-a278-11eb-9ff5-c84eb1b47b0d.png)

Bonus:
use media `print` instead `only x` because of when browsers encounter media types that don’t match, they currently treat them all the same - they load the file anyway.
See: https://www.filamentgroup.com/lab/load-css-simpler/#why-not-use-a-faux-media-attribute%3F

Beta published 👉 @s-ui/ssr@7.23.0-beta.2