### PR TITLE
Fix prepare script to copy styles in generate template

### DIFF
--- a/packages/sui-studio/bin/sui-studio-generate.js
+++ b/packages/sui-studio/bin/sui-studio-generate.js
@@ -152,9 +152,9 @@ const defaultContext = `module.exports = {
 }
 `
 
-const prepare = swc
+const buildJs = swc
   ? 'sui-js-compiler'
-  : 'npm run build:js && npm run build:styles'
+  : 'babel --presets sui ./src --out-dir ./lib'
 
 // Check if the component already exist before continuing
 if (fs.existsSync(COMPONENT_PATH)) {
@@ -196,8 +196,8 @@ test
   "description": "",
   "main": "lib/index.js",
   "scripts": {
-    "prepare": "${prepare}",
-    "build:js": "babel --presets sui ./src --out-dir ./lib",
+    "prepare": "npm run build:js && npm run build:styles",
+    "build:js": "${buildJs}",
     "build:styles": "cpx './src/**/*.scss' ./lib"
   },
   "peerDependencies": {

--- a/packages/sui-studio/bin/sui-studio-generate.js
+++ b/packages/sui-studio/bin/sui-studio-generate.js
@@ -154,7 +154,7 @@ const defaultContext = `module.exports = {
 
 const prepare = swc
   ? 'sui-js-compiler'
-  : 'babel --presets sui ./src --out-dir ./lib'
+  : 'npm run build:js && npm run build:styles'
 
 // Check if the component already exist before continuing
 if (fs.existsSync(COMPONENT_PATH)) {


### PR DESCRIPTION
## Description
It fixes the npm script ```prepare``` in the template of a new generated component.

## Example
When ```npm run generate context component``` the script ```prepare``` in ```package.json``` will copy styles to ```lib``` folder.