### PR TITLE
feat(packages/sui-theme): add scss variable drop-down user height

### DIFF
--- a/packages/sui-theme/src/settings-compat-v7/_components.scss
+++ b/packages/sui-theme/src/settings-compat-v7/_components.scss
@@ -188,6 +188,7 @@ $bd-dropdown-user-last-item: 1px solid $c-gray-light !default;
 $bg-dropdown-user-button: $c-gray !default;
 $bgc-dropdown-user: $c-white !default;
 $w-dropdown-user-avatar: 48px !default;
+$h-dropdown-user-avatar: auto !default;
 $w-dropdown-user-text: 100px !default;
 $c-dropdown-user-text-large: $c-text-base !default;
 $c-dropdown-user-icon-highlight: $c-accent !default;


### PR DESCRIPTION
## Description
Add default scss variable for avatar height in DropDown component. The actual avatar is rendering for the first time without a specific height generating annoying CLS.

## Related Issue
https://jira.scmspain.com/browse/MTR-37856

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
