### PR TITLE
feat(packages/sui-theme): add mixins to be used instead of extends

### DIFF
--- a/packages/sui-theme/src/components/atom/input/_placeholders.scss
+++ b/packages/sui-theme/src/components/atom/input/_placeholders.scss
@@ -1,33 +1,3 @@
-%sui-atom-input-input {
-  background: $bgc-atom-input;
-  border: $bd-atom-input-base;
-  box-sizing: border-box;
-  color: $c-atom-input;
-  font-family: inherit;
-  font-size: $fz-atom-input;
-  padding-left: $pl-atom-input;
-  padding-right: $pr-atom-input;
-  width: 100%;
-}
-
-%sui-atom-input-input-focus {
-  border: $bd-atom-input;
-  box-shadow: $bxsh-atom-input;
-  outline: 0 none;
-}
-
-%sui-atom-input-select-focus {
-  border: $bd-atom-select-focus;
-  box-shadow: $bxsh-atom-select-focus;
-  outline: 0 none;
-}
-
-%sui-molecule-autosuggest-focus {
-  border: $bd-molecule-autosuggest-focus;
-  box-shadow: $bxsh-molecule-autosuggest-focus;
-  outline: 0 none;
-}
-
 @mixin sui-atom-input-input() {
   background: $bgc-atom-input;
   border: $bd-atom-input-base;
@@ -56,4 +26,20 @@
   border: $bd-molecule-autosuggest-focus;
   box-shadow: $bxsh-molecule-autosuggest-focus;
   outline: 0 none;
+}
+
+%sui-atom-input-input {
+  @include sui-atom-input-input;
+}
+
+%sui-atom-input-input-focus {
+  @include sui-atom-input-input-focus;
+}
+
+%sui-atom-input-select-focus {
+  @include sui-atom-input-select-focus;
+}
+
+%sui-molecule-autosuggest-focus {
+  @include sui-molecule-autosuggest-focus;
 }


### PR DESCRIPTION
When compiling our app with the `useExperimentalSCSSLoader` optimization flag on, our `extends` are not being considered and hence our local environment lacks some styles that would be available in the fully compiled app.

We're doing this `PR` in order to progressively replace those extends by mixins (that would work with the experimental mode).

## Description
Just adding four mixins, akin to `extends` previously defined.

## Related Issue
N/A

## Example
By doing this, our `atom/input` styles should replace their use of `@extend` by use of `@include` the new mixins.

![image](https://user-images.githubusercontent.com/18154356/138887212-384b354f-6f03-4ff9-8d4f-21ec5aa5c840.png)
