### PR TITLE
fix(packages/sui-studio): mobile navbar behavior

### DIFF
--- a/packages/sui-studio/src/components/layout/_style.scss
+++ b/packages/sui-studio/src/components/layout/_style.scss
@@ -39,9 +39,15 @@
 
   &-main {
     background-color: $bgc-main;
-    width: calc(100% - #{$w-sidebar});
-    margin-left: $w-sidebar;
+    width: 100%;
+    margin-left: 0;
     min-height: 100vh;
+    transition: width 0.5s ease-in-out, margin-left 0.5s ease-in-out;
+    @include breakpoint-from(s) {
+      width: calc(100% - #{$w-sidebar});
+      margin-left: $w-sidebar;
+      transition: width 0.5s ease-in-out, margin-left 0.5s ease-in-out;
+    }
   }
 
   &.sui-Studio--fullscreen {

--- a/packages/sui-studio/src/components/navigation/_style.scss
+++ b/packages/sui-studio/src/components/navigation/_style.scss
@@ -27,6 +27,7 @@
   &-menu {
     list-style: none;
     padding-left: 16px;
+    margin: 0;
 
     &Link {
       border-left: 1px solid #e4e4e4;
@@ -56,6 +57,9 @@
       color: $c-black;
       padding-bottom: 10px;
       padding-top: 20px;
+      &:nth-child(1) {
+        padding-top: 20px;
+      }
     }
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The actual studio (v9) is presenting a 220px margin left also when the navbar is hidden for the mobile devices (small breakpoint). This PR fixes it preserving the alder transition.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
