### PR TITLE
feat(packages/sui-react-initial-props): redirect support

### DIFF
--- a/packages/sui-react-initial-props/src/ssrComponentWithInitialProps.tsx
+++ b/packages/sui-react-initial-props/src/ssrComponentWithInitialProps.tsx
@@ -1,6 +1,6 @@
 import { renderToNodeStream, renderToString } from 'react-dom/server'
 import InitialPropsContext from './initialPropsContext'
-import {SsrComponentWithInitialPropsParams, InitialProps} from './types'
+import { SsrComponentWithInitialPropsParams, InitialProps } from './types'
 
 const hrTimeToMs = (diff: [number, number]): number => diff[0] * 1e3 + diff[1] * 1e-6
 
@@ -19,9 +19,9 @@ export default async function ssrComponentWithInitialProps ({
 
   const initialProps: InitialProps = await getInitialProps(context, req, res)
   const diffGetInitialProps = process.hrtime(startGetInitialProps)
-  const {__HTTP__: http} = initialProps
+  const { __HTTP__: http } = initialProps
 
-  if (http?.redirectTo) {
+  if (http?.redirectTo !== undefined) {
     return {
       initialProps,
       performance: {

--- a/packages/sui-react-initial-props/src/types.d.ts
+++ b/packages/sui-react-initial-props/src/types.d.ts
@@ -1,7 +1,7 @@
 import { RouteInfo } from '@s-ui/react-router/src/types'
 export * as ReactRouterTypes from '@s-ui/react-router/src/types'
 
-export type InitialProps = {
+export interface InitialProps {
   [key: string]: any
 }
 export interface PageComponentOptions {

--- a/packages/sui-react-initial-props/src/types.d.ts
+++ b/packages/sui-react-initial-props/src/types.d.ts
@@ -1,6 +1,9 @@
 import { RouteInfo } from '@s-ui/react-router/src/types'
 export * as ReactRouterTypes from '@s-ui/react-router/src/types'
 
+export type InitialProps = {
+  [key: string]: any
+}
 export interface PageComponentOptions {
   keepMounted?: boolean
   renderLoading?: (params: GetInitialPropsClientFunctionParams) => React.ElementType

--- a/packages/sui-react-initial-props/src/withInitialProps.tsx
+++ b/packages/sui-react-initial-props/src/withInitialProps.tsx
@@ -1,7 +1,11 @@
 import { useContext, useEffect, useRef, useState } from 'react'
 import SUIContext from '@s-ui/react-context'
 import { RouteInfo } from '@s-ui/react-router/src/types'
-import { ClientPageComponent, WithInitialPropsComponent } from './types'
+import {
+  ClientPageComponent,
+  WithInitialPropsComponent,
+  InitialProps
+} from './types'
 
 const INITIAL_PROPS_KEY = '__INITIAL_PROPS__'
 
@@ -67,12 +71,19 @@ export default (Page: ClientPageComponent): WithInitialPropsComponent => {
           setState({ initialProps, isLoading: true })
         }
 
-        Page.getInitialProps({ context, routeInfo })
-          .then((initialProps: object) => {
-            setState({ initialProps, isLoading: false })
+        Page.getInitialProps({context, routeInfo})
+          .then((initialProps: InitialProps) => {
+            const {__HTTP__: http} = initialProps
+
+            if (http?.redirectTo) {
+              window.location = http.redirectTo
+              return
+            }
+
+            setState({initialProps, isLoading: false})
           })
           .catch((error: Error) => {
-            setState({ initialProps: { error }, isLoading: false })
+            setState({initialProps: {error}, isLoading: false})
           })
           .finally(() => {
             if (requestedInitialPropsOnceRef.current) return

--- a/packages/sui-react-initial-props/src/withInitialProps.tsx
+++ b/packages/sui-react-initial-props/src/withInitialProps.tsx
@@ -71,19 +71,19 @@ export default (Page: ClientPageComponent): WithInitialPropsComponent => {
           setState({ initialProps, isLoading: true })
         }
 
-        Page.getInitialProps({context, routeInfo})
+        Page.getInitialProps({ context, routeInfo })
           .then((initialProps: InitialProps) => {
-            const {__HTTP__: http} = initialProps
+            const { __HTTP__: http } = initialProps
 
-            if (http?.redirectTo) {
+            if (http?.redirectTo !== undefined) {
               window.location = http.redirectTo
               return
             }
 
-            setState({initialProps, isLoading: false})
+            setState({ initialProps, isLoading: false })
           })
           .catch((error: Error) => {
-            setState({initialProps: {error}, isLoading: false})
+            setState({ initialProps: { error }, isLoading: false })
           })
           .finally(() => {
             if (requestedInitialPropsOnceRef.current) return


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR:
- Avoid rendering page in Server-Side if `redirectTo` is defined. Besides saving time, this change avoids type errors since normally when performing a redirect no props are defined. See example:
```js
Page.getInitialProps = () => {
  if (!name) {
    return {
      __HTTP__: { // This will work in Client-Side and Server-Side
        redirectTo: '/path'
      }
    }
  }
  
  return {name}
}
```
- Add redirect support in Client-Side. Initially we are using `window.location` but we could also use the router in the future if needed.

We will add tests in the next pair programming session. Made with:
- @rmoralp 
- @jmanrumartinez 

## Beta
You can try it out installing the following beta package
- `@s-ui/react-initial-props@2.21.0-beta.0`

## Related Issue
None

## Example
See example above