### PR TITLE
fix(packages/sui-ssr): prevent errors if project does not have 500 an…

### DIFF
--- a/packages/sui-ssr/compiler/server.js
+++ b/packages/sui-ssr/compiler/server.js
@@ -16,8 +16,8 @@ module.exports = ({outputPath}) => ({
     ...(serverConfig.plugins || []),
     new CopyWebpackPlugin({
       patterns: [
-        {from: '404.html', to: '../public'},
-        {from: '500.html', to: '../public'}
+        {from: '404.html', to: '../public', noErrorOnMissing: true},
+        {from: '500.html', to: '../public', noErrorOnMissing: true}
       ]
     })
   ],


### PR DESCRIPTION
…d 404 html files

<!--- Provide a general summary of your changes in the Title above -->

## Description
If project does not have 500 and 404 html files, CopyWebpackPlugin shows an error. Given those files are optional this scenario should not display an Error
