### PR TITLE
feat(packages/sui-pde): Track experiment viewed only once

### DIFF
--- a/packages/sui-pde/src/hooks/platformStrategies.js
+++ b/packages/sui-pde/src/hooks/platformStrategies.js
@@ -1,5 +1,7 @@
 import {parseQueryString} from '@s-ui/js/lib/string'
 
+const experimentsAlreadyTracked = []
+
 const getServerStrategy = () => ({
   getVariation: ({pde, experimentName, attributes}) => {
     return pde.getVariation({pde, name: experimentName, attributes})
@@ -24,6 +26,9 @@ const getBrowserStrategy = ({customTrackExperimentViewed}) => ({
 
     // user is not part of the experiment
     if (!variationName) return
+    // if experiment has been already tracked
+    if (experimentsAlreadyTracked.includes(experimentName)) return
+
     if (!window.analytics?.track) {
       // eslint-disable-next-line no-console
       console.error(
@@ -33,6 +38,7 @@ const getBrowserStrategy = ({customTrackExperimentViewed}) => ({
     }
 
     window.analytics.ready(() => {
+      experimentsAlreadyTracked.push(experimentName)
       window.analytics.track('Experiment Viewed', {
         experimentName,
         variationName


### PR DESCRIPTION
Avoid sending track `Experiment Viewed` every time we call the `useExperiment`.

We store the event sent for the Experiment in order to avoid sending it more than once.