### PR TITLE
Fix/module resolution for ssr

### DIFF
--- a/packages/sui-ssr/compiler/server.js
+++ b/packages/sui-ssr/compiler/server.js
@@ -13,13 +13,8 @@ module.exports = ({outputPath}) => ({
   externals: undefined,
   resolve: {
     ...serverConfig.resolve,
-    modules: [
-      path.join(__dirname, '..', 'server'),
-      path.join(__dirname, '..', 'node_modules'),
-      path.join(process.cwd(), 'src'),
-      path.join(process.cwd(), 'node_modules'),
-      'node_modules'
-    ]
+    mainFields: ['main'],
+    modules: [path.join(process.cwd(), 'src'), 'node_modules']
   },
   node: {
     __filename: true,

--- a/packages/sui-ssr/server/hooksFactory/index.js
+++ b/packages/sui-ssr/server/hooksFactory/index.js
@@ -5,6 +5,7 @@ import {promisify} from 'util'
 // __MAGIC IMPORTS__
 // They came from {SPA}/src
 // import userHooks from 'hooks'
+// this is not a dependency, it will import from project src/routes
 import routes from 'routes'
 
 import {createServerContextFactoryParams} from '@s-ui/react-initial-props'
@@ -15,6 +16,7 @@ import {hrTimeToMs, publicFolder, siteByHost} from '../utils/index.js'
 let userHooks
 let contextFactory
 try {
+  // these are not dependencies, it will import from project src/hooks and src/routes
   userHooks = require('hooks')
   contextFactory = require('contextFactory').default
 } catch (e) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
All our dependency tree was importing their dependencies from root node_modules folder. I break some of our functionalities because dependencies do not use the same subdependencies versions.

With that changes, we will import dependencies scanning node_modules, or looking through its ancestors. If dependency have not been found, it will try to import from root node_modules folder

Beta: `@s-ui/ssr@8.9.0-beta.0`