### PR TITLE
fix(packages/sui-test): use timeout command option to increase also b…

### DIFF
--- a/packages/sui-test/bin/karma/config.js
+++ b/packages/sui-test/bin/karma/config.js
@@ -15,6 +15,8 @@ const config = {
 
   browsers: ['Chrome'],
 
+  browserDisconnectTolerance: 1,
+
   webpack: {
     devtool: 'eval',
     mode: 'development',

--- a/packages/sui-test/bin/karma/index.js
+++ b/packages/sui-test/bin/karma/index.js
@@ -5,6 +5,7 @@ const CWD = process.cwd()
 
 module.exports = ({ci, pattern, ignorePattern, srcPattern, timeout, watch}) => {
   if (ci) config.browsers = ['Firefox']
+  if (timeout) config.browserDisconnectTimeout = timeout
   if (ignorePattern) config.exclude = [ignorePattern]
   if (watch) config.singleRun = false
 


### PR DESCRIPTION
## Description
[Karma docs](http://karma-runner.github.io/6.3/config/configuration-file.html#browserdisconnecttimeout): _With a flaky connection, it is pretty common that the browser disconnects, but the actual test execution is still running without any problems. Karma does not treat a disconnection as an immediate failure and will wait for browserDisconnectTimeout (ms). If the browser reconnects during that time, everything is fine._
![image](https://user-images.githubusercontent.com/5390428/115846458-37fb6e00-a422-11eb-85fc-cdd83bc8abb6.png)

With this fix, we take advantage of the timeout option to also increase `browserDisconnectTimeout`. Also, increasing the number of tries a browser will attempt in the case of disconnection to 1. Hope we will have a stable CI with these changes.
