### PR TITLE
feat(packages/sui-domain): allow inject logger from outside

### DIFF
--- a/packages/sui-domain/README.md
+++ b/packages/sui-domain/README.md
@@ -21,24 +21,21 @@ $ npm install @s-ui/domain --save
 ## Using EntryPoint
 
 ```javascript
-import { EntryPointFactory } from '@s-ui/domain'
+import {EntryPointFactory} from '@s-ui/domain'
 
 // useCases is an object with a key with the name of the use case
 // and an array with a function to import the factory and the
 // useCase name as string
 const useCases = {
-  'current_user': [
-    () => import('./user/UseCases/factory'),
-    'currentUserUseCase'
-    ],
-  'products_search': [
+  current_user: [() => import('./user/UseCases/factory'), 'currentUserUseCase'],
+  products_search: [
     () => import('./search/UseCases/factory'),
     'productsSearchUseCase'
-    ],
-  'real_estate_detail': [
+  ],
+  real_estate_detail: [
     () => import('./detail/UseCases/factory'),
     'realEstateDetailUseCase'
-    ]
+  ]
 }
 
 // config could be a simple object or a more complicated
@@ -48,14 +45,52 @@ const config = {
 }
 
 // that returns you an instantiable EntryPoint class
-const EntryPoint = EntryPointFactory({ config, useCases })
+const EntryPoint = EntryPointFactory({config, useCases})
 const domain = new EntryPoint()
 
 // if you don't want to share the config between instances
 // you could pass the config directly to the constructor
 // useful if you're mutating the config for storing values
-const EntryPoint = EntryPointFactory({ useCases })
-const domain = new EntryPoint({ config })
+const EntryPoint = EntryPointFactory({useCases})
+const domain = new EntryPoint({config})
+```
+
+### Injecting a logger to our domain
+
+In order to increase the observability of your domain, you can pass a custom logger to your domain instance and it will be injected on each UseCase factory. Following the example of previous section:
+
+#### How to inject the logger to your domain?
+
+```javascript
+// Logger mock example
+const logger = {
+  log: () => console.log('⚠️')
+}
+
+const EntryPoint = EntryPointFactory({config, useCases, logger})
+const domain = new EntryPoint()
+```
+
+#### How use it on your domain?
+
+```javascript
+// Your factory file
+import EmptyUseCase from './EmptyUseCase.js'
+
+export default ({config, logger}) => new EmptyUseCase({config, logger})
+
+// Your UseCase implementation
+export default class UseCase {
+  constructor({config, logger}) {
+    this._config = config
+    this._logger = logger
+  }
+
+  execute() {
+    this._logger.log() // Logger ready to rock! 🎸
+    return Promise.resolve(true)
+  }
+}
 ```
 
 ## Using Fetcher
