### PR TITLE
Fix typo that prevent to generate a new component in studio

### DIFF
--- a/packages/sui-studio/bin/sui-studio-generate.js
+++ b/packages/sui-studio/bin/sui-studio-generate.js
@@ -15,7 +15,7 @@ program
   .option('-C, --context [customContextPath]', 'add context for this component')
   .option('-P, --prefix <prefix>', 'add prefix for this component')
   .option('-S, --scope <scope>', 'add scope for this component')
-  .otpion('-W, --swc', 'Use the new SWC compiler', false)
+  .option('-W, --swc', 'Use the new SWC compiler', false)
   .on('--help', () => {
     console.log('  Examples:')
     console.log('')


### PR DESCRIPTION
## Description
It fixes a typo that prevents generating a new component in the studio

## Example
```npm run generate context component``` will work properly now.