### PR TITLE
feat(packages/sui-theme): add new bdrs circular

### DIFF
--- a/packages/sui-theme/src/settings/_box-style.scss
+++ b/packages/sui-theme/src/settings/_box-style.scss
@@ -3,6 +3,7 @@
 // Border radius
 $bdrs-base: 8px !default;
 $bdrs-none: 0 !default;
+$bdrs-circle: 999px !default;
 
 $bdrs-xxxl: $bdrs-base * 4 !default; // 32 px
 $bdrs-xxl: $bdrs-base * 2 !default; // 16 px


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding a new border-radius for full circle elements
The current rounded: 50%; is ok, but it only works for 1:1 ratio elements, otherwise it produces oval shapes.  

![bdrs circle](https://user-images.githubusercontent.com/23620759/136784233-1f0a58cd-5cbd-4b6c-8ac9-97a445f9df55.png)

