### PR TITLE
feat(packages/sui-theme): add new molecule select and autosuggest tokens to theme

### DIFF
--- a/packages/sui-theme/src/components/atom/input/_placeholders.scss
+++ b/packages/sui-theme/src/components/atom/input/_placeholders.scss
@@ -19,13 +19,15 @@
 @mixin sui-atom-input-select-focus() {
   border: $bd-atom-select-focus;
   box-shadow: $bxsh-atom-select-focus;
-  outline: 0 none;
+  outline: $ol-atom-select-focus;
+  outline-offset: $olo-atom-select-focus;
 }
 
 @mixin sui-molecule-autosuggest-focus() {
   border: $bd-molecule-autosuggest-focus;
   box-shadow: $bxsh-molecule-autosuggest-focus;
-  outline: 0 none;
+  outline: $ol-molecule-autosuggest-focus;
+  outline-offset: $olo-molecule-autosuggest-focus;
 }
 
 %sui-atom-input-input {

--- a/packages/sui-theme/src/components/atom/input/_settings.scss
+++ b/packages/sui-theme/src/components/atom/input/_settings.scss
@@ -12,9 +12,13 @@ $bd-atom-input-base: $bdw-s solid $c-gray-light !default;
 
 $bd-molecule-autosuggest-focus: $bd-atom-input !default;
 $bxsh-molecule-autosuggest-focus: $bxsh-atom-input !default;
+$ol-molecule-autosuggest-focus: 0 none !default;
+$olo-molecule-autosuggest-focus: 0 !default;
 
 $bd-atom-select-focus: $bd-atom-input !default;
 $bxsh-atom-select-focus: $bxsh-atom-input !default;
+$ol-atom-select-focus: 0 none !default;
+$olo-atom-select-focus: 0 !default;
 
 $h-atom-input--xl: 7 * $sz-base !default; // 56px
 $h-atom-input--l: 6 * $sz-base !default; // 48px


### PR DESCRIPTION
# SUI-THEME
## Description
Add new outline and outline-offset tokens for molecule select and autosuggest.
What we want to achieve (at motor) is avoiding selects to grow (by its border) when are focused, but keeping the UI.

NOW:
![current ](https://user-images.githubusercontent.com/37936498/203088200-247ff20c-f526-4ede-981d-06d7439b88b8.gif)

WHAT WE WANT TO ACHIEVE
![with outline and offset](https://user-images.githubusercontent.com/37936498/203088234-ed9fd4be-b4fc-41bc-b019-a3951a1325bf.gif)
