### PR TITLE
Feat: Allow to Inject PDE in Domain

### DIFF
--- a/packages/sui-domain/README.md
+++ b/packages/sui-domain/README.md
@@ -55,9 +55,9 @@ const EntryPoint = EntryPointFactory({useCases})
 const domain = new EntryPoint({config})
 ```
 
-### Injecting a logger or pde to our domain
+### Injecting a logger to our domain
 
-In order to increase the observability of your domain, you can pass a custom logger/pde to your domain instance and it will be injected on each UseCase factory. Following the example of previous section:
+In order to increase the observability of your domain, you can pass a custom logger to your domain instance and it will be injected on each UseCase factory. Following the example of previous section:
 
 #### How to inject the logger to your domain?
 
@@ -71,7 +71,7 @@ const EntryPoint = EntryPointFactory({config, useCases, logger})
 const domain = new EntryPoint()
 ```
 
-#### How use the logger on your domain?
+#### How use it on your domain?
 
 ```javascript
 // Your factory file
@@ -93,6 +93,10 @@ export default class UseCase {
 }
 ```
 
+### Injecting a pde to our domain
+
+In order to allow your domain to work with experiments and feature flags, you can pass a custom pde to your domain instance and it will be injected on each UseCase factory.
+
 #### How to inject the pde to your domain?
 
 ```javascript
@@ -106,7 +110,7 @@ const EntryPoint = EntryPointFactory({config, useCases, pde})
 const domain = new EntryPoint()
 ```
 
-#### How use the pde on your domain?
+#### How use it on your domain?
 
 ```javascript
 // Your factory file

--- a/packages/sui-domain/README.md
+++ b/packages/sui-domain/README.md
@@ -55,9 +55,9 @@ const EntryPoint = EntryPointFactory({useCases})
 const domain = new EntryPoint({config})
 ```
 
-### Injecting a logger to our domain
+### Injecting a logger or pde to our domain
 
-In order to increase the observability of your domain, you can pass a custom logger to your domain instance and it will be injected on each UseCase factory. Following the example of previous section:
+In order to increase the observability of your domain, you can pass a custom logger/pde to your domain instance and it will be injected on each UseCase factory. Following the example of previous section:
 
 #### How to inject the logger to your domain?
 
@@ -71,7 +71,7 @@ const EntryPoint = EntryPointFactory({config, useCases, logger})
 const domain = new EntryPoint()
 ```
 
-#### How use it on your domain?
+#### How use the logger on your domain?
 
 ```javascript
 // Your factory file
@@ -89,6 +89,41 @@ export default class UseCase {
   execute() {
     this._logger.log() // Logger ready to rock! 🎸
     return Promise.resolve(true)
+  }
+}
+```
+
+#### How to inject the pde to your domain?
+
+```javascript
+// PDE mock example
+const pde = {
+  isFeatureEnabled: ({featureKey}) => true,
+  getVariation: ({name}) => 'experimentVariation'
+}
+
+const EntryPoint = EntryPointFactory({config, useCases, pde})
+const domain = new EntryPoint()
+```
+
+#### How use the pde on your domain?
+
+```javascript
+// Your factory file
+import EmptyUseCase from './EmptyUseCase.js'
+
+export default ({config, pde}) => new EmptyUseCase({config, pde})
+
+// Your UseCase implementation
+export default class UseCase {
+  constructor({config, pde}) {
+    this._config = config
+    this._pde = pde
+  }
+
+  execute() {
+    const {isActive} = this._pde.isFeatureEnabled({featureKey: 'FeatureFlagKey'})
+    return isActive ? true : false
   }
 }
 ```

--- a/packages/sui-domain/README.md
+++ b/packages/sui-domain/README.md
@@ -110,7 +110,7 @@ const EntryPoint = EntryPointFactory({config, useCases, pde})
 const domain = new EntryPoint()
 ```
 
-#### How use it on your domain?
+#### How to use it on your domain?
 
 ```javascript
 // Your factory file

--- a/packages/sui-domain/src/EntryPointFactory.js
+++ b/packages/sui-domain/src/EntryPointFactory.js
@@ -5,7 +5,7 @@ export default ({useCases, config, logger, pde}) =>
     subscribers = {}
 
     constructor(params = {config: {}, logger: {}, pde: {}}) {
-      // decide to use a static config from the factor
+      // decide to use a static config from the factory
       // or use a config passed to the constructor that could be mutated
       this._config = config || params.config
       this._useCases = useCases

--- a/packages/sui-domain/src/EntryPointFactory.js
+++ b/packages/sui-domain/src/EntryPointFactory.js
@@ -1,15 +1,16 @@
 import createNotImplementedUseCase from './createNotImplementedUseCase.js'
 
-export default ({useCases, config, logger}) =>
+export default ({useCases, config, logger, pde}) =>
   class EntryPoint {
     subscribers = {}
 
-    constructor(params = {config: {}, logger: {}}) {
-      // decide to use a static config from the factory
+    constructor(params = {config: {}, logger: {}, pde: {}}) {
+      // decide to use a static config from the factor
       // or use a config passed to the constructor that could be mutated
       this._config = config || params.config
       this._useCases = useCases
       this._logger = logger || params.logger
+      this._pde = pde || params.pde
     }
 
     /**
@@ -53,7 +54,8 @@ export default ({useCases, config, logger}) =>
                 .then(factory =>
                   getMethod(factory)({
                     config: this._config,
-                    logger: this._logger
+                    logger: this._logger,
+                    pde: this._pde
                   }).execute(params)
                 )
                 .then(result => {
@@ -93,7 +95,8 @@ export default ({useCases, config, logger}) =>
                     // makes dispose working async and we need it
                     ret.dispose = getMethod(factory)({
                       config: this._config,
-                      logger: this._logger
+                      logger: this._logger,
+                      pde: this._pde
                     }).$.execute.subscribe(onNext, onError).dispose
                   })
                   // return the object that will be mutated async


### PR DESCRIPTION
## Description

We want to allow developers inject a pde to the domain and empower them with FeaturesFlag and Experiement in domain.

### How to use it?

```javascript
const pde = new OptimizelyAdapter({
    optimizely,
    userId,
    applicationAttributes
})
const domain = new SuiDomain({pde})
```
