### PR TITLE
feat(packages/sui-theme): make url final slash optional

### DIFF
--- a/packages/sui-theme/src/utils/_url.scss
+++ b/packages/sui-theme/src/utils/_url.scss
@@ -1,6 +1,7 @@
 // --- Functions --- //
 
 // Image URL
-@function image-url($image, $url: $url-statics + 'images/') {
-  @return url('#{$url}#{$image}');
+@function image-url($image, $url: $url-statics + 'images') {
+  $url-slash: if(str-index($image, '/'), '', '/');
+  @return url('#{$url}#{$url-slash}#{$image}');
 }


### PR DESCRIPTION
## Description
With this PR, when using the `image-url` utility function, we'll be able to pass images with a starting slash because sometimes in dev envs, URLs are generated relative. If we don't put the slash, it will be added to the final URL.

## Examples
```css
$url-statics: 'https://my-cdn.com/';

background-url: image-url('my-image.jpg'); /* Will generate: `https://my-cdn.com/images/my-image.jpg` */
background-url: image-url('/my-other-image.jpg'); /* Will generate: `https://my-cdn.com/images/my-other-image.jpg` */
```