### PR TITLE
fix(packages/sui-mono): url construction before check changes to release

### DIFF
--- a/packages/sui-mono/package.json
+++ b/packages/sui-mono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/mono",
-  "version": "2.22.1-beta.0",
+  "version": "2.22.0",
   "description": "Commit and release manager",
   "main": "index.js",
   "bin": {

--- a/packages/sui-mono/package.json
+++ b/packages/sui-mono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/mono",
-  "version": "2.22.0",
+  "version": "2.22.1-beta.0",
   "description": "Commit and release manager",
   "main": "index.js",
   "bin": {

--- a/packages/sui-mono/src/check.js
+++ b/packages/sui-mono/src/check.js
@@ -43,6 +43,8 @@ const flatten = status =>
     {increment: PACKAGE_VERSION_INCREMENT.NOTHING, commits: []}
   )
 
+const getPkgFromScope = scope => (scope === 'Root' ? '.' : scope)
+
 const check = () =>
   new Promise(resolve => {
     /**
@@ -67,9 +69,10 @@ const check = () =>
         preset: 'angular',
         append: true,
         transform: (commit, cb) => {
-          if (!packagesWithChangelog.includes(commit.scope)) return cb()
+          const pkg = getPkgFromScope(commit.scope)
 
-          const pkg = commit.scope
+          if (!packagesWithChangelog.includes(pkg)) return cb()
+
           let toPush = null
 
           if (COMMIT_TYPES_WITH_RELEASE.includes(commit.type)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When a repo is monopackage and there are changes to release, `commit.scope` from `conventional-changelog` has "Root" value, and we need to convert it to a valid package path to check changes.
