### PR TITLE
fix(packages/sui-bundler): prevent error for rules that does not have…

### DIFF
--- a/packages/sui-bundler/loaders/linkLoaderConfigBuilder.js
+++ b/packages/sui-bundler/loaders/linkLoaderConfigBuilder.js
@@ -80,6 +80,9 @@ module.exports = ({config, packagesToLink, linkAll}) => {
   const {rules} = config.module
   const rulesWithLink = rules.map(rule => {
     const {use, test: regex} = rule
+
+    if (!use) return rule
+
     if (!regex.test('.css')) return rule
 
     return {

--- a/packages/sui-bundler/webpack.config.server.js
+++ b/packages/sui-bundler/webpack.config.server.js
@@ -42,7 +42,7 @@ const webpackConfig = {
       babelRules,
       {
         // ignore css/scss/svg require/imports files in the server
-        test: [/\.s?css$/, /\.svg$/],
+        test: /(\.svg|\.s?css)$/,
         type: 'asset/inline',
         generator: {
           dataUrl: () => ''


### PR DESCRIPTION

## Description
Prevent error `TypeError: regex.test is not a function` if `test` property is an array.
Also, prevent error when loader rule does not have `use` property

We have experienced errors on try to use --link-package for compiling our app as server side because of [this rule:](https://github.com/SUI-Components/sui/blob/master/packages/sui-bundler/webpack.config.server.js#L45)
![image](https://user-images.githubusercontent.com/5390428/153146312-88350647-449f-4bd6-b8c7-13f9d8c4e980.png)
