### PR TITLE
feat(packages/sui-test-contract): Use SHA as consumer version for PACT contracts

### DIFF
--- a/packages/sui-test-contract/bin/sui-test-contract-publish.js
+++ b/packages/sui-test-contract/bin/sui-test-contract-publish.js
@@ -4,7 +4,6 @@
 
 // See: https://github.com/pact-foundation/pact-js/blob/51d2ae2e41c8c40e373f264ac7ba633d258604c2/examples/e2e/test/publish.js
 
-import {versionFromGitTag} from 'absolute-version'
 import program from 'commander'
 import path from 'node:path'
 
@@ -25,12 +24,18 @@ if (!brokerUrl)
     'You need to specify the broker URL where the contracts will be published.'
   )
 const contractsDir = path.resolve(process.cwd(), 'contract/documents')
-const {TRAVIS_BRANCH, GITHUB_REF} = process.env
+const {
+  GITHUB_REF,
+  GITHUB_SHA,
+  TRAVIS_BRANCH,
+  TRAVIS_COMMIT,
+  TRAVIS_PULL_REQUEST_SHA
+} = process.env
+
 const branch =
   TRAVIS_BRANCH || GITHUB_REF || exec('git rev-parse --abbrev-ref HEAD')
-const consumerVersion = versionFromGitTag({
-  tagGlob: ''
-})
+const consumerVersion = TRAVIS_PULL_REQUEST_SHA || TRAVIS_COMMIT || GITHUB_SHA
+
 const options = {
   pactFilesOrDirs: [contractsDir],
   pactBroker: brokerUrl,

--- a/packages/sui-test-contract/package.json
+++ b/packages/sui-test-contract/package.json
@@ -16,7 +16,6 @@
     "test:server:watch": "npm run test:server -- --watch"
   },
   "dependencies": {
-    "absolute-version": "1.0.1",
     "@pact-foundation/pact": "9.18.1",
     "@pactflow/pact-msw-adapter": "1.2.1",
     "commander": "8.3.0",

--- a/packages/sui-test-contract/src/setup/index.js
+++ b/packages/sui-test-contract/src/setup/index.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
 import {setupServer} from 'msw/node'
+
 import {setupPactMswAdapter} from '@pactflow/pact-msw-adapter'
 
 import {

--- a/packages/sui-test-contract/src/setup/utils.js
+++ b/packages/sui-test-contract/src/setup/utils.js
@@ -1,5 +1,6 @@
-import {writeData2File} from '@pactflow/pact-msw-adapter/dist/utils/utils.js'
 import {stringify} from 'qs'
+
+import {writeData2File} from '@pactflow/pact-msw-adapter/dist/utils/utils.js'
 
 export const writerFactory = providers => (path, data) => {
   const {interactions, provider} = data


### PR DESCRIPTION
Use SHA as Consumer Version instead using the Absolute Version.
