### PR TITLE
Feat/add display name support for critical css

### DIFF
--- a/packages/sui-critical-css/README.md
+++ b/packages/sui-critical-css/README.md
@@ -15,7 +15,20 @@ Install package to your project:
 npm install @s-ui/critical-css -D
 ```
 
-Programmatic usage:
+## Programatical usage:
+
+In order to extract critical css and match extracted files with you page or route you can use two approaches:
+
+- Using path-to-regex
+- Using page component displayName
+
+You can combine both of them.
+
+### Using `path-to-regex`:
+
+You can use [Express Route Tester](http://forbeslindesay.github.io/express-route-tester/) to create and validate that your Path-to-Regexp works as expected.
+
+Example:
 
 ```js
 // scripts/get-critical-css-for-routes.js
@@ -37,7 +50,39 @@ const routes = {
 extractCSSFromApp({config, routes})
 ```
 
-Now you should execute this script on your CI before deploying/dockerizing your app.
+### Using `displayName`
+
+Example:
+
+```js
+// scripts/get-critical-css-for-routes.js
+import {extractCSSFromApp} from '@s-ui/critical-css'
+
+// Page display names
+const displayNames = {
+  home: 'Home',
+  list: 'List'
+}
+
+const config = {
+  hostname: 'http://localhost'
+}
+
+const routes = {
+  [displayNames.home]: {
+    url: '/es'
+  },
+  [displayNames.list]: {
+    url: '/es/catalogo-productos'
+  }
+}
+
+extractCSSFromApp({config, routes})
+```
+
+## Use in your server
+
+You should execute this script on your CI before deploying/dockerizing your app.
 
 ```
 node scripts/get-critical-css-for-routes.js

--- a/packages/sui-critical-css/README.md
+++ b/packages/sui-critical-css/README.md
@@ -17,7 +17,7 @@ npm install @s-ui/critical-css -D
 
 ## Programatical usage:
 
-In order to extract critical css and match extracted files with you page or route you can use two approaches:
+In order to extract critical css and match extracted files with your page or route you can use two approaches:
 
 - Using path-to-regex
 - Using page component displayName

--- a/packages/sui-critical-css/package.json
+++ b/packages/sui-critical-css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/critical-css",
-  "version": "1.6.0-beta.1",
+  "version": "1.5.0",
   "description": "",
   "type": "module",
   "main": "src/index.js",

--- a/packages/sui-critical-css/package.json
+++ b/packages/sui-critical-css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/critical-css",
-  "version": "1.5.0",
+  "version": "1.6.0-beta.1",
   "description": "",
   "type": "module",
   "main": "src/index.js",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "clean-css": "5.1.2",
-    "playwright": "1.10.0"
+    "playwright": "1.11.1"
   },
   "peerDependencies": {
     "path-to-regexp": "*"

--- a/packages/sui-critical-css/src/config.js
+++ b/packages/sui-critical-css/src/config.js
@@ -12,19 +12,19 @@ export const blockedResourceTypes = [
 export const devices = {
   m: {
     userAgent:
-      'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.109 Mobile Safari/537.36',
+      'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.109 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
     width: 360,
     height: 640
   },
   t: {
     userAgent:
-      'Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1',
+      'Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
     width: 768,
     height: 1024
   },
   d: {
     userAgent:
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.109 Safari/537.36',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.109 Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
     width: 1024,
     height: 768
   }

--- a/packages/sui-critical-css/src/middleware.cjs
+++ b/packages/sui-critical-css/src/middleware.cjs
@@ -13,7 +13,7 @@ const getDisplayNameFrom = (matchResult = {}) => {
   const {renderProps = {}} = matchResult
   const {components = []} = renderProps
   const pageComponent = components[components.length - 1]
-  return pageComponent?.displayName
+  return pageComponent && pageComponent.displayName
 }
 
 const findCriticalKeyFrom = ({manifest, pathFromRequest}) =>

--- a/packages/sui-critical-css/src/middleware.cjs
+++ b/packages/sui-critical-css/src/middleware.cjs
@@ -9,26 +9,41 @@ const CACHE_CRITICAL_CSS = {}
 const getFilePath = ({file, criticalDir}) =>
   path.join(process.cwd(), criticalDir, file)
 
-module.exports = ({
-  deviceType,
-  manifest,
-  criticalDir = CRITICAL_CSS_DIR
-}) => async (req, res, next) => {
-  if (deviceType !== 'mobile') return next()
+const getDisplayNameFrom = (matchResult = {}) => {
+  const {renderProps = {}} = matchResult
+  const {components = []} = renderProps
+  const pageComponent = components[components.length - 1]
+  return pageComponent?.displayName
+}
 
-  const criticalPath = Object.keys(manifest).find(path => {
+const findCriticalKeyFrom = ({manifest, pathFromRequest}) =>
+  Object.keys(manifest).find(path => {
     const regexp = pathToRegexp(path)
-    return Boolean(regexp.exec(req && req.path))
+    return Boolean(regexp.exec(pathFromRequest))
   })
 
-  if (!criticalPath) return next()
+module.exports = ({
+  deviceType,
+  manifest = {},
+  criticalDir = CRITICAL_CSS_DIR
+}) => async (req = {}, res, next) => {
+  if (deviceType !== 'mobile') return next()
 
-  if (CACHE_CRITICAL_CSS[criticalPath]) {
-    req.criticalCSS = CACHE_CRITICAL_CSS[criticalPath]
+  const {matchResult, path: pathFromRequest} = req
+  const displayName = getDisplayNameFrom(matchResult)
+
+  const criticalKey =
+    (manifest[displayName] && displayName) ||
+    findCriticalKeyFrom({manifest, pathFromRequest})
+
+  if (!criticalKey) return next()
+
+  if (CACHE_CRITICAL_CSS[criticalKey]) {
+    req.criticalCSS = CACHE_CRITICAL_CSS[criticalKey]
     return next()
   }
 
-  const file = manifest[criticalPath]
+  const file = manifest[criticalKey]
   const filePath = file && getFilePath({file, criticalDir})
   const err = await fs.access(filePath, fs.F_OK)
 
@@ -36,7 +51,7 @@ module.exports = ({
     try {
       const criticalCSS = await fs.readFile(filePath, 'utf8')
       req.criticalCSS = criticalCSS
-      CACHE_CRITICAL_CSS[criticalPath] = criticalCSS
+      CACHE_CRITICAL_CSS[criticalKey] = criticalCSS
     } catch (e) {
       console.error(e)
     }


### PR DESCRIPTION
# Description
For some websites, it could be very hard to match a path-to-regex with all URL of a page.
We add support for using page displayName in middleware in order to simplify the page match.

Changes released in `@s-ui/critical-css@1.6.0-beta.2`

## Programatical usage:

In order to extract critical CSS and match extracted files with your page or route you can use two approaches:

- Using path-to-regex
- Using page component displayName

You can combine both of them, see readme updates