### PR TITLE
feat(packages/sui-i18n): support custom culture in n and c

### DIFF
--- a/packages/sui-i18n/src/i18n.js
+++ b/packages/sui-i18n/src/i18n.js
@@ -95,23 +95,27 @@ export default class Rosetta {
   }
 
   // Format number.
-  n(number, options = {}) {
+  n(number, options = {}, culture) {
     if (typeof number !== 'number') {
       throw new Error('i18n.n should receive a number.')
     }
 
     return typeof Intl !== 'undefined'
-      ? new Intl.NumberFormat(this._culture, options).format(number)
+      ? new Intl.NumberFormat(culture || this._culture, options).format(number)
       : number
   }
 
   // Format currency number.
-  c(number, minimumFractionDigits = 0) {
-    return this.n(number, {
-      style: 'currency',
-      currency: this._currency,
-      minimumFractionDigits
-    })
+  c(number, minimumFractionDigits = 0, culture) {
+    return this.n(
+      number,
+      {
+        style: 'currency',
+        currency: this._currency,
+        minimumFractionDigits
+      },
+      culture
+    )
   }
 
   /**


### PR DESCRIPTION
## Description
This PR allows setting a custom culture for `n` and `c`.
We want to enable this behaviour since we want to format our prices with a custom culture. Given `es-ES` the price `1000` is formatted as `1000 €` (expected result according RAE) and we want to format it as `1.000 €`. `de-DE` works as expected for us for this special case.

If you have any other idea of how to handle this case properly let me know 🙏🏻 
