### PR TITLE
Fix/link package with double quotes import

### DIFF
--- a/packages/sui-bundler/loaders/LinkLoader.js
+++ b/packages/sui-bundler/loaders/LinkLoader.js
@@ -2,7 +2,9 @@ const LIB_PATH = '/lib'
 
 const createMatchTransformer = linkedPackagePath => match => {
   // we have to detect if the last char is a quote or /lib to add the correct suffix
-  const suffix = match[match.length - 1] === "'" ? "'" : LIB_PATH
+  const lastChar = match[match.length - 1]
+  const nextLastChat = lastChar === "'" ? "'" : '"'
+  const suffix = lastChar === nextLastChat ? nextLastChat : LIB_PATH
   return `${linkedPackagePath}${suffix}`.replace('/src/lib', '/src')
 }
 
@@ -19,7 +21,7 @@ function linkLoader(source) {
     // create a regex for detecting if the package is used in the source
     // we have to check if it ends with quote (normal import)
     // or with /lib, as we might be importing a submodule of a package
-    const regex = new RegExp(`${prefix}${pkg}(\\${LIB_PATH}|')`, 'g')
+    const regex = new RegExp(`${prefix}${pkg}(\\${LIB_PATH}|"|')`, 'g')
     // create a function that will be used when match ocurred
     const transformMatch = createMatchTransformer(packagesToLink[pkg])
     // replace all the uses of the package by using the function

--- a/packages/sui-bundler/test/server/linkLoaderSpec.js
+++ b/packages/sui-bundler/test/server/linkLoaderSpec.js
@@ -3,7 +3,7 @@ const {expect} = require('chai')
 const linkLoader = require('../../loaders/LinkLoader.js')
 
 describe('LinkLoader', () => {
-  it('Should rewrite the source code for JS files in the root', async () => {
+  it('Single quotes: Should rewrite the source code for JS files in the root', async () => {
     const nextSource = linkLoader.call(
       {
         query: {
@@ -19,7 +19,23 @@ describe('LinkLoader', () => {
     expect(nextSource).to.be.eql("require('/User/Developer/sui/module/src')")
   })
 
-  it('Should rewrite the source code for JS files for a deeper route', async () => {
+  it('Double quotes: Should rewrite the source code for JS files in the root', async () => {
+    const nextSource = linkLoader.call(
+      {
+        query: {
+          entryPoints: {
+            '@s-ui/module': '/User/Developer/sui/module/src'
+          }
+        },
+        request: 'file.js'
+      },
+      'require("@s-ui/module")'
+    )
+
+    expect(nextSource).to.be.eql('require("/User/Developer/sui/module/src")')
+  })
+
+  it('Single quotes: Should rewrite the source code for JS files for a deeper route', async () => {
     const nextSource = linkLoader.call(
       {
         query: {
@@ -37,7 +53,25 @@ describe('LinkLoader', () => {
     )
   })
 
-  it('Should rewrite the source code for SASS files in the root', async () => {
+  it('Double quotes: Should rewrite the source code for JS files for a deeper route', async () => {
+    const nextSource = linkLoader.call(
+      {
+        query: {
+          entryPoints: {
+            '@s-ui/module': '/User/Developer/sui/module/src'
+          }
+        },
+        request: 'file.js'
+      },
+      'require("@s-ui/module/lib/level/mod.js")'
+    )
+
+    expect(nextSource).to.be.eql(
+      'require("/User/Developer/sui/module/src/level/mod.js")'
+    )
+  })
+
+  it('Single quotes: Should rewrite the source code for SASS files in the root', async () => {
     const nextSource = linkLoader.call(
       {
         query: {
@@ -52,6 +86,24 @@ describe('LinkLoader', () => {
 
     expect(nextSource).to.be.eql(
       '@import "/User/Developer/sui/module/src/index";'
+    )
+  })
+
+  it('Double quotes: Should rewrite the source code for SASS files in the root', async () => {
+    const nextSource = linkLoader.call(
+      {
+        query: {
+          entryPoints: {
+            '@s-ui/module': '/User/Developer/sui/module/src'
+          }
+        },
+        request: 'file.scss'
+      },
+      "@import '~@s-ui/module/lib/index';"
+    )
+
+    expect(nextSource).to.be.eql(
+      "@import '/User/Developer/sui/module/src/index';"
     )
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue description
**Given** link loader was only working for single quotes imports
**And** a we want to link a sub dependency, which parent is compiled and minified using double quotation
Example: Page Ads List (page) > component ListAds (dependency) > component CardAd (sub-dependency)
**Then** link loader was not working

## Solution
This PR enables double quotation imports for linking packages
<img width="842" alt="image" src="https://user-images.githubusercontent.com/5390428/165266112-206367bd-968c-4528-b624-68289a00c220.png">



Thanks @Sabri1209 for reporting it.