### PR TITLE
Feat/avoid using script name for coverage and watch config

### DIFF
--- a/packages/sui-test/bin/karma/config.js
+++ b/packages/sui-test/bin/karma/config.js
@@ -1,9 +1,6 @@
 const webpack = require('webpack')
 const path = require('path')
 
-const TARGET = process.env.npm_lifecycle_event
-const CWD = process.cwd()
-
 const config = {
   singleRun: true,
 
@@ -90,25 +87,6 @@ const config = {
       reporter: 'html'
     }
   }
-}
-
-if (TARGET === 'test:ci') {
-  config.reporters = ['coverage'].concat(config.reporters)
-  config.preprocessors = {
-    'src/**/*.js': ['coverage']
-  }
-  config.coverageReporter = {
-    dir: `${CWD}/coverage`,
-    reporters: [
-      {type: 'cobertura', subdir: '.', file: 'coverage.xml'},
-      {type: 'html', subdir: 'report-html'},
-      {type: 'text-summary'}
-    ]
-  }
-}
-
-if (TARGET === 'test:watch') {
-  config.reporters = ['clear-screen'].concat(config.reporters)
 }
 
 module.exports = config

--- a/packages/sui-test/bin/karma/index.js
+++ b/packages/sui-test/bin/karma/index.js
@@ -4,10 +4,8 @@ const config = require('./config')
 const CWD = process.cwd()
 
 module.exports = ({ci, pattern, ignorePattern, srcPattern, timeout, watch}) => {
-  if (ci) config.browsers = ['Firefox']
   if (timeout) config.browserDisconnectTimeout = timeout
   if (ignorePattern) config.exclude = [ignorePattern]
-  if (watch) config.singleRun = false
 
   config.files = [
     `${CWD}/node_modules/@babel/polyfill/dist/polyfill.min.js`,
@@ -22,6 +20,27 @@ module.exports = ({ci, pattern, ignorePattern, srcPattern, timeout, watch}) => {
   config.client.mocha = {
     ...config.client.mocha,
     ...(timeout && {timeout})
+  }
+
+  if (ci) {
+    config.browsers = ['Firefox']
+    config.reporters = ['coverage'].concat(config.reporters)
+    config.preprocessors = {
+      'src/**/*.js': ['coverage']
+    }
+    config.coverageReporter = {
+      dir: `${CWD}/coverage`,
+      reporters: [
+        {type: 'cobertura', subdir: '.', file: 'coverage.xml'},
+        {type: 'html', subdir: 'report-html'},
+        {type: 'text-summary'}
+      ]
+    }
+  }
+
+  if (watch) {
+    config.singleRun = false
+    config.reporters = ['clear-screen'].concat(config.reporters)
   }
 
   return new Promise((resolve, reject) => {

--- a/packages/sui-test/bin/karma/index.js
+++ b/packages/sui-test/bin/karma/index.js
@@ -12,6 +12,7 @@ module.exports = ({ci, pattern, ignorePattern, srcPattern, timeout, watch}) => {
     srcPattern ? `${CWD}/${srcPattern}` : '',
     `${CWD}/${pattern}`
   ].filter(Boolean)
+
   config.preprocessors = {
     [pattern]: ['webpack'],
     ...(srcPattern && {[srcPattern]: ['webpack']})


### PR DESCRIPTION
Avoid using npm script name to determine config and instead rely on parameters passed to CLI.