### PR TITLE
feat(packages/sui-react-head): Avoid preload and prefetch link tags to create duplicated keys

### DIFF
--- a/packages/sui-react-head/src/types.d.ts
+++ b/packages/sui-react-head/src/types.d.ts
@@ -1,6 +1,7 @@
 export interface Tag {
   children?: string
   name?: string
+  href?: string
   hreflang?: string
   rel?: string
   content?: string

--- a/packages/sui-react-head/src/utils.tsx
+++ b/packages/sui-react-head/src/utils.tsx
@@ -2,12 +2,28 @@ import * as React from 'react'
 import { Children as ReactChildren } from 'react'
 import { Tag } from './types'
 
+const checkRelNeedsHref = (rel: string): boolean =>
+  ['preload', 'prefetch'].includes(rel)
+
+/**
+ * Use rel as key but put extra info if needed
+ * to avoid duplicated keys
+ */
+const extractRelAsKey = (tag: Tag): string | undefined => {
+  const { rel, href, hreflang } = tag
+  if (rel != null) {
+    if (hreflang != null) return `${rel}-${hreflang}`
+    if (checkRelNeedsHref(rel) && href != null) return `${rel}-${href}`
+    return rel
+  }
+}
+
 /**
  * Extract value in a specific order
  */
 const extractKeyFromTag = (tag: Tag): string | undefined => {
-  const { name, hreflang, rel, content } = tag
-  return name ?? hreflang ?? rel ?? content
+  const { name, content } = tag
+  return name ?? extractRelAsKey(tag) ?? content
 }
 
 /**

--- a/packages/sui-react-head/src/utils.tsx
+++ b/packages/sui-react-head/src/utils.tsx
@@ -3,7 +3,7 @@ import { Children as ReactChildren } from 'react'
 import { Tag } from './types'
 
 const checkRelNeedsHref = (rel: string): boolean =>
-  ['preload', 'prefetch'].includes(rel)
+  ['alternate', 'preload', 'prefetch'].includes(rel)
 
 /**
  * Use rel as key but put extra info if needed


### PR DESCRIPTION
- [x] Add more info for preload and prefetch links as key on React to avoid duplicated keys.
- [x] Add more info for alternate to avoid duplicated keys.

![CleanShot 2021-09-20 at 12 16 36@2x](https://user-images.githubusercontent.com/1561955/133987234-12d21e76-d532-4b78-844c-222b1c3ed65a.png)


