### PR TITLE
feat(packages/sui-ssr): skip ci release by flag

### DIFF
--- a/packages/sui-ssr/README.md
+++ b/packages/sui-ssr/README.md
@@ -160,6 +160,9 @@ jobs:
         - npm run ssr:deploy:production
 ```
 
+> If you want that release commit does not trigger a Travis build you could use the flag `--skip-ci` and commit message will have `[skip ci]` string. See more information about [Travis skipping build docs](https://docs.travis-ci.com/user/customizing-the-build/#skipping-a-build)
+
+
 ## Use the ssr output as stream
 
 It uses the stdout stream so you can do things like:

--- a/packages/sui-ssr/bin/sui-ssr-release.js
+++ b/packages/sui-ssr/bin/sui-ssr-release.js
@@ -9,6 +9,7 @@ program
   .option('-B, --branch <branch>', 'Release branch. Will be master by default')
   .option('-E, --email <email>', 'Releaser´s email')
   .option('-N, --name <name>', 'Releaser´s name')
+  .option('-sci, --skip-ci', 'Skip CI')
   .on('--help', () => {
     console.log('  Description:')
     console.log('')
@@ -26,7 +27,7 @@ program
   })
   .parse(process.argv)
 
-const {branch = 'master', email, name} = program
+const {branch = 'master', email, name, skipCi = false} = program
 
 const execute = async (cmd, full) => {
   try {
@@ -88,7 +89,11 @@ const execute = async (cmd, full) => {
       )}`
     )
 
-    await execute(`git commit -m "release(META): ${nextVersion}"`)
+    const skipCiMessage = skipCi ? '[skip ci]' : ''
+
+    await execute(
+      `git commit -m "release(META): ${nextVersion} ${skipCiMessage}"`
+    )
     await execute(`git tag -a "v${nextVersion}" -m "v${nextVersion}"`)
     await execute('git status')
     await execute(`git push --set-upstream --tags origin ${branch}`)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If you want that release commit does not to trigger a Travis build you could use the flag `--skip-ci` and commit message will have `[skip ci]` string. See more information about [Travis skipping build docs](https://docs.travis-ci.com/user/customizing-the-build/#skipping-a-build)

This feature will help us to improve our CI pipeline