### PR TITLE
feat(packages/sui-test): enable or disable logs in ci for browser test

### DIFF
--- a/packages/sui-test/README.md
+++ b/packages/sui-test/README.md
@@ -205,9 +205,15 @@ If defined, any error on your tests will create a screenshot of that moment in t
   - `esmOverride`: Boolean flag (defaults to `false`), enable patching the Node's CJS loader when facing ESM errors, like `ERR_REQUIRE_ESM` in `node > v12.12.0`. 
   - `useLibDir`: disabled by default. Prevents to compile lib folders on mocha runner if set to false
 
+- `client`: Config for `@s-ui/test browser` binary:
+  - `captureConsole`: [default: `true`] Capture all console output and pipe it to the terminal. Only customizable for CI
+
 ```json
 "config": {
   "sui-test": {
+    "client": {
+      "captureConsole": false
+    },
     "server": {
       "forceTranspilation": ["@adv-ui/vendor-by-consents-loader"],
       "esmOverride": true

--- a/packages/sui-test/bin/karma/index.js
+++ b/packages/sui-test/bin/karma/index.js
@@ -1,6 +1,7 @@
 // https://github.com/developit/karmatic/blob/master/src/index.js
 const {Server} = require('karma')
 const config = require('./config')
+const {clientConfig} = require('../../src/config')
 const CWD = process.cwd()
 
 module.exports = ({ci, pattern, ignorePattern, srcPattern, timeout, watch}) => {
@@ -21,6 +22,8 @@ module.exports = ({ci, pattern, ignorePattern, srcPattern, timeout, watch}) => {
         {type: 'text-summary'}
       ]
     }
+
+    config.captureConsole = Boolean(clientConfig.captureConsole)
   }
 
   if (watch) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
To avoid "logs noise" in CI, I propose enabling a karma option for CI to make `captureConsole` customizable.
Also, I hope it will improve a little bit memory usage in CI