### PR TITLE
Feat/avoid using copyfiles dependency

### DIFF
--- a/packages/sui-studio/.gitignore
+++ b/packages/sui-studio/.gitignore
@@ -1,0 +1,1 @@
+test/server/runtime

--- a/packages/sui-studio/README.md
+++ b/packages/sui-studio/README.md
@@ -50,7 +50,7 @@ $ npx sui-studio generate house window -C ./myCustomContext.js
 
 We're migrating to `swc` so you could generate the new component with the expected `prepare` field by using the flag `--swc` or `-W`.
 
-### To develop the new component,
+### To develop the new component
 
 #### 1) Launch the development environment
 
@@ -131,7 +131,18 @@ Launch a development environment where you can work in total isolation on your c
 
 ### `$ sui-studio test`
 
-Launch all project tests in a karma browser.
+Launch all project tests in a Karma browser.
+
+### `$ cpx`
+
+This command allow you to copy files from a source to a destination using glob patterns. It's useful to copy files from the source to the build folder.  
+
+#### Examples
+
+```sh
+# copy all files with scss extension from src to lib
+$ cpx './src/**/*.scss' ./lib
+```
 
 ## Testing
 

--- a/packages/sui-studio/bin/cpx.js
+++ b/packages/sui-studio/bin/cpx.js
@@ -1,8 +1,12 @@
 #!/usr/bin/env node
-const copyfiles = require('copyfiles')
+const copyfiles = require('./helpers/copy.js')
 
 const [, , from, to] = process.argv
 
-copyfiles([from, to], {up: 1}, err =>
-  err ? console.error(err) : console.log('Files copied successfully')
-)
+copyfiles([from, to], {up: 1})
+  .then(() => {
+    console.log('Files copied successfully')
+  })
+  .catch(err => {
+    console.error(err)
+  })

--- a/packages/sui-studio/bin/helpers/copy.js
+++ b/packages/sui-studio/bin/helpers/copy.js
@@ -1,0 +1,80 @@
+// @ts-check
+
+'use strict'
+
+const path = require('path')
+const fs = require('fs-extra')
+const glob = require('fast-glob')
+
+const {DEBUG} = process.env
+
+/**
+ * Show logging information if debug mode is enabled
+ * @param {...any} args - arguments to log
+ * @returns {void}
+ */
+const debug = (...args) => (DEBUG ? console.log('[copyfiles] ', ...args) : null)
+
+/**
+ * Check depth
+ * @param {string} filePath - path of the file
+ * @param {number} up - number of directories to go up
+ * @returns
+ */
+const checkDepth = (filePath, up) => {
+  // components/atom/button
+  const depth = path.normalize(filePath).split(path.sep).length - 1
+  return depth > up
+}
+
+/**
+ * Resolve file path
+ * @param {string} filePath - path of the file
+ * @param {object} config - configuration object
+ * @param {object} config.flatten - flatten the path
+ * @param {number} config.up - number of directories to go up
+ * @returns {string}
+ */
+const resolveFilePath = (filePath, {flatten, up}) => {
+  if (flatten === true) return path.basename(filePath)
+  if (up === 0) return filePath
+
+  if (!checkDepth(filePath, up)) {
+    throw new Error(
+      "The number of folders you're trying to go up are not correct. Check the path or the up config"
+    )
+  }
+
+  return path.join(
+    ...path
+      .normalize(filePath)
+      .split(path.sep)
+      .slice(up)
+  )
+}
+
+module.exports = async function copyFiles(args, config) {
+  const input = args.slice()
+  const outDir = input.pop()
+  const globOpts = {}
+
+  const {flatten = false, up = 0} = config
+
+  if (config.exclude) globOpts.ignore = config.exclude
+  if (config.all) globOpts.dot = true
+  if (config.follow) globOpts.followSymbolicLinks = true
+
+  debug(`Config for glob: `, globOpts)
+
+  const files = await glob(input, globOpts)
+
+  debug(`Copying ${files.length} files from ${input} to ${outDir}`)
+
+  return Promise.all(
+    files.map(file => {
+      const outName = path.join(outDir, resolveFilePath(file, {flatten, up}))
+      debug(`Copying ${file} to ${outName}`)
+      return fs.copy(file, outName)
+    })
+  )
+}

--- a/packages/sui-studio/bin/helpers/copy.js
+++ b/packages/sui-studio/bin/helpers/copy.js
@@ -53,7 +53,7 @@ const resolveFilePath = (filePath, {flatten, up}) => {
   )
 }
 
-module.exports = async function copyFiles(args, config) {
+module.exports = async function copyFiles(args, config = {}) {
   const input = args.slice()
   const outDir = input.pop()
   const globOpts = {}
@@ -67,6 +67,10 @@ module.exports = async function copyFiles(args, config) {
   debug(`Config for glob: `, globOpts)
 
   const files = await glob(input, globOpts)
+
+  if (files.length === 0) {
+    console.log('No files found.')
+  }
 
   debug(`Copying ${files.length} files from ${input} to ${outDir}`)
 

--- a/packages/sui-studio/bin/helpers/copyGlobals.js
+++ b/packages/sui-studio/bin/helpers/copyGlobals.js
@@ -1,4 +1,4 @@
-const copy = require('copyfiles')
+const copy = require('./copy.js')
 const fs = require('fs')
 
 const GLOBALS_FILE_PATH = 'components/globals.js'
@@ -7,10 +7,11 @@ const DESTINATION_FOLDER = 'public'
 module.exports = function copyGlobals() {
   if (fs.existsSync(GLOBALS_FILE_PATH)) {
     console.log('*** globals detected ***') // eslint-disable-line
-  } else {
-    fs.writeFileSync(GLOBALS_FILE_PATH, '// globals file', 'utf8')
+    return
   }
-  copy([GLOBALS_FILE_PATH, DESTINATION_FOLDER], () =>
+
+  fs.writeFileSync(GLOBALS_FILE_PATH, '// globals file', 'utf8')
+  copy([GLOBALS_FILE_PATH, DESTINATION_FOLDER]).then(() =>
     console.log('[sui-studio] Copied globals file correctly')
   )
 }

--- a/packages/sui-studio/bin/helpers/copyStaticFiles.js
+++ b/packages/sui-studio/bin/helpers/copyStaticFiles.js
@@ -1,4 +1,4 @@
-const copy = require('copyfiles')
+const copy = require('./copy.js')
 
 const DESTINATION_FOLDER = 'public'
 
@@ -14,7 +14,8 @@ module.exports = function copyStaticFiles() {
     ],
     {
       exclude: 'node_modules/**'
-    },
-    () => console.log('[sui-studio] Static files copied')
-  )
+    }
+  ).then(() => {
+    console.log('[sui-studio] Static files copied')
+  })
 }

