### PR TITLE
update bottom padding in NavBar menu to 80px and reduce the sidebar height by 48px

### DIFF
--- a/packages/sui-studio/src/components/layout/_style.scss
+++ b/packages/sui-studio/src/components/layout/_style.scss
@@ -16,7 +16,7 @@
     background-color: $c-white;
     border-right: 1px solid $c-gray-lightest;
     box-sizing: border-box;
-    height: 100vh;
+    height: calc(100vh - $h-navHeader);
     overflow-x: hidden;
     overflow-y: scroll;
     position: fixed;

--- a/packages/sui-studio/src/components/navigation/_style.scss
+++ b/packages/sui-studio/src/components/navigation/_style.scss
@@ -1,5 +1,5 @@
 .sui-StudioNav {
-  padding: 16px;
+  padding: 16px 16px 80px;
   &-header {
     align-items: center;
     display: flex;


### PR DESCRIPTION
## Description
This commit solves issue #1501 and includes the following changes:
- updating the bottom padding of `.sui-StudioNav` to `80px`
- reducing the height of `.sui-Studio-sidebar` by the height of `NavHeader` that is `48px`

## Related Issue
#1501 
