### PR TITLE
feat(packages/sui-theme): Scss changes for the atom input

### DIFF
--- a/packages/sui-theme/src/components/atom/input/_settings.scss
+++ b/packages/sui-theme/src/components/atom/input/_settings.scss
@@ -1,15 +1,3 @@
-@import '../../../settings/size';
-
-$h-atom-input--xl: 7 * $sz-base !default; // 56px
-$h-atom-input--l: 6 * $sz-base !default; // 48px
-$h-atom-input--m: 5 * $sz-base !default; // 40px
-$h-atom-input--s: 4 * $sz-base !default; // 32px
-$h-atom-input--xs: 3 * $sz-base !default; // 24px
-
-$c-atom-input--success: $c-success !default;
-$c-atom-input--error: $c-error !default;
-$c-atom-input--alert: $c-alert !default;
-
 $pl-atom-input: $p-l !default;
 $pr-atom-input: $p-l !default;
 
@@ -25,8 +13,3 @@ $bxsh-molecule-autosuggest-focus: $bxsh-atom-input !default;
 
 $bd-atom-select-focus: $bd-atom-input !default;
 $bxsh-atom-select-focus: $bxsh-atom-input !default;
-
-$sizes-atom-input: xl $h-atom-input--xl, l $h-atom-input--l, m $h-atom-input--m,
-  xs $h-atom-input--xs, s $h-atom-input--s !default;
-$states-atom-input: success $c-atom-input--success, error $c-atom-input--error,
-  alert $c-atom-input--alert !default;


### PR DESCRIPTION
## Description
Due to the SCSS architecture that we have mounted, it is not correctly collecting the color assignment of the different portals, because the variable assignment is not in this component but in the sui-theme.
We proceed to remove the assignments from here and move them to the component

Related PR:
https://github.com/SUI-Components/sui-components/pull/1873

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
