### PR TITLE
feat(packages/sui-bundler): improve sass build time

### DIFF
--- a/packages/sui-bundler/README.md
+++ b/packages/sui-bundler/README.md
@@ -311,7 +311,7 @@ You could tweak the performance of your bundle generation by using some flags pr
 
 `useExperimentalMinifier` (default: `false`): Use `esbuild-loader` to minify code instead using terser in order to boost build time and memory usage.
 
-`useExperimentalSCSSLoader` (default: `false`): Use [fast-sass-loader](https://github.com/yibn2008/fast-sass-loader) (currently a fork of it [super-sass-loader](https://github.com/andresz1/super-sass-loader)) instead of `sass-loader`
+`useExperimentalSCSSLoader` (default: `false`): Use [fast-sass-loader](https://github.com/yibn2008/fast-sass-loader) (currently a fork of it [super-sass-loader](https://github.com/andresz1/super-sass-loader)) instead of `sass-loader` (available in development only)
 
 ## Migrations
 

--- a/packages/sui-bundler/README.md
+++ b/packages/sui-bundler/README.md
@@ -311,7 +311,7 @@ You could tweak the performance of your bundle generation by using some flags pr
 
 `useExperimentalMinifier` (default: `false`): Use `esbuild-loader` to minify code instead using terser in order to boost build time and memory usage.
 
-`useExperimentalSCSSLoader` (default: `false`): Use `fast-sass-loader` instead of `sass-loader`
+`useExperimentalSCSSLoader` (default: `false`): Use [fast-sass-loader](https://github.com/yibn2008/fast-sass-loader) (currently a fork of it [super-sass-loader](https://github.com/andresz1/super-sass-loader)) instead of `sass-loader`
 
 ## Migrations
 

--- a/packages/sui-bundler/README.md
+++ b/packages/sui-bundler/README.md
@@ -124,6 +124,7 @@ sui-bundler lib umd/index.js -o lib/fancy -p http://my-cdn.com/fancy
 ```
 
 `sui-bundler lib` will add your package version as subfolder:
+
 - `-o lib/fancy` outputs to `./lib/fancy/0.0.0/`
 - `-p http://my-cdn.com/fancy` sets `http://my-cdn.com/fancy/0.0.0` as public path for chunks loading.
 - `-r http://my-cdn.com/fancy` sets `http://my-cdn.com/fancy` as public path for chunks loading, discarded the version subdirectory.
@@ -158,6 +159,7 @@ This tool works with zero configuration out the box but you could use some confi
       "alias": {
         "react": "preact"
       },
+      "measure": true,
       "offline": true,
       "targets": {
         "chrome": "41",
@@ -172,7 +174,8 @@ This tool works with zero configuration out the box but you could use some confi
       },
       "optimizations": {
         "splitFrameworkOnChunk": true,
-        "useExperimentalMinifier": true
+        "useExperimentalMinifier": true,
+        "useExperimentalSCSSLoader": true
       }
     }
   }
@@ -196,12 +199,16 @@ import {register, unregister} from '@s-ui/bundler/registerServiceWorker'
 register({
   first: () => window.alert('Content is cached for offline use.'),
   renovate: () => window.alert('New content is available; please refresh.')
-});
+})
 ```
 
 You should pass a handler in order to handle when content gets cached for the first time the content and another when you get new content and want to handle how to show a notification to the user in order to let him decide if he wants to refresh the page.
 
 If you want to remove your ServiceWorker, you need to use the method `unregister`, the same way you used the `register` method before.
+
+### Build time measurement
+
+Set `measure` to `true` if you want to check step by step build times.
 
 ### Only Caching
 
@@ -209,7 +216,7 @@ It's possible to create a service worker that caches all static resources
 
 There are two ways to activate the statics cache option:
 
-1. Create a `src/offline.html` page as mentioned in the [offline]( #Offline) section
+1. Create a `src/offline.html` page as mentioned in the [offline](#Offline) section
 2. Add the `staticsCacheOnly` option within the package.json like this:
 
 ```json
