### PR TITLE
fix(packages/sui-studio): sidebar navigation

### DIFF
--- a/packages/sui-studio/src/components/layout/_style.scss
+++ b/packages/sui-studio/src/components/layout/_style.scss
@@ -12,7 +12,7 @@
     background-color: $c-white;
     border-right: 1px solid $c-gray-lightest;
     box-sizing: border-box;
-    height: 100vh;
+    height: calc(100vh - $h-navHeader);
     overflow-x: hidden;
     overflow-y: scroll;
     position: fixed;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The sidebar scrolling area does not show the last items because it has the 100vh when it must be 100vh - 48px of 

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
#1520 

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
- open any studio deployment
- scrolldown the sidebar
- you can't see the last items
