### PR TITLE
feat(packages/sui-ssr): enable define commit to release

### DIFF
--- a/packages/sui-ssr/bin/sui-ssr-release.js
+++ b/packages/sui-ssr/bin/sui-ssr-release.js
@@ -9,6 +9,8 @@ program
   .option('-B, --branch <branch>', 'Release branch. Will be master by default')
   .option('-E, --email <email>', 'Releaser´s email')
   .option('-N, --name <name>', 'Releaser´s name')
+  .option('-C, --commit <commit>', 'Commit to tag')
+  .option('-sci, --skip-ci', 'Skip CI')
   .on('--help', () => {
     console.log('  Description:')
     console.log('')
@@ -26,7 +28,7 @@ program
   })
   .parse(process.argv)
 
-const {branch = 'master', email, name} = program
+const {branch = 'master', email, name, skipCi = false, commit} = program
 
 const execute = async (cmd, full) => {
   try {
@@ -41,6 +43,13 @@ const execute = async (cmd, full) => {
     return e
   }
 }
+
+const getCommitToTag = async () => {
+  if (commit) return commit
+
+  return execute('git rev-parse HEAD')
+}
+
 ;(async () => {
   const cwd = process.cwd()
   const {GH_TOKEN} = process.env
@@ -52,8 +61,8 @@ const execute = async (cmd, full) => {
   try {
     await execute(`git checkout ${branch}`)
     await execute(`git pull origin ${branch}`)
-    const lastCommitHash = await execute('git rev-parse HEAD')
-    const hasTag = await execute(`git tag --points-at ${lastCommitHash}`)
+    const commitToTag = await getCommitToTag()
+    const hasTag = await execute(`git tag --points-at ${commitToTag}`)
 
     if (hasTag) {
       console.log('We are going to release the current tag:', hasTag)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Move ssr7 feature to ssr6 https://github.com/SUI-Components/sui/pull/1142

**Context**
In a multipackage repository scenario, maybe we do not want to release the last commit because it could be another package release (with his self-release tag).
We enable the possibility to send commit via a command in order to define which commit we want to release. In a Travis CI pipeline it could be `npx @s-ui/ssr release --email git@email.com --name gitName --commit $(TRAVIS_COMMIT)`
