### PR TITLE
fix(packages/sui-bundler): breaking because of no fallback set

### DIFF
--- a/packages/sui-bundler/webpack.config.lib.js
+++ b/packages/sui-bundler/webpack.config.lib.js
@@ -18,6 +18,13 @@ module.exports = {
     alias: {
       ...aliasFromConfig
     },
+    fallback: {
+      assert: false,
+      fs: false,
+      http: require.resolve('stream-http'),
+      https: require.resolve('https-browserify'),
+      path: false
+    },
     extensions: ['.js', '.json'],
     modules: ['node_modules', path.resolve(process.cwd())]
   },


### PR DESCRIPTION
I got this error when creating a umd library so I just copied productions fallback config

```
ERROR in ../node_modules/@adv-ui/jobs/lib/fetchers/factory.js 1:81-106
Module not found: Error: Can't resolve 'https' in '/Users/jcger/p/frontend-jobs--common/node_modules/@adv-ui/jobs/lib/fetchers'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
	- add a fallback 'resolve.fallback: { "https": require.resolve("https-browserify") }'
	- install 'https-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
	resolve.fallback: { "https": false }
resolve 'https' in '/Users/jcger/p/frontend-jobs--common/node_modules/@adv-ui/jobs/lib/fetchers'
  Parsed request is a module
  using description file: /Users/jcger/p/frontend-jobs--common/node_modules/@adv-ui/jobs/package.json (relative path: ./lib/fetchers)
    Field 'browser' doesn't contain a valid alias configuration
```