### PR TITLE
fix(packages/sui-mono): add skip-ci as suffix

### DIFF
--- a/packages/sui-mono/bin/sui-mono-release.js
+++ b/packages/sui-mono/bin/sui-mono-release.js
@@ -91,8 +91,8 @@ const releasePackage = async ({pkg, code, skipCi} = {}) => {
 
   // Add [skip ci] to the commit message to avoid CI build
   // https://docs.travis-ci.com/user/customizing-the-build/#skipping-a-build
-  const skipCiPrefix = skipCi ? '[skip ci] ' : ''
-  const commitMsg = `${skipCiPrefix}release(${packageScope}): v${version}`
+  const skipCiSuffix = skipCi ? ' [skip ci]' : ''
+  const commitMsg = `release(${packageScope}): v${version}${skipCiSuffix}`
 
   await exec(`git commit -m "${commitMsg}"`, {cwd})
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Rollback this change https://github.com/SUI-Components/sui/commit/24763e652256613eef4d46460c206963def09e74
PR https://github.com/SUI-Components/sui/pulls?q=is%3Apr+is%3Aclosed

If we add `[skip ci]` as a prefix, we break commit naming convention and conventional-changelog does not work as expected with angular preset
