### PR TITLE
fix(packages/sui-mono): Avoid checking git status message and use porcelain instead

### DIFF
--- a/packages/sui-mono/bin/sui-mono-commit-all.js
+++ b/packages/sui-mono/bin/sui-mono-commit-all.js
@@ -40,10 +40,10 @@ const {message, type} = program
 const hasChangedFiles = path => {
   return new Promise((resolve, reject) => {
     exec(
-      `git add . && git status ${path}`,
+      `git add . && git status ${path} --porcelain`,
       {cwd: process.cwd()},
-      (err, output) => {
-        err ? reject(err) : resolve(!output.includes('nothing to commit'))
+      (err, {stdout}) => {
+        err ? reject(err) : resolve(stdout.trim() !== '')
       }
     )
   })

--- a/packages/sui-mono/src/prompter-manager.js
+++ b/packages/sui-mono/src/prompter-manager.js
@@ -79,8 +79,10 @@ const getCommitSteps = ({scopesWithChanges}) => [
  * @return {Promise<Boolean>}
  */
 const checkIfHasChangedFiles = async path => {
-  const output = await exec(`git status ${path}`, {cwd: process.cwd()})
-  return !output.stdout.includes('nothing to commit')
+  const {stdout} = await exec(`git status ${path} --porcelain`, {
+    cwd: process.cwd()
+  })
+  return stdout.trim() !== ''
 }
 
 module.exports = async function startMainCommitFlow() {


### PR DESCRIPTION
Use porcelain mode instead checking the message of the status (as some users could have this in Spanish instead).