### PR TITLE
feat(packages/sui-studio): add support for subcomponents context mapping

### DIFF
--- a/packages/sui-studio/README.md
+++ b/packages/sui-studio/README.md
@@ -60,7 +60,7 @@ $ npx sui-studio dev house/window
 
 #### 2) Go to `http://localhost:3000`
 
-#### 3) Commit changes using the appropiate command
+#### 3) Commit changes using the appropriate command
 
 First of all, stage you changes for commit with `git add` or whatever you use.
 
@@ -106,7 +106,7 @@ Launch a development environment where you can see all your components at once. 
 
 ### `$ sui-studio build`
 
-Build a static version of a web app aimed to be deployed, where you will be able to interact with all components. The interface will be the same you use for the start command, only this one is optimized for production.
+Build a static version of a web app aimed to be deployed, where you will be able to interact with all the components. The interface will be the same you use for the start command, only this one is optimized for production.
 
 #### Options
 
@@ -135,7 +135,7 @@ Launch all project tests in a Karma browser.
 
 ### `$ cpx`
 
-This command allow you to copy files from a source to a destination using glob patterns. It's useful to copy files from the source to the build folder.  
+This command allows you to copy files from a source to a destination using glob patterns. It's useful to copy files from the source to the build folder.
 
 #### Examples
 
