### PR TITLE
feat(packages/sui-critical-css): Use chromium only and add UA to critical-css service

### DIFF
--- a/packages/sui-critical-css/package.json
+++ b/packages/sui-critical-css/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "clean-css": "5.1.2",
-    "playwright": "1.11.1"
+    "playwright-chromium": "1.12.2"
   },
   "peerDependencies": {
     "path-to-regexp": "*"

--- a/packages/sui-critical-css/src/config.js
+++ b/packages/sui-critical-css/src/config.js
@@ -1,5 +1,3 @@
-import pkg from '../package.json'
-
 export const blockedResourceTypes = [
   'beacon',
   'csp_report',
@@ -13,7 +11,7 @@ export const blockedResourceTypes = [
 
 const GOOGLE_BOT_UA =
   '(compatible; Googlebot/2.1; +http://www.google.com/bot.html)'
-const CRITICAL_UA = `CriticalCSS/${pkg.version}`
+const CRITICAL_UA = `CriticalCSS`
 
 export const devices = {
   m: {

--- a/packages/sui-critical-css/src/config.js
+++ b/packages/sui-critical-css/src/config.js
@@ -1,3 +1,5 @@
+import pkg from '../package.json'
+
 export const blockedResourceTypes = [
   'beacon',
   'csp_report',
@@ -9,22 +11,23 @@ export const blockedResourceTypes = [
   'texttrack'
 ]
 
+const GOOGLE_BOT_UA =
+  '(compatible; Googlebot/2.1; +http://www.google.com/bot.html)'
+const CRITICAL_UA = `CriticalCSS/${pkg.version}`
+
 export const devices = {
   m: {
-    userAgent:
-      'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.109 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+    userAgent: `Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.109 Mobile Safari/537.36 ${GOOGLE_BOT_UA} ${CRITICAL_UA}`,
     width: 360,
     height: 640
   },
   t: {
-    userAgent:
-      'Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+    userAgent: `Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1 ${GOOGLE_BOT_UA}`,
     width: 768,
     height: 1024
   },
   d: {
-    userAgent:
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.109 Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+    userAgent: `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.109 Safari/537.36 ${GOOGLE_BOT_UA} ${CRITICAL_UA}`,
     width: 1024,
     height: 768
   }

--- a/packages/sui-critical-css/src/extract-from-url.js
+++ b/packages/sui-critical-css/src/extract-from-url.js
@@ -1,4 +1,4 @@
-import {chromium} from 'playwright'
+import {chromium} from 'playwright-chromium'
 import CleanCSS from 'clean-css'
 import {blockedResourceTypes, skippedResources} from './config.js'
 


### PR DESCRIPTION
- [x] Use `playwright-chromium` to avoid long installations with all browsers.
- [x] Add `CriticalCSS` to UserAgent. This will help us to identify this service and also to activate TCF when doing critical-css.