### PR TITLE
docs(packages/sui-studio): fix the readme cli section url

### DIFF
--- a/packages/sui-studio/README.md
+++ b/packages/sui-studio/README.md
@@ -225,7 +225,7 @@ describe.context.other('atom/button', AtomButton => {
 
 **TLDR: Apply the context exported from the `/demo/context.js` file for React components other than just the ones in `/test/index.test.js`.**
 
-Since you can use the `PATTERN=appraisal/report npm run test:studio` (see [the section on cli testing](#cli-integration-testing)) command to test a single studio component and you can have more than one `*.test.js` file inside the `/test` folder, you can use the following to test more than one component and apply to it the React Context exported from the `/demo/context.js` file.
+Since you can use the `PATTERN=appraisal/report npm run test:studio` (see [the section on cli testing](#cli-testing-integration)) command to test a single studio component and you can have more than one `*.test.js` file inside the `/test` folder, you can use the following to test more than one component and apply to it the React Context exported from the `/demo/context.js` file.
 
 #### Example `/test` folder tree structure
 


### PR DESCRIPTION
Fix a section link in the s-ui/studio README.

## Description

Fixes the section link in the s-ui/studio README for the CLI Testing Integration info.