### PR TITLE
fix(packages/sui-lint): fix sass format error in prettier

### DIFF
--- a/packages/sui-lint/package.json
+++ b/packages/sui-lint/package.json
@@ -36,7 +36,7 @@
     "eslint-plugin-react": "7.29.4",
     "eslint": "8.12.0",
     "postcss-scss": "4.0.3",
-    "prettier": "2.6.1",
+    "prettier": "2.6.2",
     "stylelint-config-prettier": "9.0.3",
     "stylelint-config-recommended-scss": "6.0.0",
     "stylelint-prettier": "2.0.0",


### PR DESCRIPTION
Apply a fix from `pettier`: https://github.com/prettier/prettier/blob/main/CHANGELOG.md#fix-lessscss-format-error-12536-by-fisker