### PR TITLE
Feat/improve package deps studio

### DIFF
--- a/packages/sui-studio/bin/helpers/copyGlobals.js
+++ b/packages/sui-studio/bin/helpers/copyGlobals.js
@@ -1,7 +1,8 @@
-const cpy = require('cpy')
+const copy = require('copyfiles')
 const fs = require('fs')
 
 const GLOBALS_FILE_PATH = 'components/globals.js'
+const DESTINATION_FOLDER = 'public'
 
 module.exports = function copyGlobals() {
   if (fs.existsSync(GLOBALS_FILE_PATH)) {
@@ -9,7 +10,7 @@ module.exports = function copyGlobals() {
   } else {
     fs.writeFileSync(GLOBALS_FILE_PATH, '// globals file', 'utf8')
   }
-  cpy([GLOBALS_FILE_PATH], 'public', {
-    parents: true
-  })
+  copy([GLOBALS_FILE_PATH, DESTINATION_FOLDER], () =>
+    console.log('[sui-studio] Copied globals file correctly')
+  )
 }

--- a/packages/sui-studio/bin/helpers/copyStaticFiles.js
+++ b/packages/sui-studio/bin/helpers/copyStaticFiles.js
@@ -1,18 +1,20 @@
-const cpy = require('cpy')
+const copy = require('copyfiles')
+
+const DESTINATION_FOLDER = 'public'
 
 module.exports = function copyStaticFiles() {
-  return cpy(
+  return copy(
     [
       'components/**/README.md',
       'components/**/CHANGELOG.md',
       'components/**/UXDEF.md',
       'components/**/src/index.js',
-      'demo/**/playground'
+      'components/**/demo/playground',
+      DESTINATION_FOLDER
     ],
-    'public',
     {
-      deep: 3,
-      parents: true
-    }
+      exclude: 'node_modules/**'
+    },
+    () => console.log('[sui-studio] Static files copied')
   )
 }

--- a/packages/sui-studio/package.json
+++ b/packages/sui-studio/package.json
@@ -10,7 +10,6 @@
   "license": "MIT",
   "dependencies": {
     "@babel/cli": "7.14.3",
-    "@babel/standalone": "7.14.1",
     "@s-ui/bundler": "7",
     "@s-ui/helpers": "1",
     "@s-ui/mono": "2",
@@ -23,11 +22,10 @@
     "chai": "4.2.0",
     "chai-dom": "1.8.2",
     "classnames": "2.2.5",
-    "codemirror": "5.59.0",
     "colors": "1.4.0",
     "commander": "6.2.1",
     "cpx": "1.5.0",
-    "cpy": "8.1.1",
+    "copyfiles": "2.4.1",
     "deepmerge": "4.2.2",
     "fast-glob": "3.2.4",
     "fs-extra": "10.0.0",
@@ -40,8 +38,8 @@
     "normalize.css": "8.0.1",
     "raw-loader": "4.0.2",
     "react": "17",
-    "react-dom": "17",
     "react-docgen": "5.3.1",
+    "react-dom": "17",
     "react-test-renderer": "17"
   },
   "config": {

--- a/packages/sui-studio/src/components/demo/CodeEditor.js
+++ b/packages/sui-studio/src/components/demo/CodeEditor.js
@@ -3,9 +3,6 @@ import PropTypes from 'prop-types'
 import cx from 'classnames'
 import debounce from 'just-debounce-it'
 
-import {fromTextArea} from 'codemirror'
-import 'codemirror/mode/javascript/javascript'
-
 const CODE_MIRROR_OPTIONS = {
   lineNumbers: true,
   mode: 'javascript',
@@ -26,7 +23,10 @@ function CodeEditor({isOpen, onChange, playground}) {
 
   useEffect(function() {
     const onChangeDebounced = createOnChangeDebounced()
-    const codeMirror = fromTextArea(textAreaRef.current, CODE_MIRROR_OPTIONS)
+    const codeMirror = window.CodeMirror.fromTextArea(
+      textAreaRef.current,
+      CODE_MIRROR_OPTIONS
+    )
     codeMirror.setValue(playground)
     codeMirror.on('change', onChangeDebounced)
 

--- a/packages/sui-studio/src/components/preview/index.js
+++ b/packages/sui-studio/src/components/preview/index.js
@@ -2,11 +2,12 @@
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import SUIContext from '@s-ui/react-context'
-import {transform} from '@babel/standalone'
 
 const TRANSFORM_PRESETS = {
   presets: ['es2015-loose', 'stage-3', 'react']
 }
+
+let previousCode = ''
 
 const getCompiledCode = ({code, scope}) => {
   const codeToCompile = `
@@ -14,7 +15,13 @@ const getCompiledCode = ({code, scope}) => {
       ${code}
     });`
 
-  return transform(codeToCompile, TRANSFORM_PRESETS).code
+  try {
+    const {code} = window.Babel.transform(codeToCompile, TRANSFORM_PRESETS)
+    previousCode = code
+    return code
+  } catch (e) {
+    return previousCode
+  }
 }
 
 class ErrorRenderBoundary extends Component {

--- a/packages/sui-studio/src/index.html
+++ b/packages/sui-studio/src/index.html
@@ -6,12 +6,11 @@
     name="viewport"
     content="width=device-width, initial-scale=1.0, maximum-scale=1"
   />
-  <link rel="stylesheet" href="https://unpkg.com/mocha/mocha.css" />
-  <script src="https://unpkg.com/mocha/mocha.js"></script>
-  <script class="mocha-init">
-    mocha.setup('bdd')
-    mocha.setup({ignoreLeaks: true})
-  </script>
+  <script defer src="https://unpkg.com/@babel/standalone@7.14.3/babel.min.js"></script>
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.61.0/codemirror.min.js"></script>
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.61.0/mode/javascript/javascript.min.js"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.61.0/codemirror.min.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.61.0/theme/material.min.css" />
 </head>
 <body>
   <div id="root"></div>

--- a/packages/sui-studio/workbench/src/index.html
+++ b/packages/sui-studio/workbench/src/index.html
@@ -3,12 +3,11 @@
   <title>SUI Studio</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
-  <link rel="stylesheet" href="https://unpkg.com/mocha/mocha.css" />
-
-  <script src="https://unpkg.com/mocha/mocha.js"></script>
-  <script class="mocha-init">
+  <link rel="stylesheet" href="https://unpkg.com/mocha@7/mocha.css" />
+  <script src="https://unpkg.com/mocha@7/mocha.js"></script>
+  <script>
     mocha.setup('bdd');
-    mocha.setup({ignoreLeaks: true});
+    mocha.setup({checkLeaks: false});
   </script>
 </head>
 <body>


### PR DESCRIPTION
- [x] Stop bundling Codemirror and @babel/standalone and use from CDN instead.
- [x] Use `copyfiles` instead `cpy` dependency (smaller)
- [x] Remove mocha from catalogue (not used) and pin to v7 on workbench (8 was not working as expected).
- [x] Change deprecated option `ignoreLeaks` for `checkLeaks`.

From 132MB to 124MB.
![image](https://user-images.githubusercontent.com/1561955/118721799-9b16cf80-b82b-11eb-8a4f-8add937d6cec.png)
