### PR TITLE
feat(packages/sui-studio): Support more files besides the index

### DIFF
--- a/packages/sui-studio/src/runtime-mocha/index.js
+++ b/packages/sui-studio/src/runtime-mocha/index.js
@@ -30,7 +30,7 @@ window.__karma__.loaded = () => {}
 const testsFiles = require.context(
   `${__BASE_DIR__}/components/`,
   true,
-  /\.\/(\w+)\/(\w+)\/test\/index.test.(js|jsx)/
+  /\.\/(\w+)\/(\w+)\/test\/(\w+).test.(js|jsx)/
 )
 
 const selectedTestFiles = testsFiles.keys().filter(filterAll)


### PR DESCRIPTION
So, people could use more files to separate tests. `index` would keep working.