### PR TITLE
feat(packages/sui-studio): Add new param to use explicit import

### DIFF
--- a/packages/sui-studio/README.md
+++ b/packages/sui-studio/README.md
@@ -46,6 +46,14 @@ Use `-C path` or `--context path` parameter to generate the component with a giv
 $ npx sui-studio generate house window -C ./myCustomContext.js
 ```
 
+#### Explicit import
+
+Use `-E` or `--explicit` parameter to generate a component in a file with its same name and an index re-export.
+
+```sh
+$ npx sui-studio generate house window -E
+```
+
 ### Use new compiler
 
 We're migrating to `swc` so you could generate the new component with the expected `prepare` field by using the flag `--swc` or `-W`.

--- a/packages/sui-studio/bin/sui-studio-generate.js
+++ b/packages/sui-studio/bin/sui-studio-generate.js
@@ -53,7 +53,7 @@ const componentInPascal = toPascalCase(
 const COMPONENT_DIR = `/components/${category}/${component}/`
 const COMPONENT_PATH = `${BASE_DIR}${COMPONENT_DIR}`
 const COMPONENT_ENTRY_JS_POINT_FILE = `${COMPONENT_PATH}src/index.js`
-const COMPONENT_JS_POINT_FILE = `${COMPONENT_PATH}src/${componentInPascal}.js`
+const EXPLICIT_COMPONENT_JS_POINT_FILE = `${COMPONENT_PATH}src/${componentInPascal}.js`
 const COMPONENT_PACKAGE_JSON_FILE = `${COMPONENT_PATH}package.json`
 const COMPONENT_PACKAGE_GITIGNORE_FILE = `${COMPONENT_PATH}.gitignore`
 const COMPONENT_PACKAGE_NPMIGNORE_FILE = `${COMPONENT_PATH}.npmignore`
@@ -249,7 +249,7 @@ test
     explicit ? explicitImportTemplate : componentTemplate
   ),
 
-  explicit && writeFile(COMPONENT_JS_POINT_FILE, componentTemplate),
+  explicit && writeFile(EXPLICIT_COMPONENT_JS_POINT_FILE, componentTemplate),
 
   writeFile(
     COMPONENT_ENTRY_SCSS_POINT_FILE,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds a new option `--explicit` to generate a component in a file with its same name and an index re-export, this makes searching easier while keeping cleaner imports. 

```
Component
  src
    |--Component.js
    |--index.js
```

Beta: @s-ui/studio@11.21.0-beta.0

Feedback is much appreciated 🙂
