### PR TITLE
fix(packages/sui-pde): fix event dispatcher on creating instance

### DIFF
--- a/packages/sui-pde/src/adapters/optimizely/index.js
+++ b/packages/sui-pde/src/adapters/optimizely/index.js
@@ -60,7 +60,7 @@ export default class OptimizelyAdapter {
     sdkKey,
     datafile,
     optimizely = optimizelySDK,
-    eventDispatcher
+    eventDispatcher = optimizelySDK.eventDispatcher
   }) {
     const options = {...DEFAULT_DATAFILE_OPTIONS, ...optionParameter}
     optimizely.setLogLevel(LOGGER_LEVEL)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix the `eventDispatcher` property when initializing Optimizely Instance.

Creating the optimizely instance does not accept an undefined function to dispatch events.
https://docs.developers.optimizely.com/full-stack/docs/configure-event-dispatcher-javascript-node

We must initialize it to the default's optimizely SDK eventDispatcher.
