### PR TITLE
Fix/studio test pattern

### DIFF
--- a/packages/sui-studio/bin/sui-studio-test.js
+++ b/packages/sui-studio/bin/sui-studio-test.js
@@ -28,7 +28,7 @@ const run = async () => {
       [
         suiTestClientPath,
         [
-          '--src-pattern',
+          '--pattern',
           path.join(
             'node_modules',
             '@s-ui',

--- a/packages/sui-studio/src/runtime-mocha/index.js
+++ b/packages/sui-studio/src/runtime-mocha/index.js
@@ -1,4 +1,8 @@
 /* global __BASE_DIR__, CATEGORIES */
+
+/**
+ * This file is being executed in browser opened to run tests
+ */
 import {importContexts, importReactComponent} from '../components/tryRequire.js'
 import {addSetupEnvironment} from '../environment-mocha/setupEnvironment.js'
 import {addReactContextToComponent} from '../components/utils.js'
@@ -17,11 +21,7 @@ const filterAll = key => {
 }
 
 // Require all the files from a context
-const importAll = request =>
-  request
-    .keys()
-    .filter(filterAll)
-    .forEach(request)
+const importAll = request => request.keys().filter(filterAll).forEach(request)
 
 // Avoid running Karma until all components tests are loaded
 const originalKarmaLoader = window.__karma__.loaded
@@ -33,58 +33,56 @@ const testsFiles = require.context(
   /\.\/(\w+)\/(\w+)\/test\/index.test.(js|jsx)/
 )
 
-// get all the needed components from the available tests
+const selectedTestFiles = testsFiles.keys().filter(filterAll)
+
 Promise.all(
-  testsFiles
-    .keys()
-    .filter(filterAll)
-    .map(async key => {
-      // get the category component from the segments of the path
-      // ex: ./card/property/index.js -> card property
-      const [, category, component] = key.split('/')
-      const categoryComponentKey = `${category}/${component}`
+  selectedTestFiles.map(async key => {
+    // get the category component from the segments of the path
+    // ex: ./card/property/index.js -> card property
+    const [, category, component] = key.split('/')
+    const categoryComponentKey = `${category}/${component}`
 
-      const getContexts = await importContexts({category, component})
-      const contexts =
-        typeof getContexts === 'function' ? await getContexts() : getContexts
+    const getContexts = await importContexts({category, component})
+    const contexts =
+      typeof getContexts === 'function' ? await getContexts() : getContexts
 
-      const componentModule = await importReactComponent({
-        category,
-        component,
-        extractDefault: true
-      })
-
-      const Component =
-        componentModule && (componentModule.type || componentModule)
-
-      if (!componentModule) {
-        console.error(
-          `Could not find component ${categoryComponentKey} in ${key}`
-        )
-        console.error(`Available keys: `, testsFiles.keys())
-        throw new Error(`Missing export default from ${categoryComponentKey}`)
-      }
-
-      const {displayName} = Component
-      // store on the window the contexts and components using the ${category/component} key
-      window.__STUDIO_CONTEXTS__[categoryComponentKey] = contexts
-      window.__STUDIO_COMPONENT__[categoryComponentKey] = Component
-
-      const ComponentWithReactContext = addReactContextToComponent(Component, {
-        context: contexts.default,
-        id: categoryComponentKey
-      })
-
-      // if the Component has a displayName, we're going to make the Component
-      // available through the window object with the default context without importing it
-      if (displayName) {
-        window[displayName] = ComponentWithReactContext
-      }
+    const componentModule = await importReactComponent({
+      category,
+      component,
+      extractDefault: true
     })
+
+    const Component =
+      componentModule && (componentModule.type || componentModule)
+
+    if (!componentModule) {
+      console.error(
+        `Could not find component ${categoryComponentKey} in ${key}`
+      )
+      console.error(`Available keys: `, selectedTestFiles.keys())
+      throw new Error(`Missing export default from ${categoryComponentKey}`)
+    }
+
+    const {displayName} = Component
+    // store on the window the contexts and components using the ${category/component} key
+    window.__STUDIO_CONTEXTS__[categoryComponentKey] = contexts
+    window.__STUDIO_COMPONENT__[categoryComponentKey] = Component
+
+    const ComponentWithReactContext = addReactContextToComponent(Component, {
+      context: contexts.default,
+      id: categoryComponentKey
+    })
+
+    // if the Component has a displayName, we're going to make the Component
+    // available through the window object with the default context without importing it
+    if (displayName) {
+      window[displayName] = ComponentWithReactContext
+    }
+  })
 )
   .then(() => {
     // in order to force all tests, we're importing all the files that matches the pattern
-    importAll(testsFiles)
+    importAll(selectedTestFiles)
     // we're ready to go
     originalKarmaLoader.call(window.__karma__)
   })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Use `--pattern` option instead `---src-pattern` to run sui-test browser from sui-studio test binary. This will prevent to have [default pattern option value](https://github.com/SUI-Components/sui/blob/master/packages/sui-test/bin/sui-test-browser.js#L14)

- sui-studio `runtime-mocha/index.js` is running in testing browser, and we need only prepare environment for selected category component tests. It will help browser to consume less memory