### PR TITLE
feat(packages/sui-mono): move skip flag before commit msg

### DIFF
--- a/packages/sui-mono/bin/sui-mono-release.js
+++ b/packages/sui-mono/bin/sui-mono-release.js
@@ -81,10 +81,8 @@ const releasePackage = async ({pkg, code, skipCi} = {}) => {
   const packageScope = isMonoPackage ? 'Root' : pkg.replace(path.sep, '/')
 
   const cwd = isMonoPackage ? BASE_DIR : path.join(process.cwd(), pkg)
-  const {
-    private: isPrivatePackage,
-    config: localPackageConfig
-  } = getPackageJson(cwd, true)
+  const {private: isPrivatePackage, config: localPackageConfig} =
+    getPackageJson(cwd, true)
 
   await exec(`npm --no-git-tag-version version ${RELEASE_CODES[code]}`, {cwd})
   await exec(`git add ${path.join(cwd, 'package.json')}`, {cwd})

--- a/packages/sui-mono/bin/sui-mono-release.js
+++ b/packages/sui-mono/bin/sui-mono-release.js
@@ -81,8 +81,10 @@ const releasePackage = async ({pkg, code, skipCi} = {}) => {
   const packageScope = isMonoPackage ? 'Root' : pkg.replace(path.sep, '/')
 
   const cwd = isMonoPackage ? BASE_DIR : path.join(process.cwd(), pkg)
-  const {private: isPrivatePackage, config: localPackageConfig} =
-    getPackageJson(cwd, true)
+  const {
+    private: isPrivatePackage,
+    config: localPackageConfig
+  } = getPackageJson(cwd, true)
 
   await exec(`npm --no-git-tag-version version ${RELEASE_CODES[code]}`, {cwd})
   await exec(`git add ${path.join(cwd, 'package.json')}`, {cwd})
@@ -91,9 +93,8 @@ const releasePackage = async ({pkg, code, skipCi} = {}) => {
 
   // Add [skip ci] to the commit message to avoid CI build
   // https://docs.travis-ci.com/user/customizing-the-build/#skipping-a-build
-  const commitMsg = `release(${packageScope}): v${version}${
-    skipCi ? ' [skip ci]' : ''
-  }`
+  const skipCiPrefix = skipCi ? '[skip ci] ' : ''
+  const commitMsg = `${skipCiPrefix}release(${packageScope}): v${version}`
 
   await exec(`git commit -m "${commitMsg}"`, {cwd})
 


### PR DESCRIPTION
# Move `[skip-ci]` before release commit to complain Ledger

## Description

We have found some metrics in Accelerate can be affected by some bot contributors in commits/releases. Here it’s [an example of an affected accelerate metric](https://github.mpi-internal.com/scmspain/frontend-fc--web-server/commit/910659f65ccc3eca4aef1577edbca8aa369b078b).

<img width="1445" alt="image" src="https://user-images.githubusercontent.com/3933098/190622230-642ce9fb-7f63-4fce-9adb-75d199835603.png">

As you can see [on this Pull Request](https://github.mpi-internal.com/scmspain/frontend-fc--web-server/commit/910659f65ccc3eca4aef1577edbca8aa369b078b), we have a [parent commit](https://github.mpi-internal.com/scmspain/frontend-fc--web-server/commit/077de986d7d0cc8158a33a72e7947a562337975d) done by a bot. And this commit has a comment with a `[skip-ci]` tag at the end of the message. Nevertheless, we can see at [Ledger documentation](https://docs.mpi-internal.com/common-platform/ledger/02-technical-reference/10-accelerate-metrics/lead-time/), to complain the Accelerate metrics the `[skip-ci]` flag must be at the beginning of the commit message.

Otherwise at [Travis documentation](https://docs.travis-ci.com/user/customizing-the-build/#skipping-a-build), there is no specification for Travis to require this `[skip-ci]` tag to be in a specific position:

So the proposal is to move the `[skip-ci]` tag at the beginning of the commit message.

@jelowin also contributed on this