### PR TITLE
refactor(packages/sui-studio): Improve navigation of the header

### DIFF
--- a/packages/sui-studio/src/components/demo/_style.scss
+++ b/packages/sui-studio/src/components/demo/_style.scss
@@ -2,6 +2,7 @@
   display: flex;
   flex: 1;
   flex-direction: column;
+  padding: 16px;
 
   &-codeButton,
   &-fullScreenButton {

--- a/packages/sui-studio/src/components/layout/Logo.js
+++ b/packages/sui-studio/src/components/layout/Logo.js
@@ -1,4 +1,4 @@
-import {getStudioLogo} from '@s-ui/studio/src/components/utils'
+import {getStudioLogo} from '../utils'
 
 export default () => (
   <picture

--- a/packages/sui-studio/src/components/layout/Logo.js
+++ b/packages/sui-studio/src/components/layout/Logo.js
@@ -1,4 +1,4 @@
-import {getStudioLogo} from '../utils'
+import {getStudioLogo} from '@s-ui/studio/src/components/utils'
 
 export default () => (
   <picture

--- a/packages/sui-studio/src/components/layout/_style.scss
+++ b/packages/sui-studio/src/components/layout/_style.scss
@@ -10,10 +10,9 @@
   &-sidebar {
     @include breakpoint-from(s) {
       flex: 0 0 $w-sidebar;
-      // transform: translate3d(0, 0, 0);
       width: $w-sidebar;
     }
-    top: $h-navHeader + 4;
+    top: $t-sidebar-and-main;
     background-color: $c-white;
     border-right: 1px solid $c-gray-lightest;
     box-sizing: border-box;
@@ -38,7 +37,7 @@
   &-main {
     background-color: $bgc-main;
     position: relative;
-    top: $h-navHeader + 4;
+    top: $t-sidebar-and-main;
     width: 100%;
     margin-left: 0;
     min-height: 100vh;

--- a/packages/sui-studio/src/components/layout/_style.scss
+++ b/packages/sui-studio/src/components/layout/_style.scss
@@ -1,6 +1,5 @@
 .sui-Studio {
   display: flex;
-
   &-logo {
     & > svg {
       height: auto;
@@ -11,9 +10,10 @@
   &-sidebar {
     @include breakpoint-from(s) {
       flex: 0 0 $w-sidebar;
-      transform: translate3d(0, 0, 0);
+      // transform: translate3d(0, 0, 0);
+      width: $w-sidebar;
     }
-
+    top: $h-navHeader + 4;
     background-color: $c-white;
     border-right: 1px solid $c-gray-lightest;
     box-sizing: border-box;
@@ -21,10 +21,9 @@
     overflow-x: hidden;
     overflow-y: scroll;
     position: fixed;
-    transform: translate3d(-100%, 0, 0);
+    transform: translate3d(0, 0, 0);
     transition: transform 0.5s ease-in-out;
-    z-index: 9998;
-    width: $w-sidebar;
+    z-index: 50;
 
     &Body {
       width: $w-sidebar;
@@ -32,21 +31,27 @@
     }
 
     &--open {
-      display: block;
-      transform: translate3d(0, 0, 0);
+      transform: translate3d(-100%, 0, 0);
     }
   }
 
   &-main {
     background-color: $bgc-main;
+    position: relative;
+    top: $h-navHeader + 4;
     width: 100%;
     margin-left: 0;
     min-height: 100vh;
     transition: width 0.5s ease-in-out, margin-left 0.5s ease-in-out;
+    z-index: 30;
     @include breakpoint-from(s) {
       width: calc(100% - #{$w-sidebar});
       margin-left: $w-sidebar;
       transition: width 0.5s ease-in-out, margin-left 0.5s ease-in-out;
+    }
+    &--open {
+      width: 100%;
+      margin-left: 0;
     }
   }
 
@@ -67,7 +72,7 @@
   background: $c-white;
   display: flex;
   flex-direction: row;
-  padding: 0 16px;
+  padding: 0;
 }
 
 .sui-StudioPreview,
@@ -97,11 +102,37 @@
     margin-top: 8px;
   }
 }
-
-.sui-Studio-navMenu {
-  @include floating-button($c-primary, 56px, 8px);
-  @include breakpoint-from(s) {
-    display: none;
+.sui-Studio-navHeader {
+  width: 100%;
+  padding: 0 8px;
+  display: flex;
+  height: $h-navHeader;
+  position: fixed;
+  top: 0;
+  background: $c-white;
+  align-items: center;
+  border-bottom: solid 1px $c-gray-lightest;
+  z-index: 40;
+  gap: 8px;
+  a {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    text-decoration: none;
+    color: #000;
   }
-  z-index: 9999;
+  h1 {
+    font-size: 16px;
+    margin: 0;
+    display: flex;
+  }
+}
+.sui-Studio-navMenu {
+  display: flex;
+  width: 32px;
+  height: 32px;
+  background: transparent;
+  border: 0;
+  align-items: center;
+  justify-content: center;
 }

--- a/packages/sui-studio/src/components/layout/index.js
+++ b/packages/sui-studio/src/components/layout/index.js
@@ -3,10 +3,13 @@ import React, {useEffect, useState} from 'react'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 
+import {Link} from '@s-ui/react-router'
+
 import Markdown from '../documentation/Markdown.js'
-import {iconClose, iconMenu} from '../icons/index.js'
+import {iconMenu} from '../icons/index.js'
 import Navigation from '../navigation/index.js'
 import {fetchComponentsReadme} from '../tryRequire.js'
+import Logo from './Logo.js'
 
 export default function Layout({children}) {
   const [readme, setReadme] = useState(null)
@@ -30,19 +33,28 @@ export default function Layout({children}) {
     'sui-Studio-sidebar--open': menuIsOpen
   })
 
+  const mainClassName = cx('sui-Studio-main', {
+    'sui-Studio-main--open': menuIsOpen
+  })
+
   return (
     <section className="sui-Studio">
-      <button className="sui-Studio-navMenu" onClick={handleClickMenu}>
-        {menuIsOpen ? iconClose : iconMenu}
-      </button>
-
+      <div className="sui-Studio-navHeader">
+        <button className="sui-Studio-navMenu" onClick={handleClickMenu}>
+          {iconMenu}
+        </button>
+        <Link to="/">
+          <Logo />
+          <h1>SUI Components</h1>
+        </Link>
+      </div>
       <aside className={sidebarClassName}>
         <div className="sui-Studio-sidebarBody">
           <Navigation handleClick={() => setMenuIsOpen(false)} />
         </div>
       </aside>
 
-      <div className="sui-Studio-main">
+      <div className={mainClassName}>
         {children !== null ? children : renderReadme()}
       </div>
     </section>

--- a/packages/sui-studio/src/components/navigation/_style.scss
+++ b/packages/sui-studio/src/components/navigation/_style.scss
@@ -1,39 +1,39 @@
 .sui-StudioNav {
+  padding: 16px;
   &-header {
     align-items: center;
     display: flex;
-    height: 65px;
-    padding: 16px;
+    height: 64px;
     text-decoration: none;
     box-sizing: border-box;
   }
 
   &-searchInput {
-    border: 1px solid $c-gray-lightest;
-    border-radius: 15px;
+    border: 1px solid $c-gray-light;
+    border-radius: 4px;
     color: #666;
     font-size: 12px;
-    margin: 0 5%;
     outline: none;
-    padding: 4px 4px 4px 8px;
-    width: 80%;
+    padding: 8px;
+    width: 100%;
 
     &:focus {
       background-color: $c-white;
-      border: 1px solid $c-gray-light;
+      border: 1px solid $c-primary;
     }
   }
 
   &-menu {
     list-style: none;
-    padding-left: 16px;
+    padding-left: 0;
     margin: 0;
 
     &Link {
       border-left: 1px solid #e4e4e4;
       color: $c-gray-dark;
       display: block;
-      padding: 5px 16px;
+      padding: 12px;
+      font-size: 16px;
       text-decoration: none;
       transition: all 0.3s ease;
       &:hover {

--- a/packages/sui-studio/src/components/navigation/index.js
+++ b/packages/sui-studio/src/components/navigation/index.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types'
 import {Link} from '@s-ui/react-router'
 
 import {getComponentsList} from '../utils.js'
-import Logo from './Logo.js'
 
 const componentsList = getComponentsList()
 
@@ -66,15 +65,11 @@ export default function Navigation({handleClick}) {
 
   return (
     <nav className="sui-StudioNav">
-      <Link className="sui-StudioNav-header" onClick={handleClick} to="/">
-        <Logo />
-      </Link>
-
       <input
         className="sui-StudioNav-searchInput"
         onChange={handleChange}
         onFocus={handleFocus}
-        placeholder="🔎 Search component..."
+        placeholder="Search"
         type="search"
         value={search}
       />

--- a/packages/sui-studio/src/components/workbench/_style.scss
+++ b/packages/sui-studio/src/components/workbench/_style.scss
@@ -2,5 +2,6 @@
   &-navigation {
     background: $c-white;
     padding: 16px;
+    border-bottom: solid 1px $c-gray-lightest;
   }
 }

--- a/packages/sui-studio/src/styles/_settings.scss
+++ b/packages/sui-studio/src/styles/_settings.scss
@@ -82,6 +82,7 @@ $w-sidebar: 220px;
 $w-sidebar-collapsed: 48px;
 
 $h-navHeader: 48px;
+$t-sidebar-and-main: 52px;
 
 @mixin breakpoint-from($floor) {
   $breakpoint: map-get($breakpoints, $floor);

--- a/packages/sui-studio/src/styles/_settings.scss
+++ b/packages/sui-studio/src/styles/_settings.scss
@@ -74,13 +74,14 @@ $breakpoints: (
   xl: 1200px
 ) !default;
 
-$bgc-main: #f5f5f5;
-
+$bgc-main: $c-white;
 $fgc-navbar: #999;
 $fgc-navbar--active: $c-white;
 
 $w-sidebar: 220px;
 $w-sidebar-collapsed: 48px;
+
+$h-navHeader: 48px;
 
 @mixin breakpoint-from($floor) {
   $breakpoint: map-get($breakpoints, $floor);


### PR DESCRIPTION
Improve side panel navigation and header, especially for mobile

ISSUES CLOSED: #1490

## Description
The current navigation has a poor UX.
The side panel navigation and the header in Mobile were not optimal in SUI Studio.

* The button to show and hide the drawer is hidden on scroll
* The header is not fixed on top hence the user needs to scroll all the way up every time to change a component
* The font-size was too small
* The menu can't be collapsed on desktop
* etc

## Related Issue
[#1490](https://github.com/SUI-Components/sui/issues/1490)

## Before and after screenshots

**BEFORE**
![before](https://user-images.githubusercontent.com/23620759/194775544-1acebcac-e6ee-41e3-890a-b1a2f642c8e6.png)

**AFTER**

https://user-images.githubusercontent.com/23620759/194775906-132d7b5a-1bca-4771-a211-f447b96b1a4e.mov

https://user-images.githubusercontent.com/23620759/194775559-5cedaaf4-7b8c-4fbb-a11b-39aaa08a3f0f.mov

