### PR TITLE
feat(Root): Use single @s-ui/test across packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@s-ui/mono": "2",
     "@s-ui/precommit": "2",
     "@s-ui/react-context": "1",
-    "@s-ui/test": "4",
+    "@s-ui/test": "5",
     "chai": "4.2.0",
     "husky": "4.3.0",
     "react": "17",

--- a/packages/sui-consents/package.json
+++ b/packages/sui-consents/package.json
@@ -13,7 +13,6 @@
   "license": "MIT",
   "devDependencies": {
     "@s-ui/react-context": "1",
-    "@s-ui/test": "4",
     "@testing-library/react": "11.2.5",
     "react": "17",
     "react-dom": "17"

--- a/packages/sui-mockmock/package.json
+++ b/packages/sui-mockmock/package.json
@@ -22,7 +22,6 @@
     "sinon": "10.0.0"
   },
   "devDependencies": {
-    "@s-ui/test": "4",
     "axios": "0.21.1"
   },
   "license": "MIT",

--- a/packages/sui-pde/package.json
+++ b/packages/sui-pde/package.json
@@ -23,7 +23,6 @@
     "react": "16 || 17"
   },
   "devDependencies": {
-    "@s-ui/test": "4",
     "@testing-library/react": "11.2.3",
     "@testing-library/react-hooks": "4.0.1",
     "react": "17",

--- a/packages/sui-pde/test/browser/browserSpec.js
+++ b/packages/sui-pde/test/browser/browserSpec.js
@@ -1,1 +1,0 @@
-import '../common'

--- a/packages/sui-react-head/package.json
+++ b/packages/sui-react-head/package.json
@@ -15,7 +15,6 @@
     "react-head": "3.4.0"
   },
   "devDependencies": {
-    "@s-ui/test": "4",
     "@testing-library/react": "11.1.0",
     "react": "17",
     "react-dom": "17"

--- a/packages/sui-react-router/package.json
+++ b/packages/sui-react-router/package.json
@@ -25,7 +25,6 @@
     "hoist-non-react-statics": "3.3.2"
   },
   "devDependencies": {
-    "@s-ui/test": "4",
     "@testing-library/react": "11.1.0",
     "react": "17",
     "react-dom": "17",

--- a/packages/sui-ssr/package.json
+++ b/packages/sui-ssr/package.json
@@ -42,8 +42,5 @@
     "parse5": "6.0.0",
     "rimraf": "3.0.0",
     "ua-parser-js": "0.7.20"
-  },
-  "devDependencies": {
-    "@s-ui/test": "4"
   }
 }


### PR DESCRIPTION
Instead of installing different @s-ui/test versions, we use only the one from the root.
Still this makes specific scripts work on every workspace.