### PR TITLE
feat(packages/sui-pde): track feature flags and feature tests

### DIFF
--- a/packages/sui-pde/README.md
+++ b/packages/sui-pde/README.md
@@ -68,7 +68,7 @@ Given experiment `experimentX` with 2 variations `variationA` and `variationB` r
 
 ⚠️ If the user did not consent to or if optimizely decides that the user will not be part of the experiment of something goes wrong, `useExperiment` will return as variation value `null`
 
-⚠️ The `useExperiment` hook will send call a global window.analytics.track method with `Experiment Viewed` as event name with the experiment properties so you are able to replicate the experiment in your analytics tool
+⚠️ The `useExperiment` hook will call a global window.analytics.track method with `Experiment Viewed` as event name with the experiment properties so you are able to replicate the experiment in your analytics tool
 
 ```js
 import {useExperiment} from '@s-ui/pde'
@@ -150,6 +150,7 @@ It's possible to force a variation for our experiment in the browser. For exampl
 ### Feature Flags and Feature Tests
 
 ⚠️ user consent do apply to feature flags only when used as feature test
+⚠️ The `useFeature` hook will call a global window.analytics.track method with `Experiment Viewed` as event name with the experiment properties so you are able to replicate the experiment in your analytics tool. For each linked experiment (feature tests), an extra `Experiment Viewed` event will be send.
 
 ```js
 import {useFeature} from '@s-ui/pde'
