### PR TITLE
feat(packages/sui-ssr): update archiver version

### DIFF
--- a/packages/sui-ssr/package.json
+++ b/packages/sui-ssr/package.json
@@ -27,7 +27,7 @@
     "@s-ui/critical-css": "1",
     "@s-ui/hoc": "1",
     "@tunnckocore/execa": "4.4.1",
-    "archiver": "3.1.1",
+    "archiver": "5.3.0",
     "commander": "3.0.1",
     "compression": "1.7.4",
     "copy-paste": "1.3.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Trying to update sui-ssr at Jobs we still use the archive method but its broken as it does not zip as it should. This change was made back in the day for sui-ssr@6 which fixed the problem

## Related Issue
https://travis.mpi-internal.com/scmspain/frontend-ij--web-app/jobs/6569573#L556

