### PR TITLE
feat(packages/sui-react-context): export useSuiContext hook

### DIFF
--- a/packages/sui-react-context/src/index.tsx
+++ b/packages/sui-react-context/src/index.tsx
@@ -23,4 +23,8 @@ SUIContext.wrapper = (Component, displayName): React.ComponentType<any> => {
   return hoistNonReactStatics(WrappedComponent, Component)
 }
 
+export function useSuiContext (): React.Context<any> {
+  return React.useContext(SUIContext)
+}
+
 export default SUIContext


### PR DESCRIPTION
Expose useSuiContext hook to consume SuiContext.

## Description
A simple abstraction to avoid requiring the SuiContext and the `React.useContext` hook from react on each usage.
Also, being this as named export, the editor will help to identify it while writing and automatically add the import on autocomplete.

## Example

**Before**
```jsx
import {useContext} from 'react'
import Context from '@s-ui/react-context'

function App () {
  const context = useContext(Context)
 
  ...
}
```
**After**
```jsx
import {useSuiContext} from '@s-ui/react-context'

function App () {
  const context = useSuiContext()
 
  ...
}
```

