### PR TITLE
feat(packages/sui-pde): force feature ssr support

### DIFF
--- a/packages/sui-pde/src/hooks/platformStrategies.js
+++ b/packages/sui-pde/src/hooks/platformStrategies.js
@@ -7,7 +7,14 @@ const getServerStrategy = () => ({
     return pde.getVariation({pde, name: experimentName, attributes})
   },
   trackExperiment: () => {},
-  getForcedValue: () => {}
+  getForcedValue: ({key, queryString}) => {
+    if (!queryString) {
+      return
+    }
+
+    const queryParams = parseQueryString(queryString)
+    return queryParams[`suipde_${key}`]
+  }
 })
 
 const getBrowserStrategy = ({customTrackExperimentViewed}) => ({


### PR DESCRIPTION
## Description
Currently forcing a feature flag is not working with Server-Side Rendering. This PR will allow it.

How could it be done ?
```js
import {useLocation} from '@s-ui/react-router'
import {useFeature} from '@s-ui/pde'

const useEnhancedFeature = (key, attributes) => {
  const location = useLocation()
  return useFeature(key, attributes, location.search)
}

export default useEnhancedFeature
```
Since `useLocation` has Server-Side Rendering support this will work out of the box.

Another alternative would be to provide the location somehow when creating an instance of `PDE`

## Related Issue
None
