### PR TITLE
feat(packages/sui-test): add cypress-file-upload dependency

### DIFF
--- a/packages/sui-test/package.json
+++ b/packages/sui-test/package.json
@@ -28,6 +28,7 @@
     "babel-preset-sui": "3",
     "chalk": "4.1.0",
     "commander": "6.2.1",
+    "cypress-file-upload": "5.0.7",
     "karma": "5.2.3",
     "karma-chrome-launcher": "3.1.0",
     "karma-clear-screen-reporter": "1.0.0",


### PR DESCRIPTION
Add `cypress-file-upload` dependency in order to enable some Cypress commands that make us test upload files easily.
