### PR TITLE
feat(packages/sui-pde): cache variation by session

### DIFF
--- a/packages/sui-pde/src/hooks/common/platformStrategies.js
+++ b/packages/sui-pde/src/hooks/common/platformStrategies.js
@@ -18,6 +18,10 @@ const getServerStrategy = () => ({
 
 const getBrowserStrategy = ({customTrackExperimentViewed, cache}) => ({
   getVariation: ({pde, experimentName, attributes}) => {
+    if (cache.includesKey(experimentName)) {
+      return cache.get(experimentName)
+    }
+
     const variationName = pde.activateExperiment({
       name: experimentName,
       attributes

--- a/packages/sui-pde/src/hooks/common/trackedEventsLocalCache.js
+++ b/packages/sui-pde/src/hooks/common/trackedEventsLocalCache.js
@@ -17,6 +17,12 @@ export const trackedEventsLocalCache = {
   includes: (key, value) => {
     return trackedKeys[key] === value
   },
+  includesKey: key => {
+    return trackedKeys[key] !== undefined
+  },
+  get: key => {
+    return trackedKeys[key]
+  },
   push: (key, value) => {
     if (trackedKeys[key] === value) return
     trackedKeys[key] = value

--- a/packages/sui-pde/test/common/useExperimentSpec.js
+++ b/packages/sui-pde/test/common/useExperimentSpec.js
@@ -267,20 +267,42 @@ describe('useExperiment hook', () => {
 
           stubFactory(activateExperiment)
         })
-        it('should send two experiment viewed events', () => {
-          renderHook(
-            () => useExperiment({experimentName: 'repeatedFeatureFlagKey'}),
-            {
-              wrapper
-            }
-          )
-          renderHook(
-            () => useExperiment({experimentName: 'repeatedFeatureFlagKey'}),
-            {
-              wrapper
-            }
-          )
-          expect(window.analytics.track.args.length).to.equal(2)
+
+        describe('when the user doesnt end the session in between', () => {
+          it('should send only one experiment viewed event', () => {
+            renderHook(
+              () => useExperiment({experimentName: 'repeatedFeatureFlagKey'}),
+              {
+                wrapper
+              }
+            )
+            renderHook(
+              () => useExperiment({experimentName: 'repeatedFeatureFlagKey'}),
+              {
+                wrapper
+              }
+            )
+            expect(window.analytics.track.args.length).to.equal(1)
+          })
+        })
+
+        describe('when the user ends the session in between', () => {
+          it('should send only one experiment viewed event', () => {
+            renderHook(
+              () => useExperiment({experimentName: 'repeatedFeatureFlagKey'}),
+              {
+                wrapper
+              }
+            )
+            window.sessionStorage.removeItem(PDE_CACHE_STORAGE_KEY)
+            renderHook(
+              () => useExperiment({experimentName: 'repeatedFeatureFlagKey'}),
+              {
+                wrapper
+              }
+            )
+            expect(window.analytics.track.args.length).to.equal(2)
+          })
         })
       })
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR tries to reduce the number of activation (as they cost money) in Optimizely by saving in the session storage the variation in which a user has fallen

A beta version has been published and will be tested first to see in which % it reduces the before mentioned Optimizely's activation calls