### PR TITLE
feat(packages/sui-studio): Remove deprecated dependency but keep compatibility

### DIFF
--- a/packages/sui-studio/bin/cpx.js
+++ b/packages/sui-studio/bin/cpx.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+const copyfiles = require('copyfiles')
+
+const [, , from, to] = process.argv
+
+copyfiles([from, to], {up: 1}, err =>
+  err ? console.error(err) : console.log('Files copied successfully')
+)

--- a/packages/sui-studio/package.json
+++ b/packages/sui-studio/package.json
@@ -4,6 +4,7 @@
   "description": "Develop, maintain and publish your SUI components.",
   "main": "index.js",
   "bin": {
+    "cpx": "./bin/cpx.js",
     "sui-studio": "./bin/sui-studio.js"
   },
   "author": "",
@@ -24,7 +25,6 @@
     "classnames": "2.2.5",
     "colors": "1.4.0",
     "commander": "6.2.1",
-    "cpx": "1.5.0",
     "copyfiles": "2.4.1",
     "deepmerge": "4.2.2",
     "fast-glob": "3.2.4",


### PR DESCRIPTION
Remove big dependency (cpx) with some deprecated dependencies and use `copyfiles` instead with a wrapper, keeping binary compatibility to avoid doing changes on repositories.

This will remove 6MB of dependencies from @s-ui/studio (137MB -> 131MB).