### PR TITLE
Fix/fix api tab styles

### DIFF
--- a/packages/sui-studio/src/components/documentation/Api.js
+++ b/packages/sui-studio/src/components/documentation/Api.js
@@ -40,7 +40,7 @@ export default function Api({params}) {
 
       return (
         <div className="sui-StudioProps-prop" key={propName}>
-          <h3>{propName}</h3>
+          <h2 className="sui-StudioProps-h2">{propName}</h2>
           <div>
             <div className="sui-StudioProps-tag sui-StudioProps-required">
               <span>required</span>
@@ -69,8 +69,8 @@ export default function Api({params}) {
     const {props} = componentDoc
     return (
       <Fragment key={index}>
-        <h1>{componentDoc.displayName}</h1>
-        <h2>Props</h2>
+        <h1 className="sui-StudioProps-h1">{componentDoc.displayName}</h1>
+        <blockquote className="sui-StudioProps-blockquote">Props</blockquote>
         {renderPropsApi({props})}
       </Fragment>
     )

--- a/packages/sui-studio/src/components/documentation/_style.scss
+++ b/packages/sui-studio/src/components/documentation/_style.scss
@@ -1,4 +1,26 @@
 .sui-StudioProps {
+  &-h1,
+  &-h2 {
+    font-weight: 400;
+    line-height: 1.25;
+    padding-bottom: 0.4em;
+  }
+  &-h1 {
+    font-size: 2.25em;
+    border-bottom: 1px solid #eaecef;
+  }
+  &-h2 {
+    font-size: 0.875em;
+    font-weight: 700;
+    margin-top: 56px;
+    text-transform: uppercase;
+  }
+  &-blockquote {
+    border-left: 0.25em solid #dfe2e5;
+    color: #6a737d;
+    padding: 0 1em;
+    margin: 0;
+  }
   &-prop {
     padding: 0 16px 24px 0;
   }

--- a/packages/sui-studio/src/components/layout/index.js
+++ b/packages/sui-studio/src/components/layout/index.js
@@ -54,7 +54,6 @@ export default function Layout({children}) {
         </button>
         <Link to="/">
           <Logo />
-          <h1>SUI Components</h1>
         </Link>
       </div>
       <aside className={sidebarClassName}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The API page lost the new styles due to the correction of styles for the tab DEMO in https://github.com/SUI-Components/sui/pull/1536.

![Tab Props](https://user-images.githubusercontent.com/23620759/201382629-365c30de-366d-4042-b9f5-f84a4876f1ce.png)

## Related Issues
- https://github.com/SUI-Components/sui/issues/1537

This PR also fixes the defect found in other studios
- https://github.com/SUI-Components/sui/issues/1524

