### PR TITLE
feat(packages/sui-bundler): Use esbuild for CSS minification

### DIFF
--- a/packages/sui-bundler/README.md
+++ b/packages/sui-bundler/README.md
@@ -321,7 +321,7 @@ You could tweak the performance of your bundle generation by using some flags pr
 
 `splitFrameworkOnChunk` (default: `false`): Separate in a chunk all the packages related to React. This gives you a separated static hashed file, as the version of React doesn't get often upgraded, and a benefit over HTTP2 connections are you're serving smaller files.
 
-`useExperimentalMinifier` (default: `false`): Use `esbuild-loader` to minify code instead using terser in order to boost build time and memory usage.
+`useExperimentalMinifier` (default: `false`): Use `esbuild-loader` to minify JavaScript and CSS instead using `terser` and `css-minimizer-webpack-plugin` in order to boost build time and memory usage.
 
 `useExperimentalSCSSLoader` (default: `false`): Use [fast-sass-loader](https://github.com/yibn2008/fast-sass-loader) (currently a fork of it [super-sass-loader](https://github.com/andresz1/super-sass-loader)) instead of `sass-loader` (available in development only)
 

--- a/packages/sui-bundler/shared/minify-css.js
+++ b/packages/sui-bundler/shared/minify-css.js
@@ -1,6 +1,6 @@
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin')
 
-module.exports = () =>
+const createCssMinimizerPlugin = () =>
   new CssMinimizerPlugin({
     minimizerOptions: {
       preset: [
@@ -11,3 +11,6 @@ module.exports = () =>
       ]
     }
   })
+
+module.exports = ({useExperimentalMinifier}) =>
+  !useExperimentalMinifier && createCssMinimizerPlugin()

--- a/packages/sui-bundler/shared/minify-js.js
+++ b/packages/sui-bundler/shared/minify-js.js
@@ -53,6 +53,7 @@ const terser = ({extractComments, sourceMap}) =>
 
 const esbuild = ({extractComments, sourceMap}) =>
   new ESBuildMinifyPlugin({
+    css: true,
     target: 'es6',
     sourcemap: sourceMap !== 'none' && sourceMap !== false
   })

--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -68,8 +68,8 @@ const webpackConfig = {
     minimize: true,
     minimizer: [
       minifyJs({useExperimentalMinifier, extractComments, sourceMap}),
-      minifyCss()
-    ],
+      minifyCss({useExperimentalMinifier})
+    ].filter(Boolean),
     runtimeChunk: true,
     splitChunks
   },


### PR DESCRIPTION
Use `esbuild` for CSS minification instead `css-minimizer-webpack-plugin` when `useExperimentalMinifier` is enabled.