### PR TITLE
fix(packages/sui-pde): fix feature tests

### DIFF
--- a/packages/sui-pde/src/hooks/useFeature.js
+++ b/packages/sui-pde/src/hooks/useFeature.js
@@ -28,19 +28,21 @@ const trackFeatureFlagViewed = ({
  * @param {function} trackExperimentViewed
  * @param {object} attributes user attributes to take into account for its segmentation
  * @param {object} pde
+ * @param {string} adapterId
  */
 const trackLinkedExperimentsViewed = ({
   linkedExperiments,
   trackExperimentViewed,
   attributes,
-  pde
+  pde,
+  adapterId
 }) => {
   if (!linkedExperiments) return
   linkedExperiments.forEach(experimentName => {
     const variationName = pde.getVariation({
-      experimentName,
-      pde,
-      attributes
+      name: experimentName,
+      attributes,
+      adapterId
     })
     trackExperimentViewed({variationName, experimentName})
   })
@@ -97,7 +99,8 @@ export default function useFeature(
       linkedExperiments,
       trackExperimentViewed: strategy.trackExperiment,
       pde,
-      attributes
+      attributes,
+      adapterId
     })
     return {isActive, variables}
   } catch (error) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Using feature tests (an A/B which is linked to a FF) causes console errors when being activated:

`[OPTIMIZELY] - ERROR 2022-05-19T10:19:19.689Z OPTIMIZELY: Provided experiment_key is in an invalid format.`

This is caused because the tracking function loses the experiment name passing the structured args to the PDE, as `experimentName` was provided for a function which expects the attribute to be `name`


Additionally, the `adapterId` is added to the passed args as it was missing there.