@@ -170,7 +170,7 @@ describe('AtomButton', () => {
 
 The component will be a global object when running tests, so it is PARAMOUNT NOT to import it. In order to avoid problems with the linter, add relevant comments, as in the example above.
 
-### How works with different SUI contexts
+### How it works with different SUI contexts
 
 If there is a `demo/context.js` file where you define several SUI contexts for your components. You have to apply a patch to Mocha to allow setup describe by context. This allows you to have a "contextify" version of your component, for the context selected.
 
@@ -180,9 +180,9 @@ First, you have to import the patcher to create the `context` object, inside the
 import '@s-ui/studio/src/patcher-mocha'
 ```
 
-After that, you can use the `describe.context` object to has a key by every context definition in your `demo/context.js` file.
+After that, you can use the `describe.context` object to have a key for every context definition in your `demo/context.js` file.
 
-For example, if your context.js file looks like:
+For example, if your `context.js` file looks like:
 
 ```js
 export default () => {
@@ -303,7 +303,7 @@ Options:
   -T, --timeout <timeout>  Timeout
   --coverage               Create coverage (default: false)
   -h, --help               display help for command
-  
+
   Examples:
     $ sui-studio test --headless
     $ sui-studio test --headless --watch
@@ -322,7 +322,7 @@ You could execute some specific tests with the `sui-studio-test` command using `
 
 Some examples:
 
-- For speciffic component: `PATTERN='./ad/card/test/index.test.js' sui-studio test` or `PATTERN='ad/card/test' sui-studio test`
+- For a specific component: `PATTERN='./ad/card/test/index.test.js' sui-studio test` or `PATTERN='ad/card/test' sui-studio test`
 
 - For categories: `PATTERN='{ad,shipping}/*/test' sui-studio test`
 

--- a/packages/sui-studio/README.md
+++ b/packages/sui-studio/README.md
@@ -225,7 +225,7 @@ describe.context.other('atom/button', AtomButton => {
 
 **TLDR: Apply the context exported from the `/demo/context.js` file for React components other than just the ones in `/test/index.test.js`.**
 
-Since you can use the `PATTERN=appraisal/report npm run test:studio` (see #cli-integration-testing) command to test a single studio component and you can have more than one `*.test.js` file inside the `/test` folder, you can use the following to test more than one component and apply to it the React Context exported from the `/demo/context.js` file.
+Since you can use the `PATTERN=appraisal/report npm run test:studio` (see [the section on cli testing](#cli-integration-testing)) command to test a single studio component and you can have more than one `*.test.js` file inside the `/test` folder, you can use the following to test more than one component and apply to it the React Context exported from the `/demo/context.js` file.
 
 #### Example `/test` folder tree structure
 

--- a/packages/sui-studio/src/components/tryRequire.js
+++ b/packages/sui-studio/src/components/tryRequire.js
@@ -41,17 +41,33 @@ export const importContexts = ({category, component}) =>
 export const importReactComponent = ({
   category,
   component,
+  subComponentName = null,
   extractDefault = false
-}) =>
-  safeImport({
+}) => {
+  if (typeof subComponentName === 'string') {
+    return safeImport({
+      extractDefault,
+      importFile: () => {
+        return import(
+          /* webpackChunkName: "src-component-[request]" */
+          /* webpackExclude: /\/node_modules\/(.*)\/src\/(.*)\/index.js$/ */
+          `${__BASE_DIR__}/components/${category}/${component}/src/${subComponentName}/index.js`
+        )
+      }
+    })
+  }
+
+  return safeImport({
     extractDefault,
-    importFile: () =>
-      import(
+    importFile: () => {
+      return import(
         /* webpackChunkName: "src-[request]" */
         /* webpackExclude: /\/node_modules\/(.*)\/src\/index.js$/ */
         `${__BASE_DIR__}/components/${category}/${component}/src/index.js`
       )
+    }
   })
+}
 
 const importDemo = ({category, component}) =>
   safeImport({


### PR DESCRIPTION
# Overview

Apply the context exported from the `/demo/context.js` file for React components other than just the ones in `/test/index.test.js`. 

## Description

Right now the React context exported from `/demo/context.js` is only applied to test files inside `/test/index.test.js`. Since we can now have multiple files inside the `/test` folder of a component by using commands such as: 

```sh
❯ PATTERN=appraisal/report npm run test:studio:ci:watch
```

With this PR we can set the context in files that use the following naming system:

```js
components.{componentName}.test.js
```

### Example tests folder tree

```sh
test
├── components.AgencyEvaluationForm.test.js
├── components.AgencyEvaluationInfo.test.js
└── index.test.js
```

This way the Component used in all 3 files will have the exported context from `/demo/context.js` applied.

### Reasoning behind `components.{componentName}.test.js`

I used this naming system because several components inside Fotocasa and Fotocasa PRO already have files other than `index.test.js` that are used for testing functions that are not React components. For example, a test for a `sum(a, b)` function that checks if the addition is working fine.

With this approach we have a way to define subcomponent tests that don't conflict with other test files that don't test React components.

## Example

**Example PR in frontend-fc--web-server that uses this feature**:
- https://github.mpi-internal.com/scmspain/frontend-fc--web-server/pull/3949

This feature is based on the `'@s-ui/studio/src/patcher-mocha'` package that can use a `componentKey`:

```js
...
get(target /* describe.context */, contextToUse /* context name */) {
    return function (title, cb, componentKey) {
      const originalFn = global[FUNCTION_TO_PATCH]

      const Component =
        global.__STUDIO_COMPONENT__[componentKey] || global.__STUDIO_COMPONENT__
...
```

If we provide this component key in a way that matches the naming system we can set the context for subcomponents.

```js
// /test/components.AgencyEvaluationInfo.test.js

/* global setupEnvironment */
import '@s-ui/studio/src/patcher-mocha'

import chai, {expect} from 'chai'
import chaiDOM from 'chai-dom'
import {ProvidersWrapper} from 'utils'

chai.use(chaiDOM)

const COMPONENT_KEY = 'appraisal/report/src/AgencyEvaluationInfo'

describe.context.default(
  'AgencyEvaluationInfo',
  describeCallback,
  COMPONENT_KEY
)

function describeCallback(AgencyEvaluationInfo) {
  const WrappedComponent = props => (
    <ProvidersWrapper>
      <AgencyEvaluationInfo {...props} />
    </ProvidersWrapper>
  )

  const setup = setupEnvironment(WrappedComponent)

  const baseProps = {}

  it('should render the pdf link', async () => {
    // Given
    const props = {...baseProps}
    const linkText = 'Informe de ejemplo'

    // When
    const {findByRole} = setup(props)
    const pdfLink = await findByRole('link', {name: linkText})

    // Then
    expect(pdfLink).to.have.text('Ver informe de ejemplo')
  })
}
```