### PR TITLE
fix(packages/sui-ssr): allow multisite cache assets manifest

### DIFF
--- a/packages/sui-ssr/server/utils/factory.js
+++ b/packages/sui-ssr/server/utils/factory.js
@@ -119,7 +119,9 @@ export default ({path, fs, config: ssrConf = {}, assetsManifest}) => {
     const site = siteByHost(req)
 
     if (cachedAssetsManifest) {
-      return site ? cachedAssetsManifest[site] : cachedAssetsManifest
+      if (site && cachedAssetsManifest[site]) return cachedAssetsManifest[site]
+
+      if (!site) return cachedAssetsManifest
     }
 
     let assetsManifest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We had some crashes when trying to access to the assets-manifest.json file for multisite configuration. This fix allows to do it avoiding crashes.
