### PR TITLE
feat(packages/sui-bundler): remove fibers dependency

### DIFF
--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -32,7 +32,6 @@
     "css-minimizer-webpack-plugin": "1.1.5",
     "esbuild-loader": "2.10.0",
     "fast-glob": "3.2.4",
-    "fibers": "5.0.0",
     "html-webpack-plugin": "4.5.0",
     "mini-css-extract-plugin": "1.3.3",
     "null-loader": "4.0.1",


### PR DESCRIPTION
`fibers` dependency is not longer compatible with node 16 and is causing problems. With Node 16 anyway its benefits are almost none, so we could remove it and everything should work as expected.