### PR TITLE
feat(packages/sui-ssr): support npm 7 and node 15 forcing mime depend…

### DIFF
--- a/packages/sui-ssr/README.md
+++ b/packages/sui-ssr/README.md
@@ -522,3 +522,10 @@ Maybe you want to use a config like this:
   }
 }
 ```
+
+# Next Steps:
+
+**Stop compiling s-ui/ssr**
+⚠️ `sui-ssr build` is going to be deprecated in some following major version:
+
+- With that we could delete mime version of package json. Added because webpack does not get correctly mime version and could cause server errors. It is an express dependency.

--- a/packages/sui-ssr/package.json
+++ b/packages/sui-ssr/package.json
@@ -36,6 +36,7 @@
     "git-url-parse": "11.1.2",
     "js-yaml": "3.12.0",
     "jsesc": "3.0.1",
+    "mime": "1.6.0",
     "noop-console": "0.8.0",
     "parse-domain": "2.3.4",
     "parse5": "6.0.0",


### PR DESCRIPTION
…ency in sui-ssr to prevent runt
## Description
We need sui-ssr supports npm 7 and node 15.

For that reason, we have installed `mime` as a dependency. Doing that we ensure express will use the correct version of `mime` and prevent webpack bundle errors importing that dependency if our project has had a newer dependency of `mime`:

![image](https://user-images.githubusercontent.com/5390428/118253745-8e504f80-b4aa-11eb-9979-7fceab32ad74.png)
