### PR TITLE
feat(packages/sui-bundler): Avoid watching files on CI and make it configurable

### DIFF
--- a/packages/sui-bundler/bin/sui-bundler-dev.js
+++ b/packages/sui-bundler/bin/sui-bundler-dev.js
@@ -25,7 +25,8 @@ const linkLoaderConfigBuilder = require('../loaders/linkLoaderConfigBuilder')
 const log = require('../shared/log')
 
 const DEFAULT_PORT = parseInt(process.env.PORT, 10) || 3000
-const HOST = process.env.HOST || '0.0.0.0'
+const {CI = false, HOST = '0.0.0.0'} = process.env
+const DEFAULT_WATCH = !CI
 
 if (!module.parent) {
   program
@@ -43,6 +44,11 @@ if (!module.parent) {
       },
       []
     )
+    .option(
+      '-w, --watch',
+      'Watch files and restart the server on change',
+      DEFAULT_WATCH
+    )
     .on('--help', () => {
       console.log('  Examples:')
       console.log('')
@@ -52,6 +58,7 @@ if (!module.parent) {
       console.log('')
     })
     .parse(process.argv)
+
   const {context} = program
   webpackConfig.context = context || webpackConfig.context
 }

--- a/packages/sui-bundler/factories/createDevServerConfig.js
+++ b/packages/sui-bundler/factories/createDevServerConfig.js
@@ -29,6 +29,7 @@ module.exports = config => ({
   historyApiFallback: {
     disableDotRule: true
   },
+  watch: config.watch,
   onAfterSetupMiddleware(devServer) {
     // This service worker file is effectively a 'no-op' that will reset any
     // previous service worker registered for the same host:port combination.


### PR DESCRIPTION
CI is facing sometimes problems with number of opened files while watching:
<img width="1295" alt="CleanShot 2021-11-15 at 10 50 04@2x" src="https://user-images.githubusercontent.com/1561955/141760163-a1827f21-a1c6-4f59-aa02-5c55f76848f3.png">

Watching files on CI doesn't make any sense. With this PR, we're stopping watching files to avoid this problem.