@@ -80,9 +115,9 @@ export default class UserRepositoriesFactory {
 
 ## Fetcher exceptions interception
 
-Aditionally, it's possible to require a special version of the http fetcher with which is possible to intercept all errors in one single point of the application. 
+Aditionally, it's possible to require a special version of the http fetcher with which is possible to intercept all errors in one single point of the application.
 
-This feature allows to handle generic http errors in a central and unique function of the web application. 
+This feature allows to handle generic http errors in a central and unique function of the web application.
 
 For example, this could be useful if it's needed to perform a specific action every time a `401` status code is retrieved as a result of an http request. (i.e. to redirect the user back to the login page)
 
@@ -103,12 +138,14 @@ Once the `interceptableHttpFetcher` has been required and is being used to perfo
 This is the way the callback function can be defined:
 
 ```javascript
-fetcher.setErrorInterceptor({callback: (error) => {
-  if (result.isAxiosError === true) {
+fetcher.setErrorInterceptor({
+  callback: error => {
+    if (result.isAxiosError === true) {
       const statusCode = result.response.status
       // Do something...
+    }
   }
-}})
+})
 ```
 
 ## Using a domain object

--- a/packages/sui-domain/src/EntryPointFactory.js
+++ b/packages/sui-domain/src/EntryPointFactory.js
@@ -1,14 +1,15 @@
 import createNotImplementedUseCase from './createNotImplementedUseCase.js'
 
-export default ({useCases, config}) =>
+export default ({useCases, config, logger}) =>
   class EntryPoint {
     subscribers = {}
 
-    constructor(params = {config: {}}) {
+    constructor(params = {config: {}, logger: {}}) {
       // decide to use a static config from the factory
       // or use a config passed to the constructor that could be mutated
       this._config = config || params.config
       this._useCases = useCases
+      this._logger = logger || params.logger
     }
 
     /**
@@ -50,7 +51,10 @@ export default ({useCases, config}) =>
               // load async the factory, execute use case and return the promise
               return loader()
                 .then(factory =>
-                  getMethod(factory)({config: this._config}).execute(params)
+                  getMethod(factory)({
+                    config: this._config,
+                    logger: this._logger
+                  }).execute(params)
                 )
                 .then(result => {
                   subscriptionsForUseCase.forEach(fn =>
@@ -88,7 +92,8 @@ export default ({useCases, config}) =>
                     // black magic: mutate the object, very small memory leak but that
                     // makes dispose working async and we need it
                     ret.dispose = getMethod(factory)({
-                      config: this._config
+                      config: this._config,
+                      logger: this._logger
                     }).$.execute.subscribe(onNext, onError).dispose
                   })
                   // return the object that will be mutated async

--- a/packages/sui-domain/test/common/EntryPointSpec.js
+++ b/packages/sui-domain/test/common/EntryPointSpec.js
@@ -1,98 +1,217 @@
 /* eslint-disable no-undef */
 import {expect} from 'chai'
+import sinon from 'sinon'
 
 import {EntryPointFactory} from '../../src/index.js'
 
 const config = {}
+const logger = {
+  log: sinon.spy(),
+  error: sinon.spy(),
+  metric: sinon.spy()
+}
 
 describe('EntryPointFactory', () => {
-  it('should be able to import the whole UseCase factory', async () => {
-    const useCases = {
-      use_case_from_factory_with_multiple_use_cases: [
-        () => import('./fixtures/factoryWithMultipleUseCases.js'),
-        'useCaseOne'
-      ]
-    }
-    const EntryPoint = EntryPointFactory({config, useCases})
-    const domain = new EntryPoint()
+  describe('without logger', () => {
+    it('should be able to import the whole UseCase factory', async () => {
+      const useCases = {
+        use_case_from_factory_with_multiple_use_cases: [
+          () => import('./fixtures/factoryWithMultipleUseCases.js'),
+          'useCaseOne'
+        ]
+      }
+      const EntryPoint = EntryPointFactory({config, useCases})
+      const domain = new EntryPoint()
 
-    const useCase = domain.get('use_case_from_factory_with_multiple_use_cases')
-    const response = await useCase.execute()
+      const useCase = domain.get(
+        'use_case_from_factory_with_multiple_use_cases'
+      )
+      const response = await useCase.execute()
 
-    expect(useCase.execute).to.be.a('function')
-    expect(useCase.$).to.be.an('object')
-    expect(response).to.eql(true)
+      expect(useCase.execute).to.be.a('function')
+      expect(useCase.$).to.be.an('object')
+      expect(response).to.eql(true)
+    })
+
+    it('should be able to import a single UseCase factory', async () => {
+      const useCases = {
+        use_case_from_single_factory_use_case: () =>
+          import('./fixtures/factoryWithSingleUseCase.js')
+      }
+      const EntryPoint = EntryPointFactory({config, useCases})
+      const domain = new EntryPoint()
+
+      const useCase = domain.get('use_case_from_single_factory_use_case')
+      const response = await useCase.execute()
+
+      expect(useCase.execute).to.be.a('function')
+      expect(useCase.$).to.be.an('object')
+      expect(response).to.eql(true)
+    })
+
+    it('should be able to subscribe to useCase execution', done => {
+      const useCases = {
+        use_case_from_single_factory_use_case: () =>
+          import('./fixtures/factoryWithSingleUseCase.js')
+      }
+      const EntryPoint = EntryPointFactory({config, useCases})
+      const domain = new EntryPoint()
+
+      domain
+        .get('use_case_from_single_factory_use_case')
+        .subscribe(({error, result, params}) => {
+          expect(error).to.be.null
+          expect(params).to.deep.equal({foo: 'bar'})
+          expect(result).to.be.true
+          done()
+        })
+
+      domain.get('use_case_from_single_factory_use_case').execute({foo: 'bar'})
+    })
+
+    it('should be able to unsubscribe to useCase subscription', done => {
+      let callCount = 0
+      const useCases = {
+        use_case_from_single_factory_use_case: () =>
+          import('./fixtures/factoryWithSingleUseCase.js')
+      }
+      const EntryPoint = EntryPointFactory({config, useCases})
+      const domain = new EntryPoint()
+
+      const {unsubscribe} = domain
+        .get('use_case_from_single_factory_use_case')
+        .subscribe(({error, result, params}) => {
+          expect(error).to.be.null
+          expect(params).to.deep.equal({foo: 'bar'})
+          expect(result).to.be.true
+          callCount++
+        })
+
+      domain
+        .get('use_case_from_single_factory_use_case')
+        .execute({foo: 'bar'})
+        .then(() => {
+          unsubscribe()
+
+          domain
+            .get('use_case_from_single_factory_use_case')
+            .execute({foo: 'bar'})
+            .then(() => {
+              expect(callCount).to.equal(1)
+              done()
+            })
+            .catch(done)
+        })
+        .catch(done)
+    })
   })
+  describe('with logger', () => {
+    it('should be able to import the whole UseCase factory', async () => {
+      const useCases = {
+        use_case_from_factory_with_multiple_use_cases_and_logger: [
+          () => import('./fixtures/factoryWithMultipleUseCasesAndLogger.js'),
+          'useCaseOne'
+        ]
+      }
+      const EntryPoint = EntryPointFactory({config, useCases, logger})
+      const domain = new EntryPoint()
 
-  it('should be able to import a single UseCase factory', async () => {
-    const useCases = {
-      use_case_from_single_factory_use_case: () =>
-        import('./fixtures/factoryWithSingleUseCase.js')
-    }
-    const EntryPoint = EntryPointFactory({config, useCases})
-    const domain = new EntryPoint()
+      const useCase = domain.get(
+        'use_case_from_factory_with_multiple_use_cases_and_logger'
+      )
+      const response = await useCase.execute()
 
-    const useCase = domain.get('use_case_from_single_factory_use_case')
-    const response = await useCase.execute()
+      expect(useCase.execute).to.be.a('function')
+      expect(useCase.$).to.be.an('object')
+      expect(response).to.eql(true)
+      expect(logger.log.called).to.eql(true)
+      expect(logger.error.called).to.eql(true)
+      expect(logger.metric.called).to.eql(true)
+    })
 
-    expect(useCase.execute).to.be.a('function')
-    expect(useCase.$).to.be.an('object')
-    expect(response).to.eql(true)
-  })
+    it('should be able to import a single UseCase factory', async () => {
+      const useCases = {
+        use_case_from_single_factory_use_case_and_logger: () =>
+          import('./fixtures/factoryWithSingleUseCaseAndLogger.js')
+      }
+      const EntryPoint = EntryPointFactory({config, useCases, logger})
+      const domain = new EntryPoint()
 
-  it('should be able to subscribe to useCase execution', done => {
-    const useCases = {
-      use_case_from_single_factory_use_case: () =>
-        import('./fixtures/factoryWithSingleUseCase.js')
-    }
-    const EntryPoint = EntryPointFactory({config, useCases})
-    const domain = new EntryPoint()
+      const useCase = domain.get(
+        'use_case_from_single_factory_use_case_and_logger'
+      )
+      const response = await useCase.execute()
 
-    domain
-      .get('use_case_from_single_factory_use_case')
-      .subscribe(({error, result, params}) => {
-        expect(error).to.be.null
-        expect(params).to.deep.equal({foo: 'bar'})
-        expect(result).to.be.true
-        done()
-      })
+      expect(useCase.execute).to.be.a('function')
+      expect(useCase.$).to.be.an('object')
+      expect(response).to.eql(true)
+      expect(logger.log.called).to.eql(true)
+      expect(logger.error.called).to.eql(true)
+      expect(logger.metric.called).to.eql(true)
+    })
 
-    domain.get('use_case_from_single_factory_use_case').execute({foo: 'bar'})
-  })
+    it('should be able to subscribe to useCase execution', done => {
+      const useCases = {
+        use_case_from_single_factory_use_case_and_logger: () =>
+          import('./fixtures/factoryWithSingleUseCaseAndLogger.js')
+      }
+      const EntryPoint = EntryPointFactory({config, useCases, logger})
+      const domain = new EntryPoint()
 
-  it('should be able to unsubscribe to useCase subscription', done => {
-    let callCount = 0
-    const useCases = {
-      use_case_from_single_factory_use_case: () =>
-        import('./fixtures/factoryWithSingleUseCase.js')
-    }
-    const EntryPoint = EntryPointFactory({config, useCases})
-    const domain = new EntryPoint()
+      domain
+        .get('use_case_from_single_factory_use_case_and_logger')
+        .subscribe(({error, result, params}) => {
+          expect(error).to.be.null
+          expect(params).to.deep.equal({foo: 'bar'})
+          expect(result).to.be.true
+          expect(logger.log.called).to.eql(true)
+          expect(logger.error.called).to.eql(true)
+          expect(logger.metric.called).to.eql(true)
+          done()
+        })
 
-    const {unsubscribe} = domain
-      .get('use_case_from_single_factory_use_case')
-      .subscribe(({error, result, params}) => {
-        expect(error).to.be.null
-        expect(params).to.deep.equal({foo: 'bar'})
-        expect(result).to.be.true
-        callCount++
-      })
+      domain
+        .get('use_case_from_single_factory_use_case_and_logger')
+        .execute({foo: 'bar'})
+    })
 
-    domain
-      .get('use_case_from_single_factory_use_case')
-      .execute({foo: 'bar'})
-      .then(() => {
-        unsubscribe()
+    it('should be able to unsubscribe to useCase subscription', done => {
+      let callCount = 0
+      const useCases = {
+        use_case_from_single_factory_use_case_and_logger: () =>
+          import('./fixtures/factoryWithSingleUseCaseAndLogger.js')
+      }
+      const EntryPoint = EntryPointFactory({config, useCases, logger})
+      const domain = new EntryPoint()
 
-        domain
-          .get('use_case_from_single_factory_use_case')
-          .execute({foo: 'bar'})
-          .then(() => {
-            expect(callCount).to.equal(1)
-            done()
-          })
-          .catch(done)
-      })
-      .catch(done)
+      const {unsubscribe} = domain
+        .get('use_case_from_single_factory_use_case_and_logger')
+        .subscribe(({error, result, params}) => {
+          expect(error).to.be.null
+          expect(params).to.deep.equal({foo: 'bar'})
+          expect(result).to.be.true
+          callCount++
+        })
+
+      domain
+        .get('use_case_from_single_factory_use_case_and_logger')
+        .execute({foo: 'bar'})
+        .then(() => {
+          unsubscribe()
+
+          domain
+            .get('use_case_from_single_factory_use_case_and_logger')
+            .execute({foo: 'bar'})
+            .then(() => {
+              expect(callCount).to.equal(1)
+              expect(logger.log.called).to.eql(true)
+              expect(logger.error.called).to.eql(true)
+              expect(logger.metric.called).to.eql(true)
+              done()
+            })
+            .catch(done)
+        })
+        .catch(done)
+    })
   })
 })

--- a/packages/sui-domain/test/common/fixtures/EmptyUseCaseWithLogger.js
+++ b/packages/sui-domain/test/common/fixtures/EmptyUseCaseWithLogger.js
@@ -1,0 +1,13 @@
+export default class UseCase {
+  constructor({config, logger}) {
+    this._config = config
+    this._logger = logger
+  }
+
+  execute() {
+    this._logger.log('log mock')
+    this._logger.error('error mock')
+    this._logger.metric('metric mock')
+    return Promise.resolve(true)
+  }
+}

--- a/packages/sui-domain/test/common/fixtures/factoryWithMultipleUseCasesAndLogger.js
+++ b/packages/sui-domain/test/common/fixtures/factoryWithMultipleUseCasesAndLogger.js
@@ -1,0 +1,11 @@
+import EmptyUseCaseWithLogger from './EmptyUseCaseWithLogger.js'
+
+export default class FactoryWithMultipleUseCases {
+  static useCaseOne({config, logger}) {
+    return new EmptyUseCaseWithLogger({config, logger})
+  }
+
+  static useCaseTwo({config, logger}) {
+    return new EmptyUseCaseWithLogger({config, logger})
+  }
+}

--- a/packages/sui-domain/test/common/fixtures/factoryWithSingleUseCaseAndLogger.js
+++ b/packages/sui-domain/test/common/fixtures/factoryWithSingleUseCaseAndLogger.js
@@ -1,0 +1,4 @@
+import EmptyUseCaseWithLogger from './EmptyUseCaseWithLogger.js'
+
+export default ({config, logger}) =>
+  new EmptyUseCaseWithLogger({config, logger})


### PR DESCRIPTION
## Description

We want to allow developers inject a logger to the domain and empower them to log/monitor from domain.

### How to use it?

```javascript
const logger = isClient
    ? createClientLogger()
    : createServerLogger({req, team: 'sui-believers'})
const domain = new SuiDomain({logger})
```
