### PR TITLE
upgrade super-sass-loader version to add use support

### DIFF
--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -41,7 +41,7 @@
     "rimraf": "3.0.2",
     "sass": "1.35.1",
     "sass-loader": "10.1.0",
-    "super-sass-loader": "0.1.1",
+    "super-sass-loader": "0.1",
     "speed-measure-webpack-plugin": "1.5.0",
     "style-loader": "2.0.0",
     "terser-webpack-plugin": "4.2.2",


### PR DESCRIPTION
## Description
This PR upgrade super-sass-loader version to add `@use` support (see [changes](https://github.com/andresz1/super-sass-loader/commit/8b83147214459d53df739809e32f06b74ebb1216)). Now `@uses` are cached and appended at the top of the merged scss file

## Related Issue
`@use` wasn't working as expected with experimental scss loader

## Example
None