### PR TITLE
Feat/sui mock

### DIFF
--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/bundler",
-  "version": "9.36.0",
+  "version": "9.37.0-beta.0",
   "description": "Config-free bundler for ES6 React apps.",
   "bin": {
     "sui-bundler": "./bin/sui-bundler.js"

--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/bundler",
-  "version": "9.37.0-beta.0",
+  "version": "9.37.0-beta.1",
   "description": "Config-free bundler for ES6 React apps.",
   "bin": {
     "sui-bundler": "./bin/sui-bundler.js"

--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/bundler",
-  "version": "9.37.0-beta.1",
+  "version": "9.36.0",
   "description": "Config-free bundler for ES6 React apps.",
   "bin": {
     "sui-bundler": "./bin/sui-bundler.js"

--- a/packages/sui-bundler/webpack.config.dev.js
+++ b/packages/sui-bundler/webpack.config.dev.js
@@ -40,7 +40,10 @@ const webpackConfig = {
       http: require.resolve('stream-http'),
       https: require.resolve('https-browserify'),
       buffer: require.resolve('buffer/'),
-      url: require.resolve('url/')
+      url: require.resolve('url/'),
+      stream: false,
+      zlib: false,
+      timers: false
     },
     modules: ['node_modules', path.resolve(process.cwd())],
     extensions: ['.js', '.json']

--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -61,7 +61,10 @@ const webpackConfig = {
       fs: false,
       http: require.resolve('stream-http'),
       https: require.resolve('https-browserify'),
-      path: false
+      path: false,
+      stream: false,
+      zlib: false,
+      timers: false
     }
   },
   entry: MAIN_ENTRY_POINT,

--- a/packages/sui-mock/.npmignore
+++ b/packages/sui-mock/.npmignore
@@ -1,0 +1,2 @@
+src
+test

--- a/packages/sui-mock/README.md
+++ b/packages/sui-mock/README.md
@@ -1,8 +1,19 @@
-# sui-mock-provider
-
-## Getting Started
+# sui-mock
 
 ### Installation
+
+```sh
+npm install @s-ui/mock --save-dev
+```
+
+### Mockers
+
+#### **Request mocking with `setupMocker`**
+
+It returns all methods included in `setupWorker` and `setupServer`. It will work in browser and server sides.
+
+👉 Check `setupWorker` and `setupServer` in [MSW docs](https://mswjs.io/docs/api/).
+
 
 ### Usage
 
@@ -122,11 +133,3 @@ Cypress.on('test:before:run:async', async () => {
   }
 })
 ```
-
-### Mockers
-
-- `initMocker` is isomorphic and returns all methods included in `setupWorker` and `setupServer`. Check it out [here](https://mswjs.io/docs/api/).
-
-- `getServerMocker` is server only and returns all methods included in `setupWorker` and `setupServer`. Check it out [here](https://mswjs.io/docs/api/setup-server). 
-
-- `setupBrowserMocker` is browser only and returns all methods included in `setupWorker` and `setupServer`. Check it out [here](https://mswjs.io/docs/api/setup-worker).

--- a/packages/sui-mock/README.md
+++ b/packages/sui-mock/README.md
@@ -1,0 +1,149 @@
+# sui-mock-provider
+
+## Getting Started
+
+### Installation
+
+### Usage
+
+#### 1. Create Request handlers
+Create a `./mocks` folder in your project root and create a `index.js` file inside it.
+
+This index.js should export an array of [Request handlers](https://mswjs.io/docs/basics/request-handler).
+
+**Example:**
+
+Given, a provider endpoint handler
+
+```js
+// ./mocks/exampleGateway/user/handlers.js
+import {rest} from 'msw'
+import {apiUrl} from '../config.js'
+
+const responseResolver = () => res(ctx.status(200), ctx.json({name: 'John Doe'}))
+
+export const getUserHandler = rest.get(`${apiUrl}/user`, responseResolver)
+```
+
+Then, we export a list of handlers
+
+```js
+// ./mocks/index.js
+import {getUserHandler} from './mocks/exampleGateway/user/handlers.js'
+
+export default [getUserHandler]
+```
+
+#### 2. Expose mocker from mocks folder
+
+We should use browser or server getMocker to create a mocker instance ready to use in our app. See how it will looks like:
+
+```js
+// ./mocks/server.js
+import {getServerMocker} from '@s-ui/mock-provider/lib/server'
+import handlers from './index.js'
+
+export {rest} from '@s-ui/mock-provider/lib/browser'
+export const mocker = getServerMocker(...handlers)
+```
+
+```js
+// ./mocks/browser.js
+import {getBrowserMocker} from '@s-ui/mock-provider/lib/browser'
+import handlers from './index.js'
+
+export {rest} from '@s-ui/mock-provider/lib/browser'
+export const mocker = getBrowserMocker(...handlers)
+```
+
+Given we have isomorphic tests in our project, we should create a `./mocks/isomorphicMocker.js` file that exports the mocker instance depending on the environment (browser / server).
+
+```js
+// ./mocks/isomorphicMocker.js
+import initMocker from '@s-ui/mock-provider'
+import applicationHandlers from './index.js'
+
+export {rest} from '@s-ui/mock-provider/lib/browser'
+export const getMocker = (handlers = applicationHandlers) =>
+  initMocker(handlers)
+```
+
+#### 3. Use it everywhere
+Use those mockers to init your mocks everywhere in your application, it means integration tests, e2e tests, component tests, etc. but also in your application code.
+
+Browser example:
+
+```js
+// src/app.js
+if (process.env.STAGE === 'development') {
+  const worker = await import('../mocks/browser.js').then(
+    pkg => pkg.worker
+  )
+  worker.start({onUnhandledRequest: 'bypass'})
+}
+```
+
+Server example:
+
+```js
+// src/hooks/preSSRHandler/index.js
+if (process.env.STAGE === 'development') {
+  const worker = await import('../../../mocks/server.js').then(
+    pkg => pkg.worker
+  )
+
+  worker.listen()
+}
+```
+
+Text example
+
+```js
+// domain/test/example/exampleSpec.js
+import axios from 'axios'
+import {getMocker} from '../../../mocks/isomorphicMocker.js'
+
+describe('Example', () => {
+  let mocker
+
+  before(async () => {
+    mocker = await getMocker()
+    await mocker.start()
+  })
+
+  after(() => {
+    mocker.stop()
+  })
+
+  it('should do something', async () => {
+    const result = await axios.get('/user?id=1')
+    expect(result).to.be.deep.equal({name: 'John Doe'})
+  })
+})
+```
+
+E2E example:
+
+```js
+// test-e2e/support/setup.js
+import {mocker, rest} from '../../mocks/browser.js'
+
+Cypress.on('test:before:run:async', async () => {
+  if (window.msw) return
+
+  await mocker.start({onUnhandledRequest: 'bypass'})
+
+  window.msw = {
+    worker: mocker,
+    rest
+  }
+})
+```
+
+### Mockers
+
+- `initMocker` is isomorphic and returns all methods included in `setupWorker` and `setupServer`. Check it out [here](https://mswjs.io/docs/api/).
+
+- `getServerMocker` is server only and returns all methods included in `setupWorker` and `setupServer`. Check it out [here](https://mswjs.io/docs/api/setup-server). 
+
+- `setupBrowserMocker` is browser only and returns all methods included in `setupWorker` and `setupServer`. Check it out [here](https://mswjs.io/docs/api/setup-worker).

--- a/packages/sui-mock/package.json
+++ b/packages/sui-mock/package.json
@@ -6,7 +6,12 @@
   "types": "lib/index",
   "scripts": {
     "lib": "babel --presets sui ./src --out-dir ./lib",
-    "prepublishOnly": "npm run lib"
+    "prepublishOnly": "npm run lib",
+    "test": "npm run test:client && npm run test:server",
+    "test:browser": "npx @s-ui/test browser -P './test/browser/**/*Spec.js'",
+    "test:browser:watch": "npm run test:client -- --watch",
+    "test:server": "npx @s-ui/test server -P './test/server/**/*Spec.js'",
+    "test:server:watch": "npm run test:server -- --watch"
   },
   "keywords": [],
   "author": "",

--- a/packages/sui-mock/package.json
+++ b/packages/sui-mock/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@s-ui/mock",
+  "version": "1.0.0-beta.5",
+  "main": "lib/index.js",
+  "description": "mock provider",
+  "types": "lib/index",
+  "scripts": {
+    "lib": "babel --presets sui ./src --out-dir ./lib",
+    "prepublishOnly": "npm run lib"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "msw": "0.47.4"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/SUI-Components/sui.git"
+  },
+  "bugs": {
+    "url": "https://github.com/SUI-Components/sui/issues"
+  },
+  "homepage": "https://github.com/SUI-Components/sui/tree/master/packages/sui-mock-provider#readme"
+}

--- a/packages/sui-mock/package.json
+++ b/packages/sui-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/mock",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.0",
   "main": "lib/index.js",
   "description": "mock provider",
   "types": "lib/index",

--- a/packages/sui-mock/package.json
+++ b/packages/sui-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/mock",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0",
   "main": "lib/index.js",
   "description": "mock provider",
   "types": "lib/index",

--- a/packages/sui-mock/package.json
+++ b/packages/sui-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s-ui/mock",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "main": "lib/index.js",
   "description": "mock provider",
   "types": "lib/index",

--- a/packages/sui-mock/src/browser.js
+++ b/packages/sui-mock/src/browser.js
@@ -1,0 +1,12 @@
+export {rest} from 'msw'
+
+export const getBrowserMocker = async handlers => {
+  const setup = await import('msw').then(pkg => pkg.setupWorker)
+  const worker = setup(...handlers)
+
+  return {
+    ...worker,
+    listen: worker.start,
+    close: worker.stop
+  }
+}

--- a/packages/sui-mock/src/index.js
+++ b/packages/sui-mock/src/index.js
@@ -8,6 +8,6 @@ const isNode =
     typeof process !== 'undefined' ? process : 0
   ) === '[object process]'
 
-const getMocker = isNode ? getServerMocker : getBrowserMocker
+const setupMocker = isNode ? getServerMocker : getBrowserMocker
 
-export {getMocker, rest}
+export {setupMocker, rest}

--- a/packages/sui-mock/src/index.js
+++ b/packages/sui-mock/src/index.js
@@ -1,0 +1,12 @@
+import {getBrowserMocker} from './browser.js'
+import {getServerMocker} from './server.js'
+
+const isNode =
+  Object.prototype.toString.call(
+    typeof process !== 'undefined' ? process : 0
+  ) === '[object process]'
+
+const initMocker = isNode ? getServerMocker : getBrowserMocker
+
+export {rest} from 'msw'
+export default initMocker

--- a/packages/sui-mock/src/index.js
+++ b/packages/sui-mock/src/index.js
@@ -1,3 +1,5 @@
+import {rest} from 'msw'
+
 import {getBrowserMocker} from './browser.js'
 import {getServerMocker} from './server.js'
 
@@ -6,7 +8,6 @@ const isNode =
     typeof process !== 'undefined' ? process : 0
   ) === '[object process]'
 
-const initMocker = isNode ? getServerMocker : getBrowserMocker
+const getMocker = isNode ? getServerMocker : getBrowserMocker
 
-export {rest} from 'msw'
-export default initMocker
+export {getMocker, rest}

--- a/packages/sui-mock/src/server.js
+++ b/packages/sui-mock/src/server.js
@@ -1,0 +1,12 @@
+export {rest} from 'msw'
+
+export const getServerMocker = async handlers => {
+  const {setupServer} = require('msw/node')
+  const worker = setupServer(...handlers)
+
+  return {
+    ...worker,
+    start: worker.listen,
+    stop: worker.close
+  }
+}

--- a/packages/sui-mock/test/browser/browserSpec.js
+++ b/packages/sui-mock/test/browser/browserSpec.js
@@ -1,0 +1,1 @@
+import '../common/indexSpec.js'

--- a/packages/sui-mock/test/common/indexSpec.js
+++ b/packages/sui-mock/test/common/indexSpec.js
@@ -1,0 +1,48 @@
+/* eslint-env mocha */
+import {expect} from 'chai'
+import {rest} from 'msw'
+
+import {getMocker} from '../../src/index.js'
+
+describe('sui-mock-provider | getMocker', () => {
+  it('should init mocker without handlers', async () => {
+    // Given
+    const mocker = await getMocker()
+
+    // Then
+    expect(mocker).to.not.throw
+  })
+
+  it('should init mocker with one handler', () => {
+    // Given
+    const handler = rest.get('/user/:userId', (req, res, ctx) => {
+      return res(
+        ctx.json({
+          firstName: 'John',
+          lastName: 'Maverick'
+        })
+      )
+    })
+
+    // When
+    const mocker = getMocker([handler])
+
+    // Then
+    expect(mocker).to.not.throw
+  })
+
+  it('should has isomorphic msw api', async () => {
+    // Given
+    const mocker = await getMocker()
+
+    // Then
+    expect(mocker).to.have.property('start')
+    expect(mocker).to.have.property('stop')
+    expect(mocker).to.have.property('listen')
+    expect(mocker).to.have.property('close')
+    expect(mocker).to.have.property('use')
+    expect(mocker).to.have.property('resetHandlers')
+    expect(mocker).to.have.property('restoreHandlers')
+    expect(mocker).to.have.property('printHandlers')
+  })
+})

--- a/packages/sui-mock/test/common/indexSpec.js
+++ b/packages/sui-mock/test/common/indexSpec.js
@@ -2,12 +2,12 @@
 import {expect} from 'chai'
 import {rest} from 'msw'
 
-import {getMocker} from '../../src/index.js'
+import {setupMocker} from '../../src/index.js'
 
-describe('sui-mock-provider | getMocker', () => {
+describe('sui-mock | setupMocker', () => {
   it('should init mocker without handlers', async () => {
     // Given
-    const mocker = await getMocker()
+    const mocker = await setupMocker()
 
     // Then
     expect(mocker).to.not.throw
@@ -25,7 +25,7 @@ describe('sui-mock-provider | getMocker', () => {
     })
 
     // When
-    const mocker = getMocker([handler])
+    const mocker = setupMocker([handler])
 
     // Then
     expect(mocker).to.not.throw
@@ -33,7 +33,7 @@ describe('sui-mock-provider | getMocker', () => {
 
   it('should has isomorphic msw api', async () => {
     // Given
-    const mocker = await getMocker()
+    const mocker = await setupMocker()
 
     // Then
     expect(mocker).to.have.property('start')

--- a/packages/sui-mock/test/server/serverSpec.js
+++ b/packages/sui-mock/test/server/serverSpec.js
@@ -1,0 +1,1 @@
+import '../common/indexSpec.js'

--- a/packages/sui-mockmock/README.md
+++ b/packages/sui-mockmock/README.md
@@ -2,6 +2,8 @@
 
 > Mocking utilities for testing.
 
+## ⚠️ It is highly recommended to use [sui-mock](https://github.com/SUI-Components/sui/tree/master/packages/sui-mock) instead of this package. It could be deprecated in the future.
+
 ## Motivation
 
 Centralize common solutions for common mocking concerns in JavaScript.

--- a/packages/sui-test-contract/package.json
+++ b/packages/sui-test-contract/package.json
@@ -18,9 +18,9 @@
   "dependencies": {
     "@pact-foundation/pact": "9.18.1",
     "@pactflow/pact-msw-adapter": "1.2.1",
+    "@s-ui/mock": "1",
     "commander": "8.3.0",
-    "headers-polyfill": "3.0.10",
-    "msw": "0.42.3"
+    "headers-polyfill": "3.0.10"
   },
   "devDependencies": {
     "@s-ui/domain": "2"

--- a/packages/sui-test-contract/test/server/setupSpec.js
+++ b/packages/sui-test-contract/test/server/setupSpec.js
@@ -1,7 +1,7 @@
 import {expect} from 'chai'
-import {rest} from 'msw'
 
 import {FetcherFactory} from '@s-ui/domain'
+import {rest} from '@s-ui/mock'
 
 import {setupContractTests} from '../../src/index.js'
 import {getContractFileData, removeContractFiles} from '../utils.js'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Wrap MWS under SUI tool to provide an easy-to-use abstraction layer for API mocking

Try this using 👇 
@s-ui/mock@1.0.0-beta.1
@s-ui/bundler@9.37.0-beta.1
@s-ui/test-contract@2.8.0-beta.2

## To be aware of

### `@s-ui/bundler`

We have added some fallbacks to resolve webpack configuration to have a redirection of module requests when normal resolving fails. It is required to avoid application bundling errors.

We resolve it as false:
```
stream: false,
zlib: false,
timers: false
```