### PR TITLE
fix(packages/sui-studio): Add a fill to the buttons icon

### DIFF
--- a/packages/sui-studio/src/components/icons/index.js
+++ b/packages/sui-studio/src/components/icons/index.js
@@ -20,7 +20,7 @@ export const iconCode = (
 export const iconMenu = (
   <svg viewBox="0 0 24 24">
     <path d="M0 0h24v24H0z" fill="none" />
-    <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z" />
+    <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z" fill="#444" />
   </svg>
 )
 

--- a/packages/sui-studio/src/components/icons/index.js
+++ b/packages/sui-studio/src/components/icons/index.js
@@ -18,13 +18,7 @@ export const iconCode = (
 )
 
 export const iconMenu = (
-  <svg
-    width="24"
-    height="24"
-    viewBox="0 0 24 24"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-  >
+  <svg viewBox="0 0 24 24">
     <rect x="3" y="6" width="18" height="2" fill="#444444" />
     <rect x="3" y="11" width="18" height="2" fill="#444444" />
     <rect x="3" y="16" width="18" height="2" fill="#444444" />

--- a/packages/sui-studio/src/components/icons/index.js
+++ b/packages/sui-studio/src/components/icons/index.js
@@ -18,9 +18,16 @@ export const iconCode = (
 )
 
 export const iconMenu = (
-  <svg viewBox="0 0 24 24">
-    <path d="M0 0h24v24H0z" fill="none" />
-    <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z" fill="#444" />
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <rect x="3" y="6" width="18" height="2" fill="#444444" />
+    <rect x="3" y="11" width="18" height="2" fill="#444444" />
+    <rect x="3" y="16" width="18" height="2" fill="#444444" />
   </svg>
 )
 

--- a/packages/sui-studio/src/components/layout/_style.scss
+++ b/packages/sui-studio/src/components/layout/_style.scss
@@ -135,5 +135,7 @@
   padding: 0;
   svg {
     vertical-align: middle;
+    width: 24px;
+    height: 24px;
   }
 }

--- a/packages/sui-studio/src/components/layout/_style.scss
+++ b/packages/sui-studio/src/components/layout/_style.scss
@@ -127,11 +127,13 @@
   }
 }
 .sui-Studio-navMenu {
-  display: flex;
+  display: block;
   width: 32px;
   height: 32px;
   background: transparent;
   border: 0;
-  align-items: center;
-  justify-content: center;
+  padding: 0;
+  svg {
+    vertical-align: middle;
+  }
 }


### PR DESCRIPTION
<!-- #### `🚢 Ship` -->
`🔍 Show`
<!-- #### `❓ Ask` -->

**Issue fixed with this PR**
https://github.com/SUI-Components/sui/issues/1500

## Description

The hamburger menu icon is not visible on mobile, although the button works as expected.

![221004 - The button is invisible on Mobile](https://user-images.githubusercontent.com/23620759/195999010-c527050a-bf05-4234-8335-b050837c1a44.png)

## Additional Information

The button is always visible on Desktop, even when you open developer tools in Chrome. You need to test with a Mobile device.

## Result after this PR

![IMG_iPhone](https://user-images.githubusercontent.com/23620759/196011199-aa737c07-6f5e-4353-8b5e-b351e3f551a5.png)




