### PR TITLE
chore(Root): workspaces are only package first level folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "sui"
   ],
   "workspaces": [
-    "packages/**"
+    "packages/*"
   ],
   "scripts": {
     "phoenix": "npx -p ./packages/sui-mono sui-mono run 'rm -rf ./node_modules' && rm -f package-lock.json && npm install",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
with ** it was installing strange packages that I'd say are not meant to be workspaces

node_modules  integration/empty-studio
node_modules  atom/button
node_modules  integration/sample-studio

on my machine client tests pass now, server test are broken because of module imports