### PR TITLE
fix(packages/sui-test): add an option to prevents compile lib folders…

### DIFF
--- a/packages/sui-test/README.md
+++ b/packages/sui-test/README.md
@@ -203,6 +203,7 @@ If defined, any error on your tests will create a screenshot of that moment in t
 - `server`: Config for `@s-ui/test server` binary:
   - `forceTranspilation`: List of regexs (string based, later will be transformed with `new Regex`) of modules to transpile. This is useful in case you're using server tests for modules that are ESModules based and need to be transpiled with `@babel/plugin-transform-modules-commonjs`.
   - `esmOverride`: Boolean flag (defaults to `false`), enable patching the Node's CJS loader when facing ESM errors, like `ERR_REQUIRE_ESM` in `node > v12.12.0`. 
+  - `useLibDir`: Prevents to compile lib folders on mocha runner
 
 ```json
 "config": {

--- a/packages/sui-test/README.md
+++ b/packages/sui-test/README.md
@@ -203,7 +203,7 @@ If defined, any error on your tests will create a screenshot of that moment in t
 - `server`: Config for `@s-ui/test server` binary:
   - `forceTranspilation`: List of regexs (string based, later will be transformed with `new Regex`) of modules to transpile. This is useful in case you're using server tests for modules that are ESModules based and need to be transpiled with `@babel/plugin-transform-modules-commonjs`.
   - `esmOverride`: Boolean flag (defaults to `false`), enable patching the Node's CJS loader when facing ESM errors, like `ERR_REQUIRE_ESM` in `node > v12.12.0`. 
-  - `useLibDir`: Prevents to compile lib folders on mocha runner
+  - `useLibDir`: activated by default. Prevents to compile lib folders on mocha runner if set to false
 
 ```json
 "config": {

--- a/packages/sui-test/bin/mocha/register.js
+++ b/packages/sui-test/bin/mocha/register.js
@@ -1,5 +1,9 @@
 const {serverConfig} = require('../../src/config')
-const {forceTranspilation = [], esmOverride = false} = serverConfig
+const {
+  forceTranspilation = [],
+  esmOverride = false,
+  useLibDir = true
+} = serverConfig
 
 const regexToAdd = forceTranspilation.map(
   regexString => new RegExp(regexString)
@@ -9,9 +13,12 @@ if (esmOverride) {
   require('./applyEsmOverride')
 }
 
+const libDir = /lib/
+const paths = [/test/, libDir, /src/, /@s-ui/, /@babel\/runtime/, ...regexToAdd]
+
 require('@babel/register')({
   ignore: [],
-  only: [/test/, /lib/, /src/, /@s-ui/, /@babel\/runtime/, ...regexToAdd],
+  only: useLibDir ? paths : paths.filter(path => path !== libDir),
   presets: [
     [
       'babel-preset-sui',


### PR DESCRIPTION
… for server tests
## Description
In some projects, if we add `/lib/` folder to the mocha register chunk increases over 500Kb and 
all tests fail.
With option `useLibDir` we could prevent compiling lib folders on the mocha runner if needed

[Failing build](https://travis.mpi-internal.com/scmspain/frontend-ma--lib-milanuncios/builds/4873285)
