### PR TITLE
feat(packages/sui-theme): allow to overwrite the card article description color

### DIFF
--- a/packages/sui-theme/src/components/_card.scss
+++ b/packages/sui-theme/src/components/_card.scss
@@ -56,6 +56,7 @@
   }
 
   &-description {
+    color: $c-card-article-description;
     font-size: $fz-m;
   }
 

--- a/packages/sui-theme/src/settings-compat-v7/_components.scss
+++ b/packages/sui-theme/src/settings-compat-v7/_components.scss
@@ -122,13 +122,14 @@ $c-button-flat-icon-stroke: transparent !default;
 $bgc-button-flat-active: $c-gray !default;
 
 // Card
+$bdc-article-featured: $c-featured !default;
+$bd-article-featured: $bdw-l solid $bdc-article-featured !default;
 $bdrs-card: 0 !default;
 $bxsh-card: $bxsh-base !default;
 $bxsh-card-hover: 0 1px 6px 2px rgba($c-black, 0.15) !default;
-$c-card-title-hover: inherit !default;
-$bdc-article-featured: $c-featured !default;
-$bd-article-featured: $bdw-l solid $bdc-article-featured !default;
+$c-card-article-description: inherit !default;
 $c-card-article-icon-fill: $c-white !default;
+$c-card-title-hover: inherit !default;
 $z-card-article-icon: 1 !default;
 
 // Card composable


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As part of the brand refresh we want to have the chance to overwrite the card article description color.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
Brand refresh https://jira.scmspain.com/browse/MTR-49164

