### PR TITLE
feat(packages/sui-js): update htmr version

### DIFF
--- a/packages/sui-js/package.json
+++ b/packages/sui-js/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "bowser": "2.11.0",
     "cookie": "0.3.1",
-    "htmr": "0.10.0",
+    "htmr": "1.0.0",
     "js-cookie": "2.1.4",
     "just-camel-case": "4.0.2",
     "just-capitalize": "1.0.0",


### PR DESCRIPTION
## Description
htmr 1.0.0 has react 17 support, looks like there is no breaking change although I've published a beta version which I'm about to test for possible incompatibilities

## Related Issue
npm@7 + components in same repo doesn't work as expected as while running the studio test it breaks because of two different react versions
