### PR TITLE
feat(packages/sui-react-router): pass state to router push

### DIFF
--- a/packages/sui-react-router/src/Link.js
+++ b/packages/sui-react-router/src/Link.js
@@ -44,6 +44,7 @@ const Link = ({
   innerRef,
   onClick,
   onlyActiveOnIndex = false,
+  state,
   target,
   to,
   ...restOfProps
@@ -60,10 +61,10 @@ const Link = ({
         !isModifiedEvent(event) // Ignore clicks with modifier keys
       ) {
         event.preventDefault()
-        router.push(resolveToLocation(to, router))
+        router.push({pathname: resolveToLocation(to, router), state})
       }
     },
-    [onClick, router, target, to]
+    [onClick, router, target, to, state]
   )
 
   // Ignore if rendered outside the context of router
@@ -94,6 +95,7 @@ const Link = ({
     className,
     href: router.createHref(toLocation),
     target,
+    state,
     style
   }
 
@@ -127,6 +129,10 @@ Link.propTypes = {
    * Only check if the destination is the actual route if you're in the index
    */
   onlyActiveOnIndex: PropTypes.bool,
+  /**
+   * The route state to pass to router push
+   */
+  state: PropTypes.object,
   /**
    * Inline style for the element
    */


### PR DESCRIPTION
Added the possibility to send a state between routes

## Description
We use the react-router functionality to pass state to the push action

## Example
```js
import {Link} from '@s-ui/react-router'

const routeState = {stateProp: 'myStateProp'}

 <Link to={href} {...props} state={routeState}>
      {children}
 </Link>
```
