### PR TITLE
feat(packages/sui-react-initial-props): hoist static props for server…

### DIFF
--- a/packages/sui-react-initial-props/package.json
+++ b/packages/sui-react-initial-props/package.json
@@ -17,10 +17,13 @@
     "react": "16 || 17"
   },
   "devDependencies": {
+    "@s-ui/react-router": "1",
     "@testing-library/react": "11.1.0",
     "@types/node": "16",
     "react": "17",
-    "react-dom": "17",
-    "@s-ui/react-router": "1"
+    "react-dom": "17"
+  },
+  "dependencies": {
+    "hoist-non-react-statics": "3.3.2"
   }
 }

--- a/packages/sui-react-initial-props/src/loadPage.tsx
+++ b/packages/sui-react-initial-props/src/loadPage.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import { useContext } from 'react'
 
+import hoistNonReactStatic from 'hoist-non-react-statics'
+
 import InitialPropsContext from './initialPropsContext'
 import { ClientPageComponent, DoneImportingPageCallback, ReactRouterTypes, WithInitialPropsComponent } from './types'
 import withInitialProps from './withInitialProps'
@@ -26,6 +28,8 @@ const createUniversalPage = (routeInfo: ReactRouterTypes.RouteInfo) => ({ defaul
     const { initialProps } = useContext(InitialPropsContext)
     return <Page {...props} {...initialProps} />
   }
+
+  hoistNonReactStatic(ServerPage, Page)
   // recover the displayName from the original page
   ServerPage.displayName = Page.displayName
   // detect if the page has getInitialProps and wrap it with the routeInfo


### PR DESCRIPTION
## Description
This PR hoist non react static props from page to server page this way they can also be used in Server-Side. For example:
in RE we are experimenting to track the SSR performance of pages and we want to enable it using a property in a page which is not available if it's no copied.

There are no breaking changes.
Beta available:
```
npm install @s-ui/react-initial-props@2.21.0-beta.1
```

## Related Issue
None