@@ -192,7 +193,7 @@ const optimizelyAdapter = new OptimizelyAdapter({
 })
 ```
 
-#### Attributes
+#### Attributes
 
 In order to pass by attributes, you'll able to do so by adding the second argument as `attributes` when using the useFeature hook. Something like this:
 

--- a/packages/sui-pde/src/adapters/optimizely/index.js
+++ b/packages/sui-pde/src/adapters/optimizely/index.js
@@ -151,7 +151,7 @@ export default class OptimizelyAdapter {
 
     // check for user consents only if featureKey is a feature that belongs to a feature test
     if (linkedExperimentNames.length > 0 && !this._hasUserConsents) {
-      return false
+      return {isActive: false, linkedExperiments: []}
     }
 
     return {

--- a/packages/sui-pde/src/adapters/optimizely/index.js
+++ b/packages/sui-pde/src/adapters/optimizely/index.js
@@ -87,12 +87,16 @@ export default class OptimizelyAdapter {
   getInitialData() {
     let datafile = null
     try {
-      datafile = this._optimizely.getOptimizelyConfig().getDatafile()
+      datafile = this.getOptimizelyConfig().getDatafile()
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error(error)
     }
     return datafile
+  }
+
+  getOptimizelyConfig() {
+    return this._optimizely.getOptimizelyConfig()
   }
 
   /**
@@ -138,24 +142,26 @@ export default class OptimizelyAdapter {
    * @param {object} param
    * @param {string} param.featureKey
    * @parma {object=} param.attributes
-   * @returns {boolean}
+   * @returns {isActive: boolean, linkedExperiments: number[]}
    */
   isFeatureEnabled({featureKey, attributes}) {
+    const linkedExperimentNames = Object.keys(
+      this.getOptimizelyConfig().featuresMap[featureKey].experimentsMap
+    )
+
     // check for user consents only if featureKey is a feature that belongs to a feature test
-    if (
-      this._optimizely.projectConfigManager.getConfig().featureKeyMap[
-        featureKey
-      ].experimentIds.length > 0 &&
-      !this._hasUserConsents
-    ) {
+    if (linkedExperimentNames.length > 0 && !this._hasUserConsents) {
       return false
     }
 
-    return this._optimizely.isFeatureEnabled(
-      featureKey,
-      this._userId,
-      attributes
-    )
+    return {
+      isActive: this._optimizely.isFeatureEnabled(
+        featureKey,
+        this._userId,
+        attributes
+      ),
+      linkedExperiments: linkedExperimentNames
+    }
   }
 
   /**

--- a/packages/sui-pde/src/hooks/useFeature.js
+++ b/packages/sui-pde/src/hooks/useFeature.js
@@ -2,6 +2,9 @@ import {useContext} from 'react'
 import PdeContext from '../contexts/PdeContext'
 import {getPlatformStrategy} from './platformStrategies'
 
+const VARIATION_NAME_ON = 'On State'
+const VARIATION_NAME_OFF = 'Off State'
+
 /**
  * track feature flag's own Experiment Viewed event
  * @param {object} param
@@ -14,7 +17,7 @@ const trackFeatureFlagViewed = ({
   trackExperimentViewed,
   featureKey
 }) => {
-  const variationName = isActive ? 'On State' : 'Off State'
+  const variationName = isActive ? VARIATION_NAME_ON : VARIATION_NAME_OFF
   trackExperimentViewed({experimentName: featureKey, variationName})
 }
 

--- a/packages/sui-pde/src/hooks/useFeature.js
+++ b/packages/sui-pde/src/hooks/useFeature.js
@@ -32,6 +32,7 @@ const trackLinkedExperimentsViewed = ({
   getExperimentVariation,
   attributes
 }) => {
+  if (!linkedExperiments) return
   linkedExperiments.forEach(experimentName => {
     const variationName = getExperimentVariation({
       name: experimentName,
@@ -61,23 +62,30 @@ export default function useFeature(featureKey, attributes, queryString) {
   })
 
   try {
-    const {isActive, linkedExperiments} = forcedValue
-      ? forcedValue === 'on'
-      : pde.isFeatureEnabled({featureKey, attributes})
+    if (forcedValue) {
+      return {isActive: forcedValue === 'on', linkedExperiments: []}
+    }
+    const {isActive, linkedExperiments} = pde.isFeatureEnabled({
+      featureKey,
+      attributes
+    })
 
     const variables = pde.getAllFeatureVariables({
       featureKey,
       attributes
     })
 
-    trackFeatureFlagViewed({isActive, track: strategy.track, featureKey})
+    trackFeatureFlagViewed({
+      isActive,
+      trackExperimentViewed: strategy.trackExperiment,
+      featureKey
+    })
     trackLinkedExperimentsViewed({
       linkedExperiments,
-      trackExperiment: strategy.track,
+      trackExperimentViewed: strategy.trackExperiment,
       getExperimentVariation: pde.getVariation,
       attributes
     })
-
     return {isActive, variables}
   } catch (error) {
     console.error(error)

--- a/packages/sui-pde/src/hooks/useFeature.js
+++ b/packages/sui-pde/src/hooks/useFeature.js
@@ -65,6 +65,7 @@ export default function useFeature(featureKey, attributes, queryString) {
     if (forcedValue) {
       return {isActive: forcedValue === 'on', linkedExperiments: []}
     }
+
     const {isActive, linkedExperiments} = pde.isFeatureEnabled({
       featureKey,
       attributes

--- a/packages/sui-pde/src/hooks/useFeature.js
+++ b/packages/sui-pde/src/hooks/useFeature.js
@@ -28,17 +28,20 @@ const trackFeatureFlagViewed = ({
  * @param {function} trackExperimentViewed
  * @param {function} getExperimentVariation gets user variation linked to experiment
  * @param {object} attributes user attributes to take into account for its segmentation
+ * @param {object} pde
  */
 const trackLinkedExperimentsViewed = ({
   linkedExperiments,
   trackExperimentViewed,
   getExperimentVariation,
-  attributes
+  attributes,
+  pde
 }) => {
   if (!linkedExperiments) return
   linkedExperiments.forEach(experimentName => {
     const variationName = getExperimentVariation({
-      name: experimentName,
+      experimentName,
+      pde,
       attributes
     })
     trackExperimentViewed({variationName, experimentName})
@@ -87,7 +90,8 @@ export default function useFeature(featureKey, attributes, queryString) {
     trackLinkedExperimentsViewed({
       linkedExperiments,
       trackExperimentViewed: strategy.trackExperiment,
-      getExperimentVariation: pde.getVariation,
+      getExperimentVariation: strategy.getVariation,
+      pde,
       attributes
     })
     return {isActive, variables}

--- a/packages/sui-pde/test/common/pdeSpec.js
+++ b/packages/sui-pde/test/common/pdeSpec.js
@@ -18,18 +18,18 @@ describe('@s-ui pde', () => {
       getEnabledFeatures: () => ['a', 'b'],
       isFeatureEnabled: sinon.stub().returns(true),
       getVariation: sinon.stub().returns('variationB'),
-      projectConfigManager: {
-        getConfig: () => ({
-          featureKeyMap: {
-            featureUsedInTest: {
-              experimentIds: ['1234']
-            },
-            featureNotUsedInTest: {
-              experimentIds: []
+      getOptimizelyConfig: () => ({
+        featuresMap: {
+          featureUsedInTest: {
+            experimentsMap: {
+              '1234': {}
             }
+          },
+          featureNotUsedInTest: {
+            experimentsMap: {}
           }
-        })
-      }
+        }
+      })
     }
     optimizelyAdapter = new OptimizelyAdapter({
       optimizely: optimizelyInstanceStub,
@@ -67,8 +67,11 @@ describe('@s-ui pde', () => {
       adapter: optimizelyAdapter,
       hasUserConsents: false
     })
-    const enabled = pde.isFeatureEnabled({featureKey: 'featureUsedInTest'})
-    expect(enabled).to.equal(false)
+    const {isActive, linkedExperiments} = pde.isFeatureEnabled({
+      featureKey: 'featureUsedInTest'
+    })
+    expect(isActive).to.equal(false)
+    expect(linkedExperiments).to.deep.equal([])
     expect(optimizelyInstanceStub.isFeatureEnabled.called).to.equal(false)
   })
 
@@ -77,8 +80,11 @@ describe('@s-ui pde', () => {
       adapter: optimizelyAdapter,
       hasUserConsents: true
     })
-    const enabled = pde.isFeatureEnabled({featureKey: 'featureUsedInTest'})
-    expect(enabled).to.equal(true)
+    const {isActive, linkedExperiments} = pde.isFeatureEnabled({
+      featureKey: 'featureUsedInTest'
+    })
+    expect(isActive).to.equal(true)
+    expect(linkedExperiments).to.deep.equal(['1234'])
     expect(optimizelyInstanceStub.isFeatureEnabled.called).to.equal(true)
     expect(optimizelyInstanceStub.isFeatureEnabled.args[0][0]).to.equal(
       'featureUsedInTest'

--- a/packages/sui-pde/test/common/useFeatureSpec.js
+++ b/packages/sui-pde/test/common/useFeatureSpec.js
@@ -20,11 +20,6 @@ describe('when pde context is set', () => {
         .returns({isActive: true, linkedExperiments: []})
       getAllFeatureVariables = sinon.stub().returns(variables)
 
-      window.analytics = {
-        ready: cb => cb(),
-        track: sinon.spy()
-      }
-
       // eslint-disable-next-line react/prop-types
       wrapper = ({children}) => (
         <PdeContext.Provider
@@ -33,10 +28,6 @@ describe('when pde context is set', () => {
           {children}
         </PdeContext.Provider>
       )
-    })
-
-    after(() => {
-      delete window.analytics
     })
 
     it('should check if a feature is enabled', () => {
@@ -88,14 +79,118 @@ describe('when pde context is set', () => {
         expect(result.current.isActive).to.equal(false)
       })
     })
-
-    // TODO: it should track experiment viewed for the feature flag
-    // TODO: check On state
-    // TODO: check Off state
-    // TODO: check doble envío
   })
 
-  describe('when its a feature test, so an experiment is linked', () => {
+  describe.client(
+    'when checking if a feature flag is active or not in browser',
+    () => {
+      let isFeatureEnabled
+      let getAllFeatureVariables
+      let getVariation
+
+      describe.client('when a feature flag is active', () => {
+        beforeEach(() => {
+          isFeatureEnabled = sinon.stub().returns({
+            isActive: true,
+            linkedExperiments: []
+          })
+          getAllFeatureVariables = sinon.stub().returns(variables)
+          getVariation = sinon.stub().returns('variation1')
+
+          window.analytics = {
+            ready: cb => cb(),
+            track: sinon.spy()
+          }
+
+          // eslint-disable-next-line react/prop-types
+          wrapper = ({children}) => (
+            <PdeContext.Provider
+              value={{
+                pde: {isFeatureEnabled, getAllFeatureVariables, getVariation}
+              }}
+            >
+              {children}
+            </PdeContext.Provider>
+          )
+        })
+
+        afterEach(() => {
+          delete window.analytics
+        })
+
+        it('should send the on state experiment viewed', () => {
+          renderHook(() => useFeature('activeFeatureFlagKey'), {
+            wrapper
+          })
+          expect(window.analytics.track.args[0][0]).to.equal(
+            'Experiment Viewed'
+          )
+          expect(window.analytics.track.args[0][1]).to.deep.equal({
+            experimentName: 'activeFeatureFlagKey',
+            variationName: 'On State'
+          })
+        })
+
+        describe.client('when a feature is seen twice', () => {
+          it('should only track one experiment viewed event', () => {
+            renderHook(() => useFeature('repeatedFeatureFlagKey'), {
+              wrapper
+            })
+            renderHook(() => useFeature('repeatedFeatureFlagKey'), {
+              wrapper
+            })
+            expect(window.analytics.track.args.length).to.equal(1)
+          })
+        })
+      })
+
+      describe.client('when a feature flag is deactivated', () => {
+        beforeEach(() => {
+          isFeatureEnabled = sinon.stub().returns({
+            isActive: false,
+            linkedExperiments: []
+          })
+          getAllFeatureVariables = sinon.stub().returns(variables)
+          getVariation = sinon.stub().returns('variation1')
+
+          window.analytics = {
+            ready: cb => cb(),
+            track: sinon.spy()
+          }
+
+          // eslint-disable-next-line react/prop-types
+          wrapper = ({children}) => (
+            <PdeContext.Provider
+              value={{
+                pde: {isFeatureEnabled, getAllFeatureVariables, getVariation}
+              }}
+            >
+              {children}
+            </PdeContext.Provider>
+          )
+        })
+
+        afterEach(() => {
+          delete window.analytics
+        })
+
+        it('should send the off state experiment viewed', () => {
+          renderHook(() => useFeature('notActiveFeatureFlagKey'), {
+            wrapper
+          })
+          expect(window.analytics.track.args[0][0]).to.equal(
+            'Experiment Viewed'
+          )
+          expect(window.analytics.track.args[0][1]).to.deep.equal({
+            experimentName: 'notActiveFeatureFlagKey',
+            variationName: 'Off State'
+          })
+        })
+      })
+    }
+  )
+
+  describe.client('when its a feature test, so an experiment is linked', () => {
     let isFeatureEnabled
     let getAllFeatureVariables
     let getVariation

--- a/packages/sui-pde/test/common/useFeatureSpec.js
+++ b/packages/sui-pde/test/common/useFeatureSpec.js
@@ -8,67 +8,146 @@ import sinon from 'sinon'
 describe('when pde context is set', () => {
   const variables = {variable: 'variable'}
   let wrapper
-  let isFeatureEnabled
-  let getAllFeatureVariables
+
   afterEach(cleanup)
 
-  before(() => {
-    isFeatureEnabled = sinon.stub().returns(true)
-    getAllFeatureVariables = sinon.stub().returns(variables)
-    // eslint-disable-next-line react/prop-types
-    wrapper = ({children}) => (
-      <PdeContext.Provider
-        value={{pde: {isFeatureEnabled, getAllFeatureVariables}}}
-      >
-        {children}
-      </PdeContext.Provider>
-    )
-  })
+  describe('when no experiment is linked', () => {
+    let isFeatureEnabled
+    let getAllFeatureVariables
+    beforeEach(() => {
+      isFeatureEnabled = sinon
+        .stub()
+        .returns({isActive: true, linkedExperiments: []})
+      getAllFeatureVariables = sinon.stub().returns(variables)
 
-  it('should check if a feature is enabled', () => {
-    const {result} = renderHook(
-      () => useFeature('feature1', {attribute1: 'value'}),
-      {wrapper}
-    )
+      window.analytics = {
+        ready: cb => cb(),
+        track: sinon.spy()
+      }
 
-    expect(result.current.isActive).to.equal(true)
-    expect(isFeatureEnabled.called).to.equal(true)
-    expect(isFeatureEnabled.args[0][0]).to.deep.equal({
-      featureKey: 'feature1',
-      attributes: {attribute1: 'value'}
+      // eslint-disable-next-line react/prop-types
+      wrapper = ({children}) => (
+        <PdeContext.Provider
+          value={{pde: {isFeatureEnabled, getAllFeatureVariables}}}
+        >
+          {children}
+        </PdeContext.Provider>
+      )
     })
-  })
 
-  it('should return feature variables', () => {
-    const {result} = renderHook(
-      () => useFeature('feature1', {attribute1: 'value'}),
-      {wrapper}
-    )
-
-    expect(result.current.variables).to.be.deep.equal(variables)
-    expect(isFeatureEnabled.called).to.equal(true)
-    expect(isFeatureEnabled.args[0][0]).to.deep.equal({
-      featureKey: 'feature1',
-      attributes: {attribute1: 'value'}
+    after(() => {
+      delete window.analytics
     })
-  })
 
-  describe.client('and the hook is executed by the browser', () => {
-    it('should check that a feature has been forced to be active', () => {
+    it('should check if a feature is enabled', () => {
       const {result} = renderHook(
-        () => useFeature('feature1', {}, '?suipde_feature1=on'),
+        () => useFeature('featureKey1', {attribute1: 'value'}),
         {wrapper}
       )
       expect(result.current.isActive).to.equal(true)
+      expect(isFeatureEnabled.called).to.equal(true)
+      expect(isFeatureEnabled.args[0][0]).to.deep.equal({
+        featureKey: 'featureKey1',
+        attributes: {attribute1: 'value'}
+      })
     })
 
-    it('should check that a feature has been forced to be not active', () => {
+    it('should return feature variables', () => {
       const {result} = renderHook(
-        () =>
-          useFeature('feature2', {}, '?suipde_feature2=off&suipde_feature1=on'),
+        () => useFeature('featureKey2', {attribute1: 'value'}),
         {wrapper}
       )
-      expect(result.current.isActive).to.equal(false)
+
+      expect(result.current.variables).to.be.deep.equal(variables)
+      expect(isFeatureEnabled.called).to.equal(true)
+      expect(isFeatureEnabled.args[0][0]).to.deep.equal({
+        featureKey: 'featureKey2',
+        attributes: {attribute1: 'value'}
+      })
+    })
+
+    describe.client('and the hook is executed by the browser', () => {
+      it('should check that a feature has been forced to be active', () => {
+        const {result} = renderHook(
+          () => useFeature('featureKey3', {}, '?suipde_feature1=on'),
+          {wrapper}
+        )
+        expect(result.current.isActive).to.equal(true)
+      })
+
+      it('should check that a feature has been forced to be not active', () => {
+        const {result} = renderHook(
+          () =>
+            useFeature(
+              'featureKey3',
+              {},
+              '?suipde_featureKey3=off&suipde_feature1=on'
+            ),
+          {wrapper}
+        )
+        expect(result.current.isActive).to.equal(false)
+      })
+    })
+
+    // TODO: it should track experiment viewed for the feature flag
+    // TODO: check On state
+    // TODO: check Off state
+    // TODO: check doble envío
+  })
+
+  describe('when its a feature test, so an experiment is linked', () => {
+    let isFeatureEnabled
+    let getAllFeatureVariables
+    let getVariation
+
+    beforeEach(() => {
+      isFeatureEnabled = sinon.stub().returns({
+        isActive: true,
+        linkedExperiments: ['abtest_fake_id', 'abtest_second_fake_id'] // definition of linked experimentIds
+      })
+      getAllFeatureVariables = sinon.stub().returns(variables)
+      getVariation = sinon.stub().returns('variation1')
+
+      window.analytics = {
+        ready: cb => cb(),
+        track: sinon.spy()
+      }
+
+      // eslint-disable-next-line react/prop-types
+      wrapper = ({children}) => (
+        <PdeContext.Provider
+          value={{
+            pde: {isFeatureEnabled, getAllFeatureVariables, getVariation}
+          }}
+        >
+          {children}
+        </PdeContext.Provider>
+      )
+    })
+
+    afterEach(() => {
+      delete window.analytics
+    })
+
+    it('should send experiment viewed event for every test asociated and the experiment viewed associated to the feature flag itself', () => {
+      renderHook(() => useFeature('featureKey4', {attribute1: 'value'}), {
+        wrapper
+      })
+      expect(window.analytics.track.args[0][0]).to.equal('Experiment Viewed')
+      expect(window.analytics.track.args[0][1]).to.deep.equal({
+        experimentName: 'featureKey4',
+        variationName: 'On State'
+      })
+      expect(window.analytics.track.args[1][0]).to.equal('Experiment Viewed')
+      expect(window.analytics.track.args[1][1]).to.deep.equal({
+        experimentName: 'abtest_fake_id',
+        variationName: 'variation1'
+      })
+      expect(window.analytics.track.args[2][0]).to.equal('Experiment Viewed')
+      expect(window.analytics.track.args[2][1]).to.deep.equal({
+        experimentName: 'abtest_second_fake_id',
+        variationName: 'variation1'
+      })
     })
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Tracking useFeature hook so we are able to analyse user behaviour based on a feature value. How will this work?
- on useFeature, we will send an Experiment Viewed with the feature key as experimentName and `On State` or `Off State` as variationName
- if a feature flag is used in a feature test, the tool will also send an Experiment Viewed for each linked experiment, working exactly the same way we track experiments with useExperiment 