@@ -221,9 +228,11 @@ There are two ways to activate the statics cache option:
   }
 }
 ```
+
 > Statics will be cached but no offline page will be activated
 
 ## Externals Manifest
+
 If your are using an external CDN to store statics assets that are now managed by Webpack, like SVG or IMGs, you can create a manifest.json file in the root of your CDN (likehttps://spa-mock-statics.surge.sh/manifest.json`).
 
 If you define the `externals-manifest` key in the config pointing to this link, sui-bundler will replace any ocurrence of each key for the value
@@ -233,14 +242,19 @@ If in your CSS you have:
 ```css
 #app {
   color: blue;
-  background: url('https://spa-mock-statics.surge.sh/images/common/sprite-sheet/sprite-ma.png') no-repeat scroll;
+  background: url('https://spa-mock-statics.surge.sh/images/common/sprite-sheet/sprite-ma.png')
+    no-repeat scroll;
 }
 ```
 
 After compile you will get:
 
 ```css
-#app{color:#00f;background:url(https://spa-mock-statics.surge.sh/images/common/sprite-sheet/sprite-ma.72d1edb214.png) no-repeat scroll}
+#app {
+  color: #00f;
+  background: url(https://spa-mock-statics.surge.sh/images/common/sprite-sheet/sprite-ma.72d1edb214.png)
+    no-repeat scroll;
+}
 ```
 
 Or if in your JS you have:
