### PR TITLE
fix(packages/sui-studio): exclude all node_modules src files

### DIFF
--- a/packages/sui-studio/src/components/tryRequire.js
+++ b/packages/sui-studio/src/components/tryRequire.js
@@ -50,7 +50,7 @@ export const importReactComponent = ({
       importFile: () => {
         return import(
           /* webpackChunkName: "src-component-[request]" */
-          /* webpackExclude: /\/node_modules\/(.*)\/src\/(.*)\/index.js$/ */
+          /* webpackExclude: /\/node_modules\/(.*)\/src\/(.*)$/ */
           `${__BASE_DIR__}/components/${category}/${component}/src/${subComponentName}/index.js`
         )
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Prevent bundle unexpected files, for example:
```bash
./components/ lazy ^\.\/.*\/index\.js$ exclude: \/node_modules\/(.*)\/src\/(.*)\/index.js$ chunkName: src-component-[request] namespace object ./content/account/node_modules/react-dropzone/src/index.js
```

Beta for testing purposes: @s-ui/studio@11.22.0-beta.0