### PR TITLE
fix(Root): use legacy peer deps to run test well in local

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "packages/*"
   ],
   "scripts": {
-    "phoenix": "npx -p ./packages/sui-mono sui-mono run 'rm -rf ./node_modules' && rm -f package-lock.json && npm install",
+    "phoenix": "npx -p ./packages/sui-mono sui-mono run 'rm -rf ./node_modules' && rm -f package-lock.json && npm install --legacy-peer-deps",
     "co": "sui-mono commit",
     "lint": "sui-lint js && sui-lint sass",
     "test": "npm run test:client && npm run test:server",

--- a/packages/sui-js/package.json
+++ b/packages/sui-js/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "bowser": "2.11.0",
     "cookie": "0.3.1",
-    "htmr": "0.8.8",
+    "htmr": "0.10.0",
     "js-cookie": "2.1.4",
     "just-camel-case": "4.0.2",
     "just-capitalize": "1.0.0",


### PR DESCRIPTION
## Description
Use legacy peer deps for phoenix. Some dependencies of dependencies uses different React versions and could cause test errors on local