### PR TITLE
fix(packages/sui-test-contract): fix branch name with travis env

### DIFF
--- a/packages/sui-test-contract/bin/sui-test-contract-publish.js
+++ b/packages/sui-test-contract/bin/sui-test-contract-publish.js
@@ -27,13 +27,17 @@ const contractsDir = path.resolve(process.cwd(), 'contract/documents')
 const {
   GITHUB_REF,
   GITHUB_SHA,
+  TRAVIS_PULL_REQUEST_BRANCH,
   TRAVIS_BRANCH,
   TRAVIS_COMMIT,
   TRAVIS_PULL_REQUEST_SHA
 } = process.env
 
 const branch =
-  TRAVIS_BRANCH || GITHUB_REF || exec('git rev-parse --abbrev-ref HEAD')
+  TRAVIS_PULL_REQUEST_BRANCH ||
+  TRAVIS_BRANCH ||
+  GITHUB_REF ||
+  exec('git rev-parse --abbrev-ref HEAD')
 const consumerVersion = TRAVIS_PULL_REQUEST_SHA || TRAVIS_COMMIT || GITHUB_SHA
 
 const options = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`TRAVIS_BRANCH`

- for push builds, or builds not triggered by a pull request, this is the name of the branch.
- **for builds triggered by a pull request this is the name of the branch targeted by the pull request.** ⚠️
- for builds triggered by a tag, this is the same as the name of the tag (TRAVIS_TAG).

`TRAVIS_PULL_REQUEST_BRANCH`

- if the current job is a pull request, the name of the branch from which the PR originated.
- if the current job is a push build, this variable is empty ("").

Source: [Travis docs](https://docs.travis-ci.com/user/environment-variables/)

## Related Issue
TRAVIS_BRANCH does not work as expected for Pull Request builds
