### PR TITLE
fix(packages/sui-lint): Show correct number of linted files

### DIFF
--- a/packages/sui-lint/bin/sui-lint-js.js
+++ b/packages/sui-lint/bin/sui-lint-js.js
@@ -6,7 +6,7 @@ const {
   getGitIgnoredFiles,
   isOptionSet,
   stageFilesIfRequired
-} = require('../src/helpers')
+} = require('../src/helpers.js')
 
 const {ESLint} = require('eslint')
 const config = require('../eslintrc.js')
@@ -14,7 +14,7 @@ const config = require('../eslintrc.js')
 const {CI} = process.env
 const EXTENSIONS = ['js', 'jsx', 'ts', 'tsx']
 const IGNORE_PATTERNS = ['lib', 'dist', 'public', 'node_modules']
-
+const DEFAULT_PATTERN = './'
 const baseConfig = {
   ...config,
   ignorePatterns: IGNORE_PATTERNS.concat(getGitIgnoredFiles())
@@ -22,8 +22,15 @@ const baseConfig = {
 const formatterName = CI ? 'stylish' : 'codeframe'
 
 ;(async function main() {
-  const files = await getFilesToLint(EXTENSIONS)
-  if (!checkFilesToLint({files, language: 'JavaScript'})) return
+  const files = await getFilesToLint(EXTENSIONS, DEFAULT_PATTERN)
+  if (
+    !checkFilesToLint({
+      files,
+      language: 'JavaScript',
+      defaultPattern: DEFAULT_PATTERN
+    })
+  )
+    return
 
   const fix = isOptionSet('fix')
   const eslint = new ESLint({

--- a/packages/sui-lint/bin/sui-lint-sass.js
+++ b/packages/sui-lint/bin/sui-lint-sass.js
@@ -7,10 +7,11 @@ const {
   checkFilesToLint,
   getGitIgnoredFiles,
   getFilesToLint
-} = require('../src/helpers')
+} = require('../src/helpers.js')
 
 const EXTENSIONS = ['scss']
 const IGNORE_PATTERNS = ['**/node_modules/**', '**/lib/**', '**/dist/**']
+const DEFAULT_PATTERN = '**/*.scss'
 
 program
   .option('--add-fixes')
@@ -19,12 +20,19 @@ program
   .option(
     '--pattern <pattern>',
     'root path to locate the sass files',
-    '**/*.scss'
+    DEFAULT_PATTERN
   )
   .parse(process.argv)
 
 getFilesToLint(EXTENSIONS, program.pattern).then(files => {
-  if (!checkFilesToLint({files, language: 'SCSS'})) return
+  if (
+    !checkFilesToLint({
+      files,
+      language: 'SCSS',
+      defaultPattern: DEFAULT_PATTERN
+    })
+  )
+    return
 
   return stylelint
     .lint({

--- a/packages/sui-lint/src/helpers.js
+++ b/packages/sui-lint/src/helpers.js
@@ -87,7 +87,15 @@ const getCommitRange = () => {
     const base = pullRequest?.base?.sha ?? before
     const head = pullRequest?.head?.sha ?? after
 
-    if (after && before) return `${base}...${head}`
+    if (after && before) {
+      const commitRange = `${base}...${head}`
+      console.log(`[sui-lint] Using commit range: ${commitRange}`)
+      return commitRange
+    }
+
+    console.log(
+      '[sui-lint] No commit range found using GitHub Event from Actions'
+    )
   }
 
   return null

--- a/packages/sui-lint/src/helpers.js
+++ b/packages/sui-lint/src/helpers.js
@@ -96,10 +96,10 @@ const getCommitRange = () => {
 /**
  * Get files to lint according to command options
  * @param {string[]} extensions Extensions list: ['js', 'sass', 'css']
- * @param {string} defaultFiles Defaults to './'
+ * @param {string} defaultFiles Pattern with the files in case no other options are set
  * @returns {Promise<string[]>} Array of file patterns
  */
-const getFilesToLint = async (extensions, defaultFiles = './') => {
+const getFilesToLint = async (extensions, defaultFiles) => {
   const range = getCommitRange()
   const staged = process.argv.includes(OPTIONS.staged)
   const getFromDiff = range || staged
@@ -133,15 +133,21 @@ const isOptionSet = option => process.argv.includes(`--${option}`)
 
 /**
  * Check if there're files to lint and output a message
- * @param {Object} params
- * @param {String[]} params.files Files to lint
+ * @param {Object}                params
+ * @param {String[]}              params.files Files to lint
  * @param {"JavaScript" | "SCSS"} params.language Language to lint
+ * @param {String}                params.defaultPattern Default pattern to lint
  * @returns {boolean} If there's files to lint
  */
-const checkFilesToLint = ({files, language}) => {
+const checkFilesToLint = ({files, language, defaultPattern}) => {
   if (!files.length) {
     console.log(`[sui-lint] No ${language} files to lint`)
     return false
+  }
+
+  if (files.length === 1 && files[0] === defaultPattern) {
+    console.log(`[sui-lint] Linting all ${language} files...`)
+    return true
   }
 
   console.log(`[sui-lint] Linting ${files.length} ${language} files...`)


### PR DESCRIPTION
Instead of showing always `1` filed linted, we show `All` when it's using the default pattern that match with all the source files of the language.