### PR TITLE
feat(packages/sui-bundler): Use as target es5 for now

### DIFF
--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -41,6 +41,7 @@ const cssFileName = config.onlyHash
 const webpackConfig = {
   devtool: sourceMap,
   mode: 'production',
+  target: ['web', 'es5'],
   context: path.resolve(process.cwd(), 'src'),
   resolve: {
     alias: {...aliasFromConfig},


### PR DESCRIPTION
Use es5 for generating bundle for now.