### PR TITLE
docs(packages/sui-studio): Improve and standardise hierarchy of texts

### DIFF
--- a/packages/sui-studio/src/components/documentation/markdown.css
+++ b/packages/sui-studio/src/components/documentation/markdown.css
@@ -302,55 +302,6 @@
   cursor: pointer;
 }
 
-.markdown-body h1,
-.markdown-body h2,
-.markdown-body h3,
-.markdown-body h4,
-.markdown-body h5,
-.markdown-body h6 {
-  margin-bottom: 0;
-  margin-top: 0;
-}
-
-.markdown-body h1 {
-  font-size: 32px;
-}
-
-.markdown-body h1,
-.markdown-body h2 {
-  font-weight: 600;
-}
-
-.markdown-body h2 {
-  font-size: 24px;
-}
-
-.markdown-body h3 {
-  font-size: 20px;
-}
-
-.markdown-body h3,
-.markdown-body h4 {
-  font-weight: 600;
-}
-
-.markdown-body h4 {
-  font-size: 16px;
-}
-
-.markdown-body h5 {
-  font-size: 14px;
-}
-
-.markdown-body h5,
-.markdown-body h6 {
-  font-weight: 600;
-}
-
-.markdown-body h6 {
-  font-size: 12px;
-}
-
 .markdown-body p {
   margin-bottom: 10px;
   margin-top: 0;
@@ -571,41 +522,31 @@
 .markdown-body h4,
 .markdown-body h5,
 .markdown-body h6 {
-  font-weight: 600;
+  font-weight: normal;
   line-height: 1.25;
-  margin-bottom: 16px;
-  margin-top: 24px;
+  padding-bottom: 0.4em;
 }
 
 .markdown-body h1 {
-  font-size: 2em;
-}
-
-.markdown-body h1,
-.markdown-body h2 {
+  font-size: 2.25em;
   border-bottom: 1px solid #eaecef;
-  padding-bottom: 0.3em;
 }
 
 .markdown-body h2 {
-  font-size: 1.5em;
+  font-size: 0.875em;
+  font-weight: bold;
+  margin-top: 56px;
+  text-transform: uppercase;
 }
 
 .markdown-body h3 {
-  font-size: 1.25em;
-}
-
-.markdown-body h4 {
   font-size: 1em;
 }
 
-.markdown-body h5 {
-  font-size: 0.875em;
-}
-
+.markdown-body h4,
+.markdown-body h5,
 .markdown-body h6 {
-  color: #6a737d;
-  font-size: 0.85em;
+  font-size: 0.875em;
 }
 
 .markdown-body ol,
@@ -690,11 +631,12 @@
 }
 
 .markdown-body code {
-  background-color: rgba(27, 31, 35, 0.05);
-  border-radius: 3px;
-  font-size: 85%;
+  background-color: #f6f8fa;
+  border-radius: 2px;
+  font-size: 0.875em;
   margin: 0;
   padding: 0.2em 0.4em;
+  color: #ff2688;
 }
 
 .markdown-body pre {

--- a/packages/sui-studio/src/components/layout/_style.scss
+++ b/packages/sui-studio/src/components/layout/_style.scss
@@ -12,7 +12,7 @@
       flex: 0 0 $w-sidebar;
       width: $w-sidebar;
     }
-    top: $t-sidebar-and-main;
+    top: $h-navHeader;
     background-color: $c-white;
     border-right: 1px solid $c-gray-lightest;
     box-sizing: border-box;
@@ -22,7 +22,7 @@
     position: fixed;
     transform: translate3d(0, 0, 0);
     transition: transform 0.5s ease-in-out;
-    z-index: 50;
+    z-index: 1;
 
     &Body {
       width: $w-sidebar;
@@ -37,12 +37,11 @@
   &-main {
     background-color: $bgc-main;
     position: relative;
-    top: $t-sidebar-and-main;
+    top: $h-navHeader;
     width: 100%;
     margin-left: 0;
     min-height: 100vh;
     transition: width 0.5s ease-in-out, margin-left 0.5s ease-in-out;
-    z-index: 30;
     @include breakpoint-from(s) {
       width: calc(100% - #{$w-sidebar});
       margin-left: $w-sidebar;
@@ -72,11 +71,12 @@
   display: flex;
   flex-direction: row;
   padding: 0;
+  margin-bottom: 16px;
 }
 
-.sui-StudioPreview,
 .sui-StudioDocumentation {
   padding: 16px;
+  font-size: 16px;
 }
 
 .sui-Studio-readme {

--- a/packages/sui-studio/src/components/navigation/_style.scss
+++ b/packages/sui-studio/src/components/navigation/_style.scss
@@ -32,8 +32,8 @@
       border-left: 1px solid #e4e4e4;
       color: $c-gray-dark;
       display: block;
-      padding: 12px;
-      font-size: 16px;
+      padding: 8px 16px;
+      font-size: 14px;
       text-decoration: none;
       transition: all 0.3s ease;
       &:hover {

--- a/packages/sui-studio/src/components/workbench/_style.scss
+++ b/packages/sui-studio/src/components/workbench/_style.scss
@@ -4,4 +4,37 @@
     padding: 16px;
     border-bottom: solid 1px $c-gray-lightest;
   }
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-weight: normal;
+    line-height: 1.25;
+    padding-bottom: 0.4em;
+  }
+
+  h1 {
+    font-size: 2.25em;
+    border-bottom: 1px solid #eaecef;
+    margin-top: 0;
+  }
+
+  h2 {
+    font-size: 0.875em;
+    font-weight: bold;
+    margin-top: 56px;
+    text-transform: uppercase;
+  }
+
+  h3 {
+    font-size: 1em;
+  }
+
+  h4,
+  h5,
+  h6 {
+    font-size: 0.875em;
+  }
 }

--- a/packages/sui-studio/src/styles/_default.scss
+++ b/packages/sui-studio/src/styles/_default.scss
@@ -1,4 +1,4 @@
 body {
   font-family: $ff-sans-serif;
-  font-size: $fz-body;
+  font-size: $fz-body !important; // to force it even if infoJobs has a different rule in their theme
 }


### PR DESCRIPTION
Improve and standardise the hierarchy of the different tabs of Studio

ISSUES CLOSED: #1493

## Description

All elements should use the documentation library. It's pretty good chaos at this moment.
https://github.com/SUI-Components/docs-components

### Definition of done (DOD)

All elements of the different tabs should look like they belong to the same universe, check the images below, i.e. the tab "readme" is using a plain H1, very different from the tab Changelog.

## Result

❌ As it was until now
![As it was originally](https://user-images.githubusercontent.com/23620759/195095298-7245b626-5f9b-46ad-ae1a-4dbb177881f2.png)

✅ This is how it looks like after this PR

![Result of this PR](https://user-images.githubusercontent.com/23620759/195095349-88323f5e-cbd7-4f45-aee1-e8f72930e146.png)

## Related Issue
[<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->](https://github.com/SUI-Components/sui/issues/1493)

### Additional info
The styles of Studio need a HUGE review, I've just changed the very minimum, but it would be nice to give it a huge love