### PR TITLE
feat(packages/sui-i18n): add or modify translations dynamically

### DIFF
--- a/packages/sui-i18n/src/i18n.js
+++ b/packages/sui-i18n/src/i18n.js
@@ -20,8 +20,7 @@ export default class Rosetta {
 
   set culture(culture) {
     this._culture = culture
-    this.translator.locale = culture.split('-')[0]
-    this.translator.translations = this._languages[culture]
+    this._updateTranslator({culture})
   }
 
   set currency(currency) {
@@ -61,6 +60,33 @@ export default class Rosetta {
 
   set languages(languages) {
     this._languages = languages
+  }
+
+  // Given a culture, it refreshes the translator with the current language.
+  _updateTranslator({culture}) {
+    const [locale] = culture.split('-')
+    const translations = this._languages[culture]
+    this.translator.locale = locale
+    this.translator.translations = translations
+  }
+
+  /**
+   * Add new languages or modify current ones.
+   *
+   * @param {String} culture The culture we want to update, takes current if left empty
+   * @param {String} key Key in where to store the translation, if empty, will overwrite the language
+   * @param {Object} translations Translations to be added
+   */
+  addTranslations({culture, key, translations}) {
+    const newCulture = culture || this._culture
+
+    if (key) {
+      this._languages[newCulture][key] = translations // won't work for nested keys
+    } else {
+      this._languages[newCulture] = translations
+    }
+
+    this._updateTranslator({culture: newCulture})
   }
 
   // Translate.

--- a/packages/sui-i18n/test/i18nSpec.js
+++ b/packages/sui-i18n/test/i18nSpec.js
@@ -141,6 +141,19 @@ describe('I18N', () => {
         expect(i18n.t('literalOne')).to.eql('TranslateOneEsES')
       })
 
+      it('modify translations "literalOne" properly', () => {
+        const translations = {literalOne: 'TranslateTwoEsES'}
+        i18n.addTranslations({translations})
+        expect(i18n.t('literalOne')).to.eql('TranslateTwoEsES')
+      })
+
+      it('add translations "dynamicLiteral" properly', () => {
+        const translations = {literalOne: 'TranslateDynamicEsES'}
+        const key = 'dynamicLiteralKey'
+        i18n.addTranslations({key, translations})
+        expect(i18n.t(`${key}.literalOne`)).to.eql('TranslateDynamicEsES')
+      })
+
       describe('properly formats minor types like', () => {
         describe('percentage', () => {
           it('from a non-decimal amount when ', () => {


### PR DESCRIPTION
## Description
Added a new method to add translations dynamically and refresh the translator.

## Related Issue
N/A

## Example
It is useful if you are adding new translations dynamically. You can load less translations by default and then, when you navigate to a certain page, load the specific translations for that.