### PR TITLE
Chore/isolate playwright dep

### DIFF
--- a/packages/sui-ssr/package.json
+++ b/packages/sui-ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/ssr",
-  "version": "8.9.0",
+  "version": "8.10.0-beta.0",
   "description": "> Plug SSR to you SUI SPA.",
   "main": "index.js",
   "bin": {
@@ -24,7 +24,7 @@
     }
   },
   "dependencies": {
-    "@s-ui/critical-css": "1",
+    "@s-ui/critical-css-middleware": "1",
     "@s-ui/hoc": "1",
     "@tunnckocore/execa": "5.2.7",
     "archiver": "5.3.0",

--- a/packages/sui-ssr/package.json
+++ b/packages/sui-ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/ssr",
-  "version": "8.10.0-beta.0",
+  "version": "8.9.0",
   "description": "> Plug SSR to you SUI SPA.",
   "main": "index.js",
   "bin": {

--- a/packages/sui-ssr/server/middlewares/criticalCss.js
+++ b/packages/sui-ssr/server/middlewares/criticalCss.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 const parser = require('ua-parser-js')
-const getCriticalCssMiddleware = require('@s-ui/critical-css/src/middleware.cjs')
+const getCriticalCssMiddleware = require('@s-ui/critical-css-middleware')
 const {criticalDir, criticalManifest} = require('../utils/index.js')
 
 const criticalCssMiddleware = (req, res, next) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Import `criticalCssMiddleware` directly from `sui-critical-css-middleware` and avoid install `sui-critical-css` in `sui-ssr`
It will avoid that `sui-ssr` installs playwright (a >8Mb dependency)
