### PR TITLE
feat(packages/sui-critical-css): use Clean CSS instead PurgeCSS. 

### DIFF
--- a/packages/babel-preset-sui/test/server/indexSpec.js
+++ b/packages/babel-preset-sui/test/server/indexSpec.js
@@ -11,7 +11,7 @@ const babel = source => transform(source, babelConfig)
 describe('babel-preset-sui', function() {
   // first time babel is called is pretty slow
   // and could be worse than 2s
-  this.timeout(20000)
+  this.timeout(25000)
 
   describe('regarding React', () => {
     it('should support and use JSX Runtime', async () => {

--- a/packages/sui-critical-css/package.json
+++ b/packages/sui-critical-css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/critical-css",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "",
   "type": "module",
   "main": "src/index.js",
@@ -8,7 +8,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "css-purge": "3.1.8",
+    "clean-css": "5.1.2",
     "playwright": "1.10.0"
   },
   "peerDependencies": {

--- a/packages/sui-critical-css/src/extract-from-url.js
+++ b/packages/sui-critical-css/src/extract-from-url.js
@@ -1,10 +1,10 @@
 import {chromium} from 'playwright'
-import cssPurge from 'css-purge'
+import CleanCSS from 'clean-css'
 import {blockedResourceTypes, skippedResources} from './config.js'
 
-const {purgeCSS} = cssPurge
-
 let browser
+
+const css = new CleanCSS({level: 2})
 
 // Setup a browser instance or return the one already created
 const getBrowser = async () => {
@@ -93,11 +93,11 @@ export async function extractCSSFromUrl({
     await closeAll()
 
     // return minified css
-    return new Promise((resolve, reject) => {
-      purgeCSS(coveredCSS, {}, (err, result) =>
-        err ? reject(err) : resolve(result)
-      )
-    })
+    const {styles, stats} = css.minify(coveredCSS)
+    console.log(
+      `[css] Minified from ${stats.originalSize} to ${stats.minifiedSize} bytes`
+    )
+    return styles
   } catch (e) {
     console.log(e)
     browser && browser.close && (await browser.close())


### PR DESCRIPTION
Improve Critical CSS in order to get better output size by minify by using Clean CSS.

It's a smaller dependency, faster and better. 🚀 

![image](https://user-images.githubusercontent.com/1561955/117641949-0ce57e00-b187-11eb-908f-dbdcd27dd8b9.png)
