### PR TITLE
feat(packages/sui-domain): Add a way to globally intercept errors on all axios instances

### DIFF
--- a/packages/sui-domain/README.md
+++ b/packages/sui-domain/README.md
@@ -78,6 +78,39 @@ export default class UserRepositoriesFactory {
 }
 ```
 
+## Fetcher exceptions interception
+
+Aditionally, it's possible to require a special version of the http fetcher with which is possible to intercept all errors in one single point of the application. 
+
+This feature allows to handle generic http errors in a central and unique function of the web application. 
+
+For example, this could be useful if it's needed to perform any specific action every time a `401` status code is retrieved as a result of an http request. (i.e. to redirect the user back to the login page)
+
+### How to require the interceptable fetcher
+
+To be able to use this feature, instead of initializing the fetcher normally, it is needed to invoke the following method of the `FetcherFactory` class:
+
+```javascript
+FetcherFactory.interceptableHttpFetcher()
+```
+
+The `interceptableHttpFetcher` is fully retrocompatible with the standard `httpFetcher` class, so there is no need to adapt anything before doing this change.
+
+### Setting a function to intercept errors
+
+Once the `interceptableHttpFetcher` has been required and is being used to perform http requests, it's possible to set a function that will be invoked every time an error occurs when performing an http request.
+
+This is the way the callback function can be defined:
+
+```javascript
+fetcher.setErrorInterceptor({callback: (error) => {
+  if (result.isAxiosError === true) {
+      const statusCode = result.response.status
+      // Do something...
+  }
+}})
+```
+
 ## Using a domain object
 
 ```javascript

--- a/packages/sui-domain/README.md
+++ b/packages/sui-domain/README.md
@@ -84,17 +84,17 @@ Aditionally, it's possible to require a special version of the http fetcher with
 
 This feature allows to handle generic http errors in a central and unique function of the web application. 
 
-For example, this could be useful if it's needed to perform any specific action every time a `401` status code is retrieved as a result of an http request. (i.e. to redirect the user back to the login page)
+For example, this could be useful if it's needed to perform a specific action every time a `401` status code is retrieved as a result of an http request. (i.e. to redirect the user back to the login page)
 
 ### How to require the interceptable fetcher
 
 To be able to use this feature, instead of initializing the fetcher normally, it is needed to invoke the following method of the `FetcherFactory` class:
 
 ```javascript
-FetcherFactory.interceptableHttpFetcher()
+const fetcher = FetcherFactory.interceptableHttpFetcher()
 ```
 
-The `interceptableHttpFetcher` is fully retrocompatible with the standard `httpFetcher` class, so there is no need to adapt anything before doing this change.
+The `interceptableHttpFetcher` is fully retrocompatible with the standard `httpFetcher` class, so there is no need to adapt any code before doing this change.
 
 ### Setting a function to intercept errors
 

