### PR TITLE
chore(packages/sui-bundler): upgrade sass dep to 1.52.3

### DIFF
--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -42,7 +42,7 @@
     "postcss": "8.4.14",
     "postcss-loader": "7.0.0",
     "process": "0.11.10",
-    "sass": "1.52.2",
+    "sass": "1.52.3",
     "stream-http": "3.2.0",
     "strip-ansi": "6.0.1",
     "style-loader": "3.3.1",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Latest upgrade to `sass` `1.52.2` was causing an error on our builds:

```
[1]  @use 'sass:math';$home-categories-base-path: '/home-categories/coches/';
[2]  // Deprecated (sui-theme V7)
[3]  
[4]  
[5]  $m-base: 8px !default;
[6]  $m-v: ceil($m-base); // 8px
[7]  $m-h: $m-base * 2; // 16px
[8]  $m-v-xsmall: ceil(math.div($m-v, 3)); // 3px
[9]  $m-h-xsmall: ceil(math.div($m-h, 3)); // 8px
[10] $m-v-small: ceil($m-v * 0.5); // 4px
----------------------------------------
Error: RangeError: Invalid value: Not in inclusive range 0..128: -1
```

## Related Issue
[Sass issue](https://github.com/sass/dart-sass/issues/1712)

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