--- a/packages/sui-studio/package.json
+++ b/packages/sui-studio/package.json
@@ -25,7 +25,6 @@
     "classnames": "2.2.5",
     "colors": "1.4.0",
     "commander": "6.2.1",
-    "copyfiles": "2.4.1",
     "deepmerge": "4.2.2",
     "fast-glob": "3.2.7",
     "fs-extra": "10.0.0",

--- a/packages/sui-studio/test/server/copySpec.js
+++ b/packages/sui-studio/test/server/copySpec.js
@@ -1,0 +1,56 @@
+const fs = require('fs-extra')
+const path = require('path')
+const {expect} = require('chai')
+
+const copyfiles = require('../../bin/helpers/copy')
+
+describe('copyfiles', () => {
+  const cwd = process.cwd()
+
+  beforeEach(() => {
+    fs.rm('./runtime', {recursive: true})
+    process.chdir(__dirname)
+  })
+
+  afterEach(() => {
+    process.chdir(cwd)
+  })
+
+  it('should copy files from src to dest', async () => {
+    const from = 'fixturesCopy/**/*.js'
+    const to = 'runtime'
+
+    return copyfiles([from, to]).then(async () => {
+      const out = path.join(__dirname, 'runtime/fixturesCopy/a.js')
+      const stat = await fs.stat(out)
+      expect(stat.isFile()).to.be.true
+    })
+  })
+
+  it('should copy files from src to dest moving up one level', async () => {
+    const from = 'fixturesCopy/components/**/*.js'
+    const to = 'runtime'
+
+    return copyfiles([from, to], {up: 1}).then(async () => {
+      const out = path.join(
+        __dirname,
+        'runtime/components/atom/button/index.js'
+      )
+      const stat = await fs.stat(out)
+      expect(stat.isFile()).to.be.true
+    })
+  })
+
+  it('should copy files from src to dest and flatten it', async () => {
+    const from = 'fixturesCopy/**/*.js'
+    const to = 'runtime'
+
+    return copyfiles([from, to], {flatten: true}).then(async () => {
+      const out = path.join(__dirname, 'runtime/index.js')
+      const stat = await fs.stat(out)
+      expect(stat.isFile()).to.be.true
+    })
+  })
+})
+
+describe('cpx', () => {})

--- a/packages/sui-studio/test/server/fixturesCopy/a.js
+++ b/packages/sui-studio/test/server/fixturesCopy/a.js
@@ -1,0 +1,1 @@
+// this file is for testing purposes only

--- a/packages/sui-studio/test/server/fixturesCopy/components/atom/button/index.js
+++ b/packages/sui-studio/test/server/fixturesCopy/components/atom/button/index.js
@@ -1,0 +1,1 @@
+// this file is for testing purposes only

--- a/packages/sui-test-e2e/package.json
+++ b/packages/sui-test-e2e/package.json
@@ -17,7 +17,8 @@
     "@testing-library/cypress": "8.0.1",
     "commander": "8.2.0",
     "cypress": "8.6.0",
-    "cypress-file-upload": "5.0.8"
+    "cypress-file-upload": "5.0.8",
+    "har-validator": "5.1.5"
   },
   "keywords": [],
   "author": "",

--- a/packages/sui-test-e2e/package.json
+++ b/packages/sui-test-e2e/package.json
@@ -17,8 +17,7 @@
     "@testing-library/cypress": "8.0.1",
     "commander": "8.2.0",
     "cypress": "8.6.0",
-    "cypress-file-upload": "5.0.8",
-    "har-validator": "5.1.5"
+    "cypress-file-upload": "5.0.8"
   },
   "keywords": [],
   "author": "",

--- a/packages/sui-theme/package.json
+++ b/packages/sui-theme/package.json
@@ -5,13 +5,10 @@
   "main": "lib/index.scss",
   "scripts": {
     "clean:lib": "npx rimraf lib",
-    "lib": "copyup './src/**/*.scss' lib/ ",
+    "lib": "cp -R src lib",
     "lint": "sui-lint sass",
     "prepare": "npm run lib"
   },
   "license": "ISC",
-  "homepage": "https://github.com/SUI-Components/sui",
-  "devDependencies": {
-    "copyfiles": "2.4.1"
-  }
+  "homepage": "https://github.com/SUI-Components/sui"
 }


### PR DESCRIPTION
`copyfiles` dependency stopped working suddenly. It seems that some sub-dependency changed and caused some problems.

In order to avoid this kind of problems, we're moving to create our own copyfiles funcitonality. It mimics the same API as before and it allows you to use the CLI for the componentes.

Also, I've removed the usage of copyes on `@s-ui/theme` package and use the system cp command.
