### PR TITLE
fix(packages/sui-studio): studio default style loading

### DIFF
--- a/packages/sui-studio/src/components/demo/fetch-styles.js
+++ b/packages/sui-studio/src/components/demo/fetch-styles.js
@@ -10,7 +10,7 @@ const requireAvailableThemes = require.context(
 const requireComponentStyles = require.context(
   `!css-loader!sass-loader!${__BASE_DIR__}/components`,
   true,
-  /^\.\/\w+\/\w+\/src\/index\.scss/,
+  /^\.\/\w+\/\w+\/(src|demo)\/index\.scss/,
   'lazy'
 )
 
@@ -33,17 +33,25 @@ export default /* stylesFor */ async ({
     `[sui-studio] Applying new styles for ${componentPath} with theme: ${withTheme}`
   )
 
-  // if we're not using any theme, we load the default styles from the component itself
-  // if we've selected a theme, we load the styles for that specific theme
-  const stylePath = isDefaultTheme
-    ? `./${componentPath}/src/index.scss`
-    : `./${componentPath}/demo/themes/${withTheme}.scss`
-
   // use the correct require method to extract the expected styles
   const requireLazyStyles = isDefaultTheme
     ? requireComponentStyles
     : requireAvailableThemes
 
+  // if we're not using any theme, we load the default styles from its demo or the component itself default styles.
+  // if we've selected a theme, we load the styles for that specific theme
+  const stylePath = requireLazyStyles.keys().find(fileName => {
+    if (
+      !isDefaultTheme &&
+      `./${componentPath}/demo/themes/${withTheme}.scss` === fileName
+    ) {
+      return `./${componentPath}/demo/themes/${withTheme}.scss`
+    } else if (`./${componentPath}/demo/index.scss` === fileName) {
+      return fileName
+    } else if (`./${componentPath}/src/index.scss` === fileName) {
+      return fileName
+    }
+  })
   try {
     // extract the `default` property from the ESModule from lazy required styles
     const {default: style} = await requireLazyStyles(stylePath)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Working with themes, sbdy may need to load index.scss files in a demos that are currently not loaded (in case of existing) with de default theme wiew. It loads by default the package styles, ignoring the index.scss file located in the demo directory. This PR fix this behavior diferentiating between 3 different cases:

- Theme selected --> loads that file
- default theme && not demo/index.scss --> loads src/index.scss component styles file
- default theme && demo/index.scss --> loads demo/index.scss demo styles file

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