--- a/packages/sui-domain/src/fetcher/AxiosFetcher.js
+++ b/packages/sui-domain/src/fetcher/AxiosFetcher.js
@@ -9,57 +9,6 @@ export default class AxiosFetcher {
    */
   constructor({config}) {
     this._axios = axios.create(config)
-    this._initInterceptors()
-  }
-
-  /**
-   * Initializes interceptors
-   */
-  _initInterceptors() {
-    this._axios.interceptors.response.use(
-      this._interceptResponse,
-      this._interceptError
-    )
-  }
-
-  /**
-   * Intercepts all responses and, in case an interceptor has been defined, calls it
-   * @param {Object} response
-   * @returns {Object}
-   */
-  _interceptResponse(response) {
-    if (AxiosFetcher.responseInterceptor !== undefined)
-      AxiosFetcher.responseInterceptor(response)
-
-    return response
-  }
-
-  /**
-   * Intercepts all errors and, in case an interceptor has been defined, calls it
-   * @param {Error} error
-   * @returns {Error}
-   */
-  _interceptError(error) {
-    if (AxiosFetcher.errorInterceptor !== undefined)
-      AxiosFetcher.errorInterceptor(error)
-
-    return error
-  }
-
-  /**
-   * Defines which function will be called when an error occurs
-   * @param {Function} interceptor
-   */
-  setErrorInterceptor(interceptor) {
-    AxiosFetcher.errorInterceptor = interceptor
-  }
-
-  /**
-   * Defines which function will be called when a response is received
-   * @param {Function} interceptor
-   */
-  setResponseInterceptor(interceptor) {
-    AxiosFetcher.responseInterceptor = interceptor
   }
 
   /**

--- a/packages/sui-domain/src/fetcher/AxiosFetcher.js
+++ b/packages/sui-domain/src/fetcher/AxiosFetcher.js
@@ -9,6 +9,57 @@ export default class AxiosFetcher {
    */
   constructor({config}) {
     this._axios = axios.create(config)
+    this._initInterceptors()
+  }
+
+  /**
+   * Initializes interceptors
+   */
+  _initInterceptors() {
+    this._axios.interceptors.response.use(
+      this._interceptResponse,
+      this._interceptError
+    )
+  }
+
+  /**
+   * Intercepts all responses and, in case an interceptor has been defined, calls it
+   * @param {Object} response
+   * @returns {Object}
+   */
+  _interceptResponse(response) {
+    if (AxiosFetcher.responseInterceptor !== undefined)
+      AxiosFetcher.responseInterceptor(response)
+
+    return response
+  }
+
+  /**
+   * Intercepts all errors and, in case an interceptor has been defined, calls it
+   * @param {Error} error
+   * @returns {Error}
+   */
+  _interceptError(error) {
+    if (AxiosFetcher.errorInterceptor !== undefined)
+      AxiosFetcher.errorInterceptor(error)
+
+    return error
+  }
+
+  /**
+   * Defines which function will be called when an error occurs
+   * @param {Function} interceptor
+   */
+  setErrorInterceptor(interceptor) {
+    AxiosFetcher.errorInterceptor = interceptor
+  }
+
+  /**
+   * Defines which function will be called when a response is received
+   * @param {Function} interceptor
+   */
+  setResponseInterceptor(interceptor) {
+    AxiosFetcher.responseInterceptor = interceptor
   }
 
   /**

--- a/packages/sui-domain/src/fetcher/FetcherInterceptor.js
+++ b/packages/sui-domain/src/fetcher/FetcherInterceptor.js
@@ -1,0 +1,148 @@
+/** @typedef {import('./InterceptableFetcherInterface').default} InterceptableFetcherInterface */
+/** @implements {InterceptableFetcherInterface} */
+export default class FetcherInterceptor {
+  _fetcher
+  static errorInterceptor = null
+
+  /**
+   * @param {object} deps
+   * @param {FetcherInterface} deps.fetcher
+   */
+  constructor({fetcher}) {
+    this._fetcher = fetcher
+  }
+
+  /**
+   * Checks if the result contains a promise
+   * @param {object} result
+   * @returns
+   */
+  _isPromiseType(result) {
+    return typeof result === 'object' && 'then' in result
+  }
+
+  /**
+   * Replaces the original result with a promise to intercept exceptions
+   * @param {object} deps
+   * @param {object} deps.originalResult
+   * @returns
+   */
+  _interceptResult({originalResult}) {
+    let result = originalResult
+
+    if (this._isPromiseType(result)) {
+      result = new Promise((resolve, reject) =>
+        this._catchExceptions({resolve, reject, originalResult})
+      )
+    }
+
+    return result
+  }
+
+  /**
+   * Catches exceptions on the original result and calls the error interceptor
+   * @param {object} deps
+   * @param {object} deps.originalResult
+   * @param {object} deps.reject
+   * @param {object} deps.resolve
+   */
+  async _catchExceptions({originalResult, resolve, reject}) {
+    try {
+      const response = await originalResult
+      resolve(response)
+    } catch (error) {
+      if (
+        FetcherInterceptor.errorInterceptor !== null &&
+        typeof FetcherInterceptor.errorInterceptor === 'function'
+      ) {
+        FetcherInterceptor.errorInterceptor(error)
+      }
+
+      reject(error)
+    }
+  }
+
+  /**
+   * Defines the function to be called when an error is intercepted
+   * @param {object} deps
+   * @param {object} deps.callback
+   * @returns
+   */
+  setErrorInterceptor({callback}) {
+    FetcherInterceptor.errorInterceptor = callback
+  }
+
+  /**
+   * Unsets the function called when an error is intercepted
+   */
+  unsetErrorInterceptor() {
+    FetcherInterceptor.errorInterceptor = null
+  }
+
+  /**
+   * Get method
+   * @param {String} url
+   * @param {Object} options
+   * @return {Promise<any>}
+   */
+  get(url, options) {
+    const originalResult = this._fetcher.get(url, options)
+    const result = this._interceptResult({originalResult})
+    return result
+  }
+
+  /**
+   * Post method
+   * @method post
+   * @param {String} url
+   * @param {String} body
+   * @param {Object} options
+   * @return {Promise}
+   */
+  post(url, body, options) {
+    const originalResult = this._fetcher.post(url, body, options)
+    const result = this._interceptResult({originalResult})
+    return result
+  }
+
+  /**
+   * Put method
+   * @method put
+   * @param {String} url
+   * @param {String} body
+   * @param {Object} options
+   * @return {Object}
+   */
+  put(url, body, options) {
+    const originalResult = this._fetcher.put(url, body, options)
+    const result = this._interceptResult({originalResult})
+    return result
+  }
+
+  /**
+   * Patch method
+   * @method patch
+   * @param {String} url
+   * @param {String} body
+   * @param {Object} options
+   * @return {Object}
+   */
+  patch(url, body, options) {
+    const originalResult = this._fetcher.patch(url, body, options)
+    const result = this._interceptResult({originalResult})
+    return result
+  }
+
+  /**
+   * Delete method
+   * @method delete
+   * @param {String} url
+   * @param {Object} options
+   * @return {Object}
+   */
+  delete(url, options) {
+    const originalResult = this._fetcher.delete(url, options)
+    const result = this._interceptResult({originalResult})
+    return result
+  }
+}

--- a/packages/sui-domain/src/fetcher/FetcherInterface.d.ts
+++ b/packages/sui-domain/src/fetcher/FetcherInterface.d.ts
@@ -4,6 +4,4 @@ export default interface FetcherInterface {
   patch: (url: string, body: string, options: object) => Promise<any>
   post: (url: string, body: string, options: object) => Promise<any>
   put: (url: string, body: string, options: object) => Promise<any>
-  setErrorInterceptor: (callback: Function) => void
-  setResponseInterceptor: (callback: Function) => void
 }

--- a/packages/sui-domain/src/fetcher/FetcherInterface.d.ts
+++ b/packages/sui-domain/src/fetcher/FetcherInterface.d.ts
@@ -1,7 +1,9 @@
 export default interface FetcherInterface {
+  delete: (url: string, options: object) => Promise<any>
   get: (url: string, options: object) => Promise<any>
+  patch: (url: string, body: string, options: object) => Promise<any>
   post: (url: string, body: string, options: object) => Promise<any>
   put: (url: string, body: string, options: object) => Promise<any>
-  patch: (url: string, body: string, options: object) => Promise<any>
-  delete: (url: string, options: object) => Promise<any>
+  setErrorInterceptor: (callback: Function) => void
+  setResponseInterceptor: (callback: Function) => void
 }

--- a/packages/sui-domain/src/fetcher/InterceptableFetcherInterface.d.ts
+++ b/packages/sui-domain/src/fetcher/InterceptableFetcherInterface.d.ts
@@ -1,0 +1,6 @@
+/** @typedef {import('./FetcherInterface').default} FetcherInterface */
+/** @extends {FetcherInterface} */
+export default interface InterceptableFetcherInterface {
+  setErrorInterceptor: (callback: Function) => void
+  unsetErrorInterceptor: () => void
+}

--- a/packages/sui-domain/src/fetcher/factory.js
+++ b/packages/sui-domain/src/fetcher/factory.js
@@ -1,5 +1,11 @@
 import AxiosFetcher from './AxiosFetcher.js'
+import FetcherInterceptor from './FetcherInterceptor.js'
 
 export default class FetcherFactory {
+  static interceptableHttpFetcher = ({config}) =>
+    new FetcherInterceptor({
+      fetcher: new AxiosFetcher({config})
+    })
+
   static httpFetcher = ({config}) => new AxiosFetcher({config})
 }

--- a/packages/sui-domain/test/common/FetcherInterceptorSpec.js
+++ b/packages/sui-domain/test/common/FetcherInterceptorSpec.js
@@ -1,0 +1,61 @@
+import {expect} from 'chai'
+import sinon from 'sinon'
+import FetcherInterceptor from '../../src/fetcher/FetcherInterceptor.js'
+
+describe('FetcherInterceptor', () => {
+  const interceptableMockedFetcher = statusCode => {
+    return {
+      get: async () => {
+        if (statusCode !== 200)
+          throw new Error(`HTTP simulated error: ${statusCode}`)
+
+        return 'It works!'
+      }
+    }
+  }
+
+  it('should return the expected value if no error occurs', async () => {
+    const fetcher = new FetcherInterceptor({
+      config: {},
+      fetcher: interceptableMockedFetcher(200)
+    })
+
+    // Do not encapsulate inside a try-catch: If it fails test should be considered failed
+    const result = await fetcher.get('/')
+
+    expect(result).to.eql('It works!')
+  })
+
+  it('should return errors to the original caller even if using the FetcherInterceptor wrapper', async () => {
+    const fetcher = new FetcherInterceptor({
+      config: {},
+      fetcher: interceptableMockedFetcher(401)
+    })
+
+    try {
+      await fetcher.get('/')
+    } catch (error) {
+      expect(error.message).to.eql(`HTTP simulated error: 401`)
+    }
+  })
+
+  it('should call the error interceptor when a exception occurs', async () => {
+    const fetcher = new FetcherInterceptor({
+      config: {},
+      fetcher: interceptableMockedFetcher(401)
+    })
+
+    const callback = sinon.spy()
+    fetcher.setErrorInterceptor({callback})
+
+    try {
+      await fetcher.get('/')
+    } catch (error) {
+      expect(error.message).to.eql(`HTTP simulated error: 401`)
+    }
+
+    expect(callback.called).to.be.true
+    const result = callback.firstCall.args[0]
+    expect(result).to.be.instanceOf(Error)
+  })
+})


### PR DESCRIPTION
This `PR` introduces a way to intercept all http responses and errors ocurred while using any `fetcher ` from the `sui-domain` package, by defining one single function that will be called every time an http error occurs.

## Description

### Why?

Recently in COCHES NET PRO, we needed a way to handle all http errors ocurred in all requests, to handle 401 status codes and redirect the user back to the login page when their token expired or became invalid.

Our first approach was to intercept errors by creating a facade class inside our domain package, that wrapped the sui-domain fetcher. 

This class, which we called `FetcherInterceptor`, exposed the same methods than the sui fetcher, and intercepted all errors ocurred during any http request, notifying them to a function in charge of error handling.

However, although this solution worked for us, our colleague @tomcask suggested us to implement something similar directly on the sui fetcher, in order to increase reusability.

### Why not using Axios Interceptors?

We wanted a solution decoupled from the final fetcher library, so if on a future we decide to use other third-party libraries that doesn't include interceptor features, we'll be sure that it doesn't affect to exceptions interception capabilities, and it won't require to implement interception logic every time a new fetcher is implemented.

### This suggestion

This PR suggests a way to wrap the standard `httpFetcher` inside a new class named `FetcherInterceptor`. This class, exposes the same methods than an standard fetcher, and ads two more: One to define the an error handle (the function that will be called if an error occurs), and another one to unset the error handler.

With these changes, two fetchers are exported: The standard `httpFetcher` and a new `interceptableHttpFetcher`, which is the one encapsulated by the `FetcherInterceptor` class.

## Related Issue

#[MTR-51774](https://jira.scmspain.com/browse/MTR-51774)

## Example

**How this works in COCHES NET PRO?**

We use an structure similar to this:

![image](https://user-images.githubusercontent.com/16169223/160793376-0a3d09af-e887-421a-8875-2490e1ee31f3.png)

We have a single point in our web app in where we are able to intercept generic http errors. Mainly used nowadays to handle 401 errors.

This is an example of how a repository defines which function will intercept errors:

```
  interceptErrors({interceptHttpExceptionsRequest}) {
    const callback = interceptHttpExceptionsRequest.getCallback()
    this._fetcher._httpFetcher.setErrorInterceptor({callback})
  }
```

## Special Thanks ❤️

A lot of people contributed by planning this implementation and by giving ideas and feedback... (Apologies if I forget someone)

@tomcask 
@kikoruiz 
@davidmartin84 
@jordevo 
