### PR TITLE
fix(packages/sui-studio): hide menu clicking on an overlay in mobile

### DIFF
--- a/packages/sui-studio/src/components/layout/_style.scss
+++ b/packages/sui-studio/src/components/layout/_style.scss
@@ -50,7 +50,7 @@
       width: 100vw;
       height: 100vh;
       z-index: 1;
-      background-color: rgba(0, 0, 0, 0.2);
+      background-color: rgba($c-black, 0.2);
       @include breakpoint-from(s) {
         display: none;
       }

--- a/packages/sui-studio/src/components/layout/_style.scss
+++ b/packages/sui-studio/src/components/layout/_style.scss
@@ -8,10 +8,6 @@
   }
 
   &-sidebar {
-    @include breakpoint-from(s) {
-      flex: 0 0 $w-sidebar;
-      width: $w-sidebar;
-    }
     top: $h-navHeader;
     background-color: $c-white;
     border-right: 1px solid $c-gray-lightest;
@@ -22,14 +18,14 @@
     position: fixed;
     transform: translate3d(0, 0, 0);
     transition: transform 0.5s ease-in-out;
-    z-index: 1;
+    z-index: 2;
 
     &Body {
       width: $w-sidebar;
       transition: width 0.25s ease-out;
     }
 
-    &--open {
+    &--hidden {
       transform: translate3d(-100%, 0, 0);
     }
   }
@@ -47,9 +43,24 @@
       margin-left: $w-sidebar;
       transition: width 0.5s ease-in-out, margin-left 0.5s ease-in-out;
     }
-    &--open {
+    .overlay {
+      position: fixed;
+      top: 0%;
+      left: 0;
+      width: 100vw;
+      height: 100vh;
+      z-index: 1;
+      background-color: rgba(0, 0, 0, 0.2);
+      @include breakpoint-from(s) {
+        display: none;
+      }
+    }
+    &--sidebar_hidden {
       width: 100%;
       margin-left: 0;
+      & .overlay {
+        display: none;
+      }
     }
   }
 

--- a/packages/sui-studio/src/components/layout/index.js
+++ b/packages/sui-studio/src/components/layout/index.js
@@ -13,10 +13,10 @@ import Logo from './Logo.js'
 
 export default function Layout({children}) {
   const [readme, setReadme] = useState(null)
-  const [menuIsOpen, setMenuIsOpen] = useState(false)
+  const [menuIsHidden, setMenuIsHidden] = useState(false)
 
   const handleClickMenu = () => {
-    setMenuIsOpen(!menuIsOpen)
+    setMenuIsHidden(!menuIsHidden)
   }
 
   useEffect(() => {
@@ -30,11 +30,11 @@ export default function Layout({children}) {
   )
 
   const sidebarClassName = cx('sui-Studio-sidebar', {
-    'sui-Studio-sidebar--open': menuIsOpen
+    'sui-Studio-sidebar--hidden': menuIsHidden
   })
 
   const mainClassName = cx('sui-Studio-main', {
-    'sui-Studio-main--open': menuIsOpen
+    'sui-Studio-main--sidebar_hidden': menuIsHidden
   })
 
   return (
@@ -50,11 +50,14 @@ export default function Layout({children}) {
       </div>
       <aside className={sidebarClassName}>
         <div className="sui-Studio-sidebarBody">
-          <Navigation handleClick={() => setMenuIsOpen(false)} />
+          <Navigation />
         </div>
       </aside>
 
       <div className={mainClassName}>
+        <div className="overlay" onClick={() => setMenuIsHidden(true)}>
+          {' '}
+        </div>
         {children !== null ? children : renderReadme()}
       </div>
     </section>


### PR DESCRIPTION
<!-- #### `🚢 Ship` -->
`🔍 Show`
<!-- #### `❓ Ask` -->

**ISSUE CLOSED** #1503

### Acceptance Criteria

The drawer should close by clicking outside of it (mobile only)

- There's an overlay $c-black at 10% 
- The user can close the drawer by tapping on the overlay

**Result of this PR:**

https://user-images.githubusercontent.com/23620759/196283304-22c6883c-8bb8-422f-b0a7-f31178a49055.mov

