### PR TITLE
Fix some compatibility issues

### DIFF
--- a/packages/sui-test-e2e/bin/sui-test-e2e.js
+++ b/packages/sui-test-e2e/bin/sui-test-e2e.js
@@ -114,7 +114,7 @@ const {
   noWebSecurity,
   parallel,
   record,
-  scope,
+  scope = '/integration/',
   screenshotsOnError,
   userAgent,
   userAgentAppend,

--- a/packages/sui-test-e2e/bin/sui-test-e2e.js
+++ b/packages/sui-test-e2e/bin/sui-test-e2e.js
@@ -29,6 +29,13 @@ const DEFAULT_CYPRESS_CONFIG_FILE_CONTENT = `module.exports = {
   e2e: {} 
 };`
 
+const CYPRESS_CONFIG_FILE_WITH_LEGACY_PLUGINS = `const plugins = require('./plugins/index.js')
+module.exports = {
+  e2e: {
+    setupNodeEvents: plugins
+  } 
+};`
+
 const HELP_MESSAGE = `
   Description:
     Run end-to-end tests with Cypress
@@ -139,10 +146,6 @@ if (existsSync(supportFilesFolderPath)) {
   cypressConfig.e2e.supportFile = supportFilesFolderPath
 }
 
-if (existsSync(pluginsFilesFolderPath)) {
-  cypressConfig.e2e.pluginsFile = pluginsFilesFolderPath
-}
-
 if (userAgent) {
   cypressConfig.userAgent = `"${userAgent}"`
 } else if (userAgentAppend) {
@@ -172,7 +175,10 @@ if (noWebSecurity) cypressConfig.chromeWebSecurity = false
 const configFilePath = join(TESTS_FOLDER, 'cypress.config.js')
 
 if (!existsSync(configFilePath)) {
-  writeFileSync(configFilePath, DEFAULT_CYPRESS_CONFIG_FILE_CONTENT)
+  const configFileContent = existsSync(pluginsFilesFolderPath)
+    ? CYPRESS_CONFIG_FILE_WITH_LEGACY_PLUGINS
+    : DEFAULT_CYPRESS_CONFIG_FILE_CONTENT
+  writeFileSync(configFilePath, configFileContent)
 }
 
 const cypressExecutableConfig = {


### PR DESCRIPTION
Avoid failures when running e2e tests using plugins after updating to the latest `@s-ui/test-e2e` version, and when `scope` parameter is not defined.

## Description

Since Cypress 10, plugins do not have a specific folder where to be stored. Plugins are now stored as part of the cypress config file.

This update, performs a fix in terms of compatibility. When a project is updated from a previous `@s-ui/test-e2e` version, if there's a plugins folder, it's required from the Cypress config file, so it keeps working as usual without any breaking change.

Additionally, before the update, if the scope parameter was not defined, tests were loaded from the `integration` folder. After the upgrade, the `scope` parameter has become mandatory and in case it is not defined, tests execution fails. This PR sets a default value for that parameter to avoid these compatibility issues.

## Example

Fotocasa is using a small Cypress plugin, and they need this change to be able to run it.