### PR TITLE
feat(packages/sui-studio): Remove title of the Themes tabs

### DIFF
--- a/packages/sui-studio/src/components/demo/Tabs.js
+++ b/packages/sui-studio/src/components/demo/Tabs.js
@@ -1,9 +1,7 @@
 import PropTypes from 'prop-types'
 
 export default function Tabs({children, title}) {
-  return (
-    <ul className="sui-StudioTabs sui-StudioTabs--small">{children}</ul>
-  )
+  return <ul className="sui-StudioTabs sui-StudioTabs--small">{children}</ul>
 }
 
 Tabs.propTypes = {

--- a/packages/sui-studio/src/components/demo/Tabs.js
+++ b/packages/sui-studio/src/components/demo/Tabs.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 export default function Tabs({children, title}) {
   return (
     <ul className="sui-StudioTabs sui-StudioTabs--small">
-      <li className="sui-StudioTabs-title">{title}</li>
       {children}
     </ul>
   )

--- a/packages/sui-studio/src/components/demo/Tabs.js
+++ b/packages/sui-studio/src/components/demo/Tabs.js
@@ -2,9 +2,7 @@ import PropTypes from 'prop-types'
 
 export default function Tabs({children, title}) {
   return (
-    <ul className="sui-StudioTabs sui-StudioTabs--small">
-      {children}
-    </ul>
+    <ul className="sui-StudioTabs sui-StudioTabs--small">{children}</ul>
   )
 }
 


### PR DESCRIPTION
Remove "THEMES" tab, the information is redundant
✅ I push as `feat` to force a new release

![tabs resolve](https://user-images.githubusercontent.com/23620759/195611756-dd8123e5-9111-452b-b253-bcb6d1fdc2ad.png)



