### PR TITLE
feat(packages/sui-pde): add feature variables support

### DIFF
--- a/packages/sui-pde/README.md
+++ b/packages/sui-pde/README.md
@@ -161,6 +161,25 @@ const MyComponent = () => {
 }
 ```
 
+#### Feature Flags Variables
+
+Returns all feature variables for the specified feature flag
+
+```js
+import {useFeature} from '@s-ui/pde'
+
+const MyComponent = () => {
+  const {isActive, variables} = useFeature('myFeatureKey') // variables = an object with all the feature variables
+
+  return (
+    <p>
+      The feature 'myFeatureKey' is{' '}
+      {isActive ? `active and price value is ${variables.price}` : 'inactive'}
+    </p>
+  )
+}
+```
+
 #### Segment integration
 
 By default, segment integration will be active, this means that a global `window.optimizelyClientInstance` reference to the `optimizelyIntance` object passed by to the PDE constructor will be created. In case you want to turn this option off, create the optimizely adapter as follows:

--- a/packages/sui-pde/src/adapters/default.js
+++ b/packages/sui-pde/src/adapters/default.js
@@ -26,4 +26,8 @@ export default class DefaultAdapter {
   isFeatureEnabled() {
     return false
   }
+
+  getAllFeatureVariables() {
+    return {}
+  }
 }

--- a/packages/sui-pde/src/adapters/optimizely/index.js
+++ b/packages/sui-pde/src/adapters/optimizely/index.js
@@ -158,6 +158,21 @@ export default class OptimizelyAdapter {
     )
   }
 
+  /**
+   * Return all variables of a given feature
+   * @param {object} param
+   * @param {string} param.featureKey
+   * @parma {object=} param.attributes
+   * @returns {object}
+   */
+  getAllFeatureVariables({featureKey, attributes}) {
+    return this._optimizely.getAllFeatureVariables(
+      featureKey,
+      this._userId,
+      attributes
+    )
+  }
+
   updateConsents({hasUserConsents}) {
     this._hasUserConsents = hasUserConsents
     updateIntegrations({

--- a/packages/sui-pde/src/hooks/useFeature.js
+++ b/packages/sui-pde/src/hooks/useFeature.js
@@ -21,16 +21,18 @@ export default function useFeature(featureKey, attributes, queryString) {
     queryString
   })
 
-  if (forcedValue) {
-    return {isActive: forcedValue === 'on'}
-  }
-
-  let isActive
   try {
-    isActive = pde.isFeatureEnabled({featureKey, attributes})
+    const isActive = forcedValue
+      ? forcedValue === 'on'
+      : pde.isFeatureEnabled({featureKey, attributes})
+
+    const variables = pde.getAllFeatureVariables({
+      featureKey,
+      attributes
+    })
+
+    return {isActive, variables}
   } catch (error) {
-    console.error(error)
-    isActive = false
+    return {isActive: false, variables: {}}
   }
-  return {isActive}
 }

--- a/packages/sui-pde/src/pde.js
+++ b/packages/sui-pde/src/pde.js
@@ -49,6 +49,23 @@ export default class PDE {
    * @returns {boolean}
    */
   isFeatureEnabled({featureKey, attributes}) {
-    return this._adapter.isFeatureEnabled({featureKey, attributes})
+    return this._adapter.isFeatureEnabled({
+      featureKey,
+      attributes
+    })
+  }
+
+  /**
+   * Return all variables of a given feature
+   * @param {object} param
+   * @param {string} param.featureKey Feature flag key
+   * @parma {object=} param.attributes
+   * @returns {object}
+   */
+  getAllFeatureVariables({featureKey, attributes}) {
+    return this._adapter.getAllFeatureVariables({
+      featureKey,
+      attributes
+    })
   }
 }

--- a/packages/sui-pde/test/common/useFeatureSpec.js
+++ b/packages/sui-pde/test/common/useFeatureSpec.js
@@ -6,15 +6,20 @@ import useFeature from '../../src/hooks/useFeature'
 import sinon from 'sinon'
 
 describe('when pde context is set', () => {
+  const variables = {variable: 'variable'}
   let wrapper
   let isFeatureEnabled
+  let getAllFeatureVariables
   afterEach(cleanup)
 
   before(() => {
     isFeatureEnabled = sinon.stub().returns(true)
+    getAllFeatureVariables = sinon.stub().returns(variables)
     // eslint-disable-next-line react/prop-types
     wrapper = ({children}) => (
-      <PdeContext.Provider value={{pde: {isFeatureEnabled}}}>
+      <PdeContext.Provider
+        value={{pde: {isFeatureEnabled, getAllFeatureVariables}}}
+      >
         {children}
       </PdeContext.Provider>
     )
@@ -25,7 +30,22 @@ describe('when pde context is set', () => {
       () => useFeature('feature1', {attribute1: 'value'}),
       {wrapper}
     )
+
     expect(result.current.isActive).to.equal(true)
+    expect(isFeatureEnabled.called).to.equal(true)
+    expect(isFeatureEnabled.args[0][0]).to.deep.equal({
+      featureKey: 'feature1',
+      attributes: {attribute1: 'value'}
+    })
+  })
+
+  it('should return feature variables', () => {
+    const {result} = renderHook(
+      () => useFeature('feature1', {attribute1: 'value'}),
+      {wrapper}
+    )
+
+    expect(result.current.variables).to.be.deep.equal(variables)
     expect(isFeatureEnabled.called).to.equal(true)
     expect(isFeatureEnabled.args[0][0]).to.deep.equal({
       featureKey: 'feature1',


### PR DESCRIPTION
This PR adds feature variables support

## Description
- Add feature variables support using [getAllFeatureVariables](https://docs.developers.optimizely.com/full-stack/docs/get-all-feature-variables-javascript) method.
- Tests added

Variables can be added in feature flags from Optimizely dashboard as follows:
![Screenshot 2021-06-04 at 11 37 57](https://user-images.githubusercontent.com/6877967/120793399-220bbd80-c537-11eb-95da-ee26abf84478.png)


## Related Issue
None

## Example

Returns all feature variables for the specified feature flag. If not `variables` are being set the default value will be an empty object (`{}`)

```js
import {useFeature} from '@s-ui/pde'

const MyComponent = () => {
  const {isActive, variables} = useFeature('myFeatureKey') // variables = an object with all the feature variables

  return (
    <p>
      The feature 'myFeatureKey' is{' '}
      {isActive ? `active and price value is ${variables.price}` : 'inactive'}
    </p>
  )
}
```