@@ -287,7 +301,6 @@ Different values can be configured for development (`dev`) and production (`prod
 }
 ```
 
-
 Check all possible values accepted by webpack in the [devtool webpack docs](https://webpack.js.org/configuration/devtool/#devtool)
 
 ## Optimizations
@@ -297,6 +310,8 @@ You could tweak the performance of your bundle generation by using some flags pr
 `splitFrameworkOnChunk` (default: `false`): Separate in a chunk all the packages related to React. This gives you a separated static hashed file, as the version of React doesn't get often upgraded, and a benefit over HTTP2 connections are you're serving smaller files.
 
 `useExperimentalMinifier` (default: `false`): Use `esbuild-loader` to minify code instead using terser in order to boost build time and memory usage.
+
+`useExperimentalSCSSLoader` (default: `false`): Use `fast-sass-loader` instead of `sass-loader`
 
 ## Migrations
 

--- a/packages/sui-bundler/loaders/linkLoaderConfigBuilder.js
+++ b/packages/sui-bundler/loaders/linkLoaderConfigBuilder.js
@@ -1,9 +1,13 @@
 const fg = require('fast-glob')
 const path = require('path')
 
+const {config} = require('../shared')
 const log = require('../shared/log')
 const {defaultAlias} = require('../shared/resolve-alias')
 const createSassLinkImporter = require('./sassLinkImporter.js')
+
+const useExperimentalSCSSLoader =
+  config.optimizations && config.optimizations.useExperimentalSCSSLoader
 
 const diccFromAbsolutePaths = (paths, init = {}) =>
   paths.reduce((acc, pkg) => {
@@ -65,7 +69,9 @@ module.exports = ({config, packagesToLink, linkAll}) => {
    * and thus is sass binary which needs a special config for them.
    */
   const sassLoaderWithLinkImporter = {
-    loader: require.resolve('super-sass-loader'),
+    loader: useExperimentalSCSSLoader
+      ? require.resolve('super-sass-loader')
+      : require.resolve('sass-loader'),
     options: {
       sassOptions: {
         importer: createSassLinkImporter(entryPoints)

--- a/packages/sui-bundler/loaders/linkLoaderConfigBuilder.js
+++ b/packages/sui-bundler/loaders/linkLoaderConfigBuilder.js
@@ -65,9 +65,8 @@ module.exports = ({config, packagesToLink, linkAll}) => {
    * and thus is sass binary which needs a special config for them.
    */
   const sassLoaderWithLinkImporter = {
-    loader: require.resolve('fast-sass-loader'),
+    loader: require.resolve('super-sass-loader'),
     options: {
-      resolveURLs: false,
       sassOptions: {
         importer: createSassLinkImporter(entryPoints)
       }

--- a/packages/sui-bundler/loaders/linkLoaderConfigBuilder.js
+++ b/packages/sui-bundler/loaders/linkLoaderConfigBuilder.js
@@ -65,8 +65,9 @@ module.exports = ({config, packagesToLink, linkAll}) => {
    * and thus is sass binary which needs a special config for them.
    */
   const sassLoaderWithLinkImporter = {
-    loader: require.resolve('sass-loader'),
+    loader: require.resolve('fast-sass-loader'),
     options: {
+      resolveURLs: false,
       sassOptions: {
         importer: createSassLinkImporter(entryPoints)
       }

--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/bundler",
-  "version": "7.22.0-beta.6",
+  "version": "7.22.0",
   "description": "Config-free bundler for ES6 React apps.",
   "bin": {
     "sui-bundler": "./bin/sui-bundler.js"

--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/bundler",
-  "version": "7.22.0-beta.3",
+  "version": "7.22.0-beta.5",
   "description": "Config-free bundler for ES6 React apps.",
   "bin": {
     "sui-bundler": "./bin/sui-bundler.js"

--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/bundler",
-  "version": "7.22.0",
+  "version": "7.22.0-beta.1",
   "description": "Config-free bundler for ES6 React apps.",
   "bin": {
     "sui-bundler": "./bin/sui-bundler.js"
@@ -40,7 +40,8 @@
     "react-dev-utils": "11.0.4",
     "rimraf": "3.0.2",
     "sass": "1.32.13",
-    "fast-sass-loader": "2.0.0",
+    "sass-loader": "10.1.0",
+    "super-sass-loader": "0.1.0",
     "style-loader": "2.0.0",
     "terser-webpack-plugin": "4.2.2",
     "webpack": "4.46.0",

--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -40,7 +40,7 @@
     "react-dev-utils": "11.0.4",
     "rimraf": "3.0.2",
     "sass": "1.32.13",
-    "sass-loader": "10.1.0",
+    "fast-sass-loader": "2.0.0",
     "style-loader": "2.0.0",
     "terser-webpack-plugin": "4.2.2",
     "webpack": "4.46.0",

--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/bundler",
-  "version": "7.22.0-beta.5",
+  "version": "7.22.0-beta.6",
   "description": "Config-free bundler for ES6 React apps.",
   "bin": {
     "sui-bundler": "./bin/sui-bundler.js"
@@ -41,7 +41,7 @@
     "rimraf": "3.0.2",
     "sass": "1.32.13",
     "sass-loader": "10.1.0",
-    "super-sass-loader": "0.1.0",
+    "super-sass-loader": "0.1.1",
     "speed-measure-webpack-plugin": "1.5.0",
     "style-loader": "2.0.0",
     "terser-webpack-plugin": "4.2.2",

--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/bundler",
-  "version": "7.22.0-beta.1",
+  "version": "7.22.0-beta.3",
   "description": "Config-free bundler for ES6 React apps.",
   "bin": {
     "sui-bundler": "./bin/sui-bundler.js"
@@ -42,6 +42,7 @@
     "sass": "1.32.13",
     "sass-loader": "10.1.0",
     "super-sass-loader": "0.1.0",
+    "speed-measure-webpack-plugin": "1.5.0",
     "style-loader": "2.0.0",
     "terser-webpack-plugin": "4.2.2",
     "webpack": "4.46.0",

--- a/packages/sui-bundler/webpack.config.dev.js
+++ b/packages/sui-bundler/webpack.config.dev.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const webpack = require('webpack')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
+const SpeedMeasurePlugin = require('speed-measure-webpack-plugin')
 
 const definePlugin = require('./shared/define')
 const manifestLoaderRules = require('./shared/module-rules-manifest-loader')
@@ -8,6 +9,8 @@ const {aliasFromConfig, defaultAlias} = require('./shared/resolve-alias')
 
 const {envVars, MAIN_ENTRY_POINT, config, cleanList, when} = require('./shared')
 const {resolveLoader} = require('./shared/resolve-loader')
+
+const smp = new SpeedMeasurePlugin({disable: !process.env.MEASURE})
 
 const EXCLUDED_FOLDERS_REGEXP = new RegExp(
   `node_modules(?!${path.sep}@s-ui(${path.sep}svg|${path.sep}studio)(${path.sep}workbench)?${path.sep}src)`
@@ -102,4 +105,4 @@ const webpackConfig = {
     config.sourcemaps && config.sourcemaps.dev ? config.sourcemaps.dev : 'none'
 }
 
-module.exports = webpackConfig
+module.exports = smp.wrap(webpackConfig)

--- a/packages/sui-bundler/webpack.config.dev.js
+++ b/packages/sui-bundler/webpack.config.dev.js
@@ -2,19 +2,19 @@ const path = require('path')
 const webpack = require('webpack')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const SpeedMeasurePlugin = require('speed-measure-webpack-plugin')
-
 const definePlugin = require('./shared/define')
 const manifestLoaderRules = require('./shared/module-rules-manifest-loader')
 const {aliasFromConfig, defaultAlias} = require('./shared/resolve-alias')
-
 const {envVars, MAIN_ENTRY_POINT, config, cleanList, when} = require('./shared')
 const {resolveLoader} = require('./shared/resolve-loader')
-
-const smp = new SpeedMeasurePlugin({disable: !process.env.MEASURE})
 
 const EXCLUDED_FOLDERS_REGEXP = new RegExp(
   `node_modules(?!${path.sep}@s-ui(${path.sep}svg|${path.sep}studio)(${path.sep}workbench)?${path.sep}src)`
 )
+const useExperimentalSCSSLoader =
+  config.optimizations && config.optimizations.useExperimentalSCSSLoader
+
+const smp = new SpeedMeasurePlugin({disable: !config.measure})
 
 const webpackConfig = {
   mode: 'development',
@@ -93,7 +93,9 @@ const webpackConfig = {
               }
             }
           },
-          require.resolve('super-sass-loader')
+          useExperimentalSCSSLoader
+            ? require.resolve('super-sass-loader')
+            : require.resolve('sass-loader')
         ])
       },
       when(config['externals-manifest'], () =>

--- a/packages/sui-bundler/webpack.config.dev.js
+++ b/packages/sui-bundler/webpack.config.dev.js
@@ -90,7 +90,7 @@ const webpackConfig = {
               }
             }
           },
-          require.resolve('sass-loader')
+          require.resolve('fast-sass-loader')
         ])
       },
       when(config['externals-manifest'], () =>

--- a/packages/sui-bundler/webpack.config.dev.js
+++ b/packages/sui-bundler/webpack.config.dev.js
@@ -14,7 +14,7 @@ const EXCLUDED_FOLDERS_REGEXP = new RegExp(
 const useExperimentalSCSSLoader =
   config.optimizations && config.optimizations.useExperimentalSCSSLoader
 
-const smp = new SpeedMeasurePlugin({disable: !config.measure})
+const smp = new SpeedMeasurePlugin()
 
 const webpackConfig = {
   mode: 'development',
@@ -107,4 +107,4 @@ const webpackConfig = {
     config.sourcemaps && config.sourcemaps.dev ? config.sourcemaps.dev : 'none'
 }
 
-module.exports = smp.wrap(webpackConfig)
+module.exports = config.measure ? smp.wrap(webpackConfig) : webpackConfig

--- a/packages/sui-bundler/webpack.config.dev.js
+++ b/packages/sui-bundler/webpack.config.dev.js
@@ -90,7 +90,7 @@ const webpackConfig = {
               }
             }
           },
-          require.resolve('fast-sass-loader')
+          require.resolve('super-sass-loader')
         ])
       },
       when(config['externals-manifest'], () =>

--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -124,7 +124,7 @@ module.exports = {
               }
             }
           },
-          require.resolve('fast-sass-loader')
+          require.resolve('super-sass-loader')
         ])
       },
       when(config['externals-manifest'], () =>

--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -7,9 +7,6 @@ const {WebpackManifestPlugin} = require('webpack-manifest-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const InlineChunkHtmlPlugin = require('react-dev-utils/InlineChunkHtmlPlugin')
 const SpeedMeasurePlugin = require('speed-measure-webpack-plugin')
-
-const smp = new SpeedMeasurePlugin({disable: !process.env.MEASURE})
-
 const {
   when,
   cleanList,
@@ -40,6 +37,11 @@ const filename = config.onlyHash
 const cssFileName = config.onlyHash
   ? '[contenthash:8].css'
   : '[name].[contenthash:8].css'
+
+const useExperimentalSCSSLoader =
+  config.optimizations && config.optimizations.useExperimentalSCSSLoader
+
+const smp = new SpeedMeasurePlugin({disable: !process.env.MEASURE})
 
 const webpackConfig = {
   devtool: sourceMap,
@@ -127,7 +129,9 @@ const webpackConfig = {
               }
             }
           },
-          require.resolve('super-sass-loader')
+          useExperimentalSCSSLoader
+            ? require.resolve('super-sass-loader')
+            : require.resolve('sass-loader')
         ])
       },
       when(config['externals-manifest'], () =>

--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -124,7 +124,7 @@ module.exports = {
               }
             }
           },
-          require.resolve('sass-loader')
+          require.resolve('fast-sass-loader')
         ])
       },
       when(config['externals-manifest'], () =>

--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -41,7 +41,7 @@ const cssFileName = config.onlyHash
 const useExperimentalSCSSLoader =
   config.optimizations && config.optimizations.useExperimentalSCSSLoader
 
-const smp = new SpeedMeasurePlugin({disable: !process.env.MEASURE})
+const smp = new SpeedMeasurePlugin()
 
 const webpackConfig = {
   devtool: sourceMap,
@@ -147,4 +147,4 @@ const webpackConfig = {
   }
 }
 
-module.exports = smp.wrap(webpackConfig)
+module.exports = config.measure ? smp.wrap(webpackConfig) : webpackConfig

--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -6,6 +6,9 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const {WebpackManifestPlugin} = require('webpack-manifest-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const InlineChunkHtmlPlugin = require('react-dev-utils/InlineChunkHtmlPlugin')
+const SpeedMeasurePlugin = require('speed-measure-webpack-plugin')
+
+const smp = new SpeedMeasurePlugin({disable: !process.env.MEASURE})
 
 const {
   when,
@@ -38,7 +41,7 @@ const cssFileName = config.onlyHash
   ? '[contenthash:8].css'
   : '[name].[contenthash:8].css'
 
-module.exports = {
+const webpackConfig = {
   devtool: sourceMap,
   mode: 'production',
   context: path.resolve(process.cwd(), 'src'),
@@ -139,3 +142,5 @@ module.exports = {
     tls: 'empty'
   }
 }
+
+module.exports = smp.wrap(webpackConfig)

--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -38,9 +38,6 @@ const cssFileName = config.onlyHash
   ? '[contenthash:8].css'
   : '[name].[contenthash:8].css'
 
-const useExperimentalSCSSLoader =
-  config.optimizations && config.optimizations.useExperimentalSCSSLoader
-
 const smp = new SpeedMeasurePlugin()
 
 const webpackConfig = {
@@ -129,9 +126,7 @@ const webpackConfig = {
               }
             }
           },
-          useExperimentalSCSSLoader
-            ? require.resolve('super-sass-loader')
-            : require.resolve('sass-loader')
+          require.resolve('sass-loader')
         ])
       },
       when(config['externals-manifest'], () =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR:

- Tries to improve sass build time using an experimental loader based on [fast-sass-loader](https://github.com/yibn2008/fast-sass-loader) named [super-sass-loader](https://github.com/andresz1/super-sass-loader). I forked it and published a version with changes needed to make it work properly with our project (I wanted to test and iterate it fast, if it works as expected we can open a PR to the previous repo and use it instead). Use `useExperimentalSCSSLoader` to try it out (by default disabled)

Results using Milanuncios web app:

**Before**

![image (1)](https://user-images.githubusercontent.com/6877967/121677363-0dd73b80-cab6-11eb-8b7d-4fa0477ff5db.png)

**After**

![Screenshot 2021-06-11 at 12 19 08](https://user-images.githubusercontent.com/6877967/121677389-13348600-cab6-11eb-8956-ef3ac592a831.png)

- Adds a way to measure build times. Use `measure` to try it out (by default disabled)

## Related Issue
None

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
