### PR TITLE
Sui mono/workspace release config

### DIFF
--- a/packages/sui-mono/README.md
+++ b/packages/sui-mono/README.md
@@ -34,8 +34,8 @@ We use:
     - [`access`](#access)
     - [`workspaces`](#workspaces)
       - [Examples](#examples)
-          - [Project Example](#project-example)
-          - [Case `sui-studio`](#case-sui-studio)
+        - [Project Example](#project-example)
+        - [Case `sui-studio`](#case-sui-studio)
       - [Manual scopes](#manual-scopes)
   - [Migration from v1](#migration-from-v1)
     - [`packagesFolder` and `deepLevel` are not longer used](#packagesfolder-and-deeplevel-are-not-longer-used)
@@ -198,7 +198,18 @@ If you specify that your package is private (`"private": true,`), it will be ign
 
 ### `access`
 
-By default packages will be published as `restricted` in npm. If you want them to be public you will need to set `"access": "public"`.
+By default packages will be published as `restricted` in npm. If you want them to be public you will need to set `"access": "public"`. It is possible to set the access property by package, for example:
+
+```
+Root
+├── Package A - Access set to "public"
+├── Package B - Access set to "restricted"
+└── Package C - No access prop set
+```
+
+- Package A will always be released as "public" no matter Root's value
+- Package B will always be released as "restricted" no matter Root's value
+- Package C will be released as "public" or "restricted" depending on the Root's value, if not set there either, it will be released as "restricted"
 
 ### `workspaces`
 

--- a/packages/sui-mono/src/config.js
+++ b/packages/sui-mono/src/config.js
@@ -21,6 +21,15 @@ const getWorkspaces = workspaces => {
   return paths.map(path => path.replace('/package.json', ''))
 }
 
+const getPublishAccess = ({localPackageConfig = {}, packageConfig = {}}) => {
+  const publishAccess =
+    localPackageConfig['sui-mono']?.access ||
+    packageConfig['sui-mono']?.access ||
+    'restricted'
+
+  return publishAccess
+}
+
 function factoryConfigMethods(packageFile) {
   const {
     config: packageConfig = {},
@@ -28,13 +37,13 @@ function factoryConfigMethods(packageFile) {
     workspaces = []
   } = packageFile
 
-  const {access: publishAccess = 'restricted'} = packageConfig['sui-mono'] || {}
-
   return {
     checkIsMonoPackage: () => workspaces.length === 0,
     getChangelogFilename: () => CHANGELOG_FILENAME,
     getProjectName: () => packageName,
-    getPublishAccess: () => publishAccess,
+    getPublishAccess: ({localPackageConfig = {}}) => {
+      return getPublishAccess({localPackageConfig, packageConfig})
+    },
     getWorkspaces: () => getWorkspaces(workspaces)
   }
 }

--- a/packages/sui-mono/src/config.js
+++ b/packages/sui-mono/src/config.js
@@ -41,7 +41,7 @@ function factoryConfigMethods(packageFile) {
     checkIsMonoPackage: () => workspaces.length === 0,
     getChangelogFilename: () => CHANGELOG_FILENAME,
     getProjectName: () => packageName,
-    getPublishAccess: ({localPackageConfig = {}}) => {
+    getPublishAccess: ({localPackageConfig} = {}) => {
       return getPublishAccess({localPackageConfig, packageConfig})
     },
     getWorkspaces: () => getWorkspaces(workspaces)

--- a/packages/sui-mono/test/server/configSpec.js
+++ b/packages/sui-mono/test/server/configSpec.js
@@ -70,7 +70,7 @@ describe('config', () => {
       expect(getPublishAccess()).to.equal('restricted')
     })
 
-    it('returns the access of the project if private', () => {
+    it('return the access set by the local config over the global config', () => {
       const {getPublishAccess} = factoryConfigMethods({
         config: {
           'sui-mono': {
@@ -79,7 +79,12 @@ describe('config', () => {
         },
         workspaces: ['components/**']
       })
-      expect(getPublishAccess()).to.equal('restricted')
+      const localPackageConfig = {
+        'sui-mono': {
+          access: 'public'
+        }
+      }
+      expect(getPublishAccess({localPackageConfig})).to.equal('public')
     })
   })
 


### PR DESCRIPTION
## Description
There might be repos with restricted and public packages. This repo allows us to use sui-mono config within each package to use its individual access info. In case the current package has no config, it will use the root one, if this one isn't set either it will use `restricted` by default as it did before.

## Example

Check out docs update