### PR TITLE
feat(packages/sui-mono): add "refactor" as commit type with release

### DIFF
--- a/packages/sui-mono/src/check.js
+++ b/packages/sui-mono/src/check.js
@@ -18,14 +18,18 @@ const PACKAGE_VERSION_INCREMENT = {
   MAJOR: 3
 }
 
-const COMMIT_TYPES_WITH_RELEASE = ['fix', 'feat', 'perf', 'refactor']
-
 const isCommitBreakingChange = commit => {
   const {body, footer} = commit
 
   return [body, footer].some(
     msg => typeof msg === 'string' && msg.includes('BREAKING CHANGE')
   )
+}
+
+const COMMIT_TYPES_WITH_RELEASE = ['fix', 'feat', 'perf', 'refactor']
+
+const isCommitReleaseTrigger = commit => {
+  return COMMIT_TYPES_WITH_RELEASE.includes(commit.type)
 }
 
 const flattenForMonopackage = status =>
@@ -75,7 +79,7 @@ const check = () =>
 
           let toPush = null
 
-          if (COMMIT_TYPES_WITH_RELEASE.includes(commit.type)) {
+          if (isCommitReleaseTrigger(commit)) {
             status[pkg].increment = Math.max(
               status[pkg].increment,
               PACKAGE_VERSION_INCREMENT.MINOR
@@ -111,5 +115,6 @@ const check = () =>
 
 module.exports = {
   check,
-  isCommitBreakingChange
+  isCommitBreakingChange,
+  isCommitReleaseTrigger
 }

--- a/packages/sui-mono/src/check.js
+++ b/packages/sui-mono/src/check.js
@@ -18,7 +18,7 @@ const PACKAGE_VERSION_INCREMENT = {
   MAJOR: 3
 }
 
-const COMMIT_TYPES_WITH_RELEASE = ['fix', 'feat', 'perf']
+const COMMIT_TYPES_WITH_RELEASE = ['fix', 'feat', 'perf', 'refactor']
 
 const isCommitBreakingChange = commit => {
   const {body, footer} = commit

--- a/packages/sui-mono/src/check.js
+++ b/packages/sui-mono/src/check.js
@@ -26,9 +26,8 @@ const isCommitBreakingChange = commit => {
   )
 }
 
-const COMMIT_TYPES_WITH_RELEASE = ['fix', 'feat', 'perf', 'refactor']
-
 const isCommitReleaseTrigger = commit => {
+  const COMMIT_TYPES_WITH_RELEASE = ['fix', 'feat', 'perf', 'refactor']
   return COMMIT_TYPES_WITH_RELEASE.includes(commit.type)
 }
 

--- a/packages/sui-mono/test/server/checkSpec.js
+++ b/packages/sui-mono/test/server/checkSpec.js
@@ -1,6 +1,9 @@
 import {expect} from 'chai'
 
-import {isCommitBreakingChange} from '../../src/check.js'
+import {
+  isCommitBreakingChange,
+  isCommitReleaseTrigger
+} from '../../src/check.js'
 
 describe('check', () => {
   describe('isCommitBreakingChange', () => {
@@ -10,6 +13,32 @@ describe('check', () => {
 
     it('returns false if commit is not breaking change', () => {
       expect(isCommitBreakingChange({footer: ''})).to.equal(false)
+    })
+  })
+
+  describe('isCommitReleaseTrigger', () => {
+    it('returns true if commit is of type feat', () => {
+      expect(isCommitReleaseTrigger({type: 'feat'})).to.equal(true)
+    })
+
+    it('returns true if commit is of type fix', () => {
+      expect(isCommitReleaseTrigger({type: 'fix'})).to.equal(true)
+    })
+
+    it('returns true if commit is of type perf', () => {
+      expect(isCommitReleaseTrigger({type: 'perf'})).to.equal(true)
+    })
+
+    it('returns true if commit is of type refactor', () => {
+      expect(isCommitReleaseTrigger({type: 'refactor'})).to.equal(true)
+    })
+
+    it('returns false if commit is of type chore', () => {
+      expect(isCommitReleaseTrigger({type: 'chore'})).to.equal(false)
+    })
+
+    it('returns false if commit is of type test', () => {
+      expect(isCommitReleaseTrigger({type: 'test'})).to.equal(false)
     })
   })
 


### PR DESCRIPTION
## Description
`refactor` type of commits will now trigger a new release. 

## Related Issue
#1478 

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
