### PR TITLE
feat(packages/sui-mono): use latest commitizen with less dependencies

### DIFF
--- a/packages/sui-mono/package.json
+++ b/packages/sui-mono/package.json
@@ -10,11 +10,11 @@
   "dependencies": {
     "@s-ui/helpers": "1",
     "commander": "6.2.1",
-    "commitizen": "4.2.3",
+    "commitizen": "4.2.4",
     "conventional-changelog": "3.1.24",
     "editor": "1.0.0",
     "git-url-parse": "11.4.4",
-    "glob": "7.1.6",
+    "glob": "7.1.7",
     "rimraf": "3.0.2",
     "temp": "0.9.4",
     "word-wrap": "1.2.3"


### PR DESCRIPTION
Use latest version of commitizen with 2MB less of dependencies.
https://packagephobia.com/result?p=commitizen@4.2.4

![image](https://user-images.githubusercontent.com/1561955/117650213-bc731e00-b190-11eb-9486-e03a74694e2a.png)
