### PR TITLE
Feat/remove warns on optimizely

### DIFF
--- a/packages/sui-pde/src/adapters/optimizely/index.js
+++ b/packages/sui-pde/src/adapters/optimizely/index.js
@@ -1,13 +1,24 @@
 import optimizelySDK from '@optimizely/optimizely-sdk'
 import {updateIntegrations} from './integrations/handler'
 
-const DEFAULT_OPTIONS = {
+const DEFAULT_DATAFILE_OPTIONS = {
   autoUpdate: true,
-  updateInterval: 5 * 60 * 1000, // 5 minutes
-  logLevel: 'info'
+  updateInterval: 5 * 60 * 1000 // 5 minutes
+}
+
+const DEFAULT_EVENTS_OPTIONS = {
+  eventBatchSize: 10,
+  eventFlushInterval: 1000
 }
 
 const DEFAULT_TIMEOUT = 500
+
+const {
+  enums: {LOG_LEVEL}
+} = optimizelySDK
+
+const LOGGER_LEVEL =
+  process.env.NODE_ENV === 'production' ? LOG_LEVEL.error : LOG_LEVEL.info
 
 export default class OptimizelyAdapter {
   /**
@@ -51,8 +62,8 @@ export default class OptimizelyAdapter {
     datafile,
     optimizely = optimizelySDK
   }) {
-    const options = {...DEFAULT_OPTIONS, ...optionParameter}
-    optimizely.setLogLevel(options.logLevel)
+    const options = {...DEFAULT_DATAFILE_OPTIONS, ...optionParameter}
+    optimizely.setLogLevel(LOGGER_LEVEL)
     optimizely.setLogger(optimizely.logging.createLogger())
     if (
       !datafile &&
@@ -66,7 +77,8 @@ export default class OptimizelyAdapter {
     const optimizelyInstance = optimizely.createInstance({
       sdkKey,
       datafileOptions: options,
-      datafile
+      datafile,
+      ...DEFAULT_EVENTS_OPTIONS
     })
 
     return optimizelyInstance

--- a/packages/sui-pde/src/adapters/optimizely/index.js
+++ b/packages/sui-pde/src/adapters/optimizely/index.js
@@ -161,8 +161,11 @@ export default class OptimizelyAdapter {
       this.getOptimizelyConfig().featuresMap[featureKey].experimentsMap
     )
 
-    // check for user consents only if featureKey is a feature that belongs to a feature test
-    if (linkedExperimentNames.length > 0 && !this._hasUserConsents) {
+    // check for user consents only if featureKey is a feature that belongs to a feature test or if a userId is available
+    if (
+      (linkedExperimentNames.length > 0 && !this._hasUserConsents) ||
+      !this._userId
+    ) {
       return {isActive: false, linkedExperiments: []}
     }
 


### PR DESCRIPTION
- [x] Remove warnings for missing options for events batching.
- [x] Remove error when userId is malformed because we're passing null or undefined (as it's unknown the first time user arrives to the website) 