### PR TITLE
fix(packages/sui-studio): studio demo should use src code instead lib

### DIFF
--- a/packages/sui-studio/bin/sui-studio-generate.js
+++ b/packages/sui-studio/bin/sui-studio-generate.js
@@ -193,7 +193,7 @@ return (<${componentInPascal} />)
 
   writeFile(
     COMPONENT_PLAYGROUND_FILE,
-    `import ${componentInPascal} from 'components/${category}/${component}/'
+    `import ${componentInPascal} from 'components/${category}/${component}/src'
 export default () => <${componentInPascal} />
 `
   ),


### PR DESCRIPTION
## Bug description
Studio generate demo file imports component from root component path and `package.json` indicates that entry point is `/lib/index.js`
It causes confusion in development mode because src changes compile but not updates demo.

This PR fix studio generate, doing that demo file imports uses `src` code

Reported by @Sabri1209 