### PR TITLE
feat(packages/sui-test): add lcov n html test coverage dual report

### DIFF
--- a/packages/sui-test/bin/karma/index.js
+++ b/packages/sui-test/bin/karma/index.js
@@ -32,7 +32,7 @@ module.exports = async ({
       dir: `${CWD}/coverage`,
       reporters: [
         {type: 'cobertura', subdir: '.', file: 'coverage.xml'},
-        {type: 'html', subdir: 'report-html'},
+        {type: 'lcov', subdir: '.'},
         {type: 'json-summary', subdir: '.', file: 'coverage.json'},
         {type: 'text-summary'}
       ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The process is the same but it can also output the lcov.info in the same lifecycle as the html directory files is generated.
https://github.com/karma-runner/karma-coverage/blob/master/docs/configuration.md

🚨 it also changes the out coverage inner report dir from `html-report` to `lcov-report`

Do you know if someone is using the html report for any process?

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
