### PR TITLE
feat(packages/sui-bundler): add shorthand to link packages

### DIFF
--- a/packages/sui-bundler/README.md
+++ b/packages/sui-bundler/README.md
@@ -81,11 +81,23 @@ To link more than one package at time, use as many times as desired the argument
 $ sui-bundler dev --link-package=/absolute_path/to/npm_package --link-package=/absolute_path2/to/npm_package
 ```
 
+You can also use `-l` as a shorthand to link a package.
+
+```
+$ sui-bundler dev -l /absolute_path/to/npm_package -l /absolute_path2/to/npm_package
+```
+
 If you want to link all the packages inside a monorepo-multipackage. Use the flag `--link-all` pointing to the folder where each package lives.
 For example, if you want to link all the components in a Studio, the command should be:
 
 ```
 $ sui-bundler dev --link-all ../frontend-ma--uilib-components/components
+```
+
+You can use `-L` as a shorthand to link all packages.
+
+```
+$ sui-bundler dev -L ../frontend-ma--uilib-components/components
 ```
 
 And of course you can combine `link-all` and `link-package` flags

--- a/packages/sui-bundler/bin/sui-bundler-build.js
+++ b/packages/sui-bundler/bin/sui-bundler-build.js
@@ -19,7 +19,7 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 program
   .option('-C, --clean', 'Remove public folder before create a new one')
   .option(
-    '--link-package [package]',
+    '-l, --link-package [package]',
     'Replace each occurrence of this package with an absolute path to this folder',
     (v, m) => {
       m.push(v)

--- a/packages/sui-bundler/bin/sui-bundler-dev.js
+++ b/packages/sui-bundler/bin/sui-bundler-dev.js
@@ -42,12 +42,23 @@ if (!module.parent) {
       },
       []
     )
+    .option(
+      '--link-multiple-packages [packages]',
+      'Replace each comma-separated given package with an absolute path to this folder',
+      (v, m) => {
+        return m.concat(v.split(','))
+      },
+      []
+    )
     .on('--help', () => {
       console.log('  Examples:')
       console.log('')
       console.log('    $ sui-bundler dev')
       console.log('    $ sui-bundler dev --context /my/app/folder')
       console.log('    $ sui-bundler dev --link-package /my/domain/folder')
+      console.log(
+        '    $ sui-bundler dev --link-multiple-packages /my/domain/folder,/my/literals/folder'
+      )
       console.log('')
     })
     .parse(process.argv)
@@ -60,7 +71,8 @@ process.noDeprecation = true
 
 const start = async ({
   config = webpackConfig,
-  packagesToLink = program.linkPackage || []
+  singlePackagesToLink = program.linkPackage || [],
+  multiplePackagesToLink = program.linkMultiplePackages || []
 } = {}) => {
   clearConsole()
   // Warn and crash if required files are missing
@@ -78,6 +90,8 @@ const start = async ({
   const protocol = process.env.HTTPS === 'true' ? 'https' : 'http'
   const port = await choosePort(HOST, DEFAULT_PORT)
   const urls = prepareUrls(protocol, HOST, port)
+  // bundle all packages given by arguments
+  const packagesToLink = singlePackagesToLink.concat(multiplePackagesToLink)
   const nextConfig = linkLoaderConfigBuilder({
     config,
     linkAll: program.linkAll,

--- a/packages/sui-bundler/bin/sui-bundler-dev.js
+++ b/packages/sui-bundler/bin/sui-bundler-dev.js
@@ -30,23 +30,15 @@ if (!module.parent) {
   program
     .option('-c, --context [folder]', 'Context folder (cwd by default)')
     .option(
-      '--link-all [monorepo]',
+      '-L, --link-all [monorepo]',
       'Link all packages inside of monorepo multipackage'
     )
     .option(
-      '--link-package [package]',
+      '-l, --link-package [package]',
       'Replace each occurrence of this package with an absolute path to this folder',
       (v, m) => {
         m.push(v)
         return m
-      },
-      []
-    )
-    .option(
-      '--link-multiple-packages [packages]',
-      'Replace each comma-separated given package with an absolute path to this folder',
-      (v, m) => {
-        return m.concat(v.split(','))
       },
       []
     )
@@ -56,9 +48,6 @@ if (!module.parent) {
       console.log('    $ sui-bundler dev')
       console.log('    $ sui-bundler dev --context /my/app/folder')
       console.log('    $ sui-bundler dev --link-package /my/domain/folder')
-      console.log(
-        '    $ sui-bundler dev --link-multiple-packages /my/domain/folder,/my/literals/folder'
-      )
       console.log('')
     })
     .parse(process.argv)
@@ -71,8 +60,7 @@ process.noDeprecation = true
 
 const start = async ({
   config = webpackConfig,
-  singlePackagesToLink = program.linkPackage || [],
-  multiplePackagesToLink = program.linkMultiplePackages || []
+  packagesToLink = program.linkPackage || []
 } = {}) => {
   clearConsole()
   // Warn and crash if required files are missing
@@ -90,8 +78,6 @@ const start = async ({
   const protocol = process.env.HTTPS === 'true' ? 'https' : 'http'
   const port = await choosePort(HOST, DEFAULT_PORT)
   const urls = prepareUrls(protocol, HOST, port)
-  // bundle all packages given by arguments
-  const packagesToLink = singlePackagesToLink.concat(multiplePackagesToLink)
   const nextConfig = linkLoaderConfigBuilder({
     config,
     linkAll: program.linkAll,


### PR DESCRIPTION
## Edited Description
Added shorthands for `--link-package` and `--link-all`.  `-l` and `-L` respectively.

## Original Description
Added --link-multiple-packages option for the command line.

This allows to pass multiple comma-separated directories while running _dev_ script instead of using `--link-package` option for each one. 

E.g.: `sui-bundler dev --link-multiple-packages=/my/domain,/my/components/header`


## Related Issue
None

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

![477519b32a0f9f05a38b938f24ac63e2](https://user-images.githubusercontent.com/22194171/125811747-bb8571f9-7eca-4772-a0a4-6ded7f17bb50.gif)

