### PR TITLE
Avoid private packages

### DIFF
--- a/packages/sui-helpers/file.js
+++ b/packages/sui-helpers/file.js
@@ -1,6 +1,6 @@
 const fse = require('fs-extra')
-const colors = require('./colors')
-const {showError} = require('./cli')
+const colors = require('./colors.js')
+const {showError} = require('./cli.js')
 
 const log = msg => console.log(colors.gray(msg)) // eslint-disable-line no-console
 

--- a/packages/sui-mono/bin/sui-mono-check.js
+++ b/packages/sui-mono/bin/sui-mono-check.js
@@ -1,7 +1,7 @@
 /* eslint no-console:0 */
 const program = require('commander')
 const colors = require('@s-ui/helpers/colors')
-const checker = require('../src/check')
+const checker = require('../src/check.js')
 
 program
   .on('--help', () => {

--- a/packages/sui-mono/bin/sui-mono-release.js
+++ b/packages/sui-mono/bin/sui-mono-release.js
@@ -11,8 +11,8 @@ const {
   checkIsMonoPackage,
   getChangelogFilename,
   getPublishAccess
-} = require('../src/config')
-const checker = require('../src/check')
+} = require('../src/config.js')
+const checker = require('../src/check.js')
 
 program
   .option('-S, --scope <scope>', 'release a single scope')

--- a/packages/sui-mono/src/check.js
+++ b/packages/sui-mono/src/check.js
@@ -1,7 +1,14 @@
 /* eslint no-console:0 */
 
 const conventionalChangelog = require('conventional-changelog')
-const {checkIsMonoPackage, getProjectName, getWorkspaces} = require('./config')
+const {readJsonSync} = require('fs-extra')
+
+const {
+  checkIsMonoPackage,
+  getProjectName,
+  getWorkspaces
+} = require('./config.js')
+
 const gitRawCommitsOpts = {reverse: true, topoOrder: true}
 
 const PACKAGE_VERSION_INCREMENT = {
@@ -38,7 +45,14 @@ const flatten = status =>
 
 const check = () =>
   new Promise(resolve => {
-    const packagesWithChangelog = getWorkspaces()
+    /**
+     * Remove packages with private field with true value
+     * so we avoid them to be listed as releaseable
+     */
+    const packagesWithChangelog = getWorkspaces().filter(pkg => {
+      const {private: privateField} = readJsonSync(`${pkg}/package.json`)
+      return privateField !== true
+    })
 
     const status = {}
     packagesWithChangelog.forEach(pkg => {


### PR DESCRIPTION
Filter packages with the private field present as true so we avoid release them and list them as releasable