### PR TITLE
feat(packages/sui-test): Pin colors version on package.json

### DIFF
--- a/packages/sui-test-e2e/package.json
+++ b/packages/sui-test-e2e/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@testing-library/cypress": "8.0.1",
+    "colors": "1.4.0",
     "commander": "8.2.0",
     "cypress": "8.6.0",
     "cypress-file-upload": "5.0.8"

--- a/packages/sui-test/package.json
+++ b/packages/sui-test/package.json
@@ -22,6 +22,7 @@
     "babel-plugin-dynamic-import-node": "2.3.3",
     "babel-plugin-istanbul": "6.0.0",
     "babel-preset-sui": "3",
+    "colors": "1.4.0",
     "commander": "6.2.1",
     "karma": "6.3.4",
     "karma-chrome-launcher": "3.1.0",


### PR DESCRIPTION
Pin `colors` version to avoid infinite loop as `1.4.0` is fine.