### PR TITLE
feat(packages/sui-mockmock): Upgrade dependencies

### DIFF
--- a/packages/sui-mockmock/package.json
+++ b/packages/sui-mockmock/package.json
@@ -18,8 +18,8 @@
     "./lib/http/serverMocker.js": false
   },
   "dependencies": {
-    "nock": "9.1.6",
-    "sinon": "2.4.1"
+    "nock": "13.0.11",
+    "sinon": "10.0.0"
   },
   "devDependencies": {
     "@s-ui/test": "4",


### PR DESCRIPTION
Upgrade dependencies of sui-mockmock.
Shaving off 3MB.
Stop using deprecated sinon with very old dependencies.
Tests still passing.

BREAKING CHANGES:

sinon has some major changes. Users of this package might be using sinon as peer-dependency and they
might need to recheck everything is working as expected still.
