### PR TITLE
feat(packages/sui-studio-utils): Be able to mock a domain config

### DIFF
--- a/packages/sui-studio-utils/README.md
+++ b/packages/sui-studio-utils/README.md
@@ -45,6 +45,16 @@ domain.get('current_user_use_case').execute().then((products) => {
 ```
 
 
+### Mocking the configuration
+
+```js
+DomainBuilder.extend(
+  {
+    domain,
+    config: 'moked-config'
+  })
+```
+
 ### Forcing an error throw
 
 ```js

--- a/packages/sui-studio-utils/README.md
+++ b/packages/sui-studio-utils/README.md
@@ -51,7 +51,7 @@ domain.get('current_user_use_case').execute().then((products) => {
 DomainBuilder.extend(
   {
     domain,
-    config: 'moked-config'
+    config: 'mocked-config'
   })
 ```
 

--- a/packages/sui-studio-utils/package.json
+++ b/packages/sui-studio-utils/package.json
@@ -4,6 +4,11 @@
   "description": "Set of utils made to be used on the desired studios",
   "main": "lib/index.js",
   "scripts": {
+    "test": "npm run test:server && npm run test:browser",
+    "test:browser": "NODE_ENV=test sui-test browser -P 'test/browser/*Spec.js'",
+    "test:browser:watch": "NODE_ENV=test npm run test:browser -- --watch",
+    "test:server": "NODE_ENV=test sui-test server -P 'test/server/*Spec.js'",
+    "test:server:watch": "npm run test:server -- --watch",
     "lib": "babel --presets sui ./src --out-dir ./lib",
     "prepublishOnly": "npm run lib"
   },

--- a/packages/sui-studio-utils/package.json
+++ b/packages/sui-studio-utils/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "npm run test:server && npm run test:browser",
     "test:browser": "NODE_ENV=test sui-test browser -P 'test/browser/*Spec.js'",
-    "test:browser:watch": "NODE_ENV=test npm run test:browser -- --watch",
+    "test:browser:watch": "npm run test:browser -- --watch",
     "test:server": "NODE_ENV=test sui-test server -P 'test/server/*Spec.js'",
     "test:server:watch": "npm run test:server -- --watch",
     "lib": "babel --presets sui ./src --out-dir ./lib",

--- a/packages/sui-studio-utils/src/domain-builder/index.js
+++ b/packages/sui-studio-utils/src/domain-builder/index.js
@@ -1,12 +1,12 @@
 export default class DomainBuilder {
-  static extend({domain = {}}) {
-    return new DomainBuilder({domain})
+  static extend({domain, config} = {domain: {}}) {
+    return new DomainBuilder({domain, config})
   }
 
-  constructor({domain} = {}) {
+  constructor({domain, config} = {}) {
     this._domain = domain
     this._useCase = false
-    this._config = domain.get('config')
+    this._config = config || domain.get('config')
     this._useCases = {}
   }
 

--- a/packages/sui-studio-utils/src/test/browser/browserSpec.js
+++ b/packages/sui-studio-utils/src/test/browser/browserSpec.js
@@ -1,0 +1,1 @@
+import '../common/index.js'

--- a/packages/sui-studio-utils/src/test/common/domainBuilderSpec.js
+++ b/packages/sui-studio-utils/src/test/common/domainBuilderSpec.js
@@ -1,0 +1,30 @@
+/* eslint-env mocha */
+import {expect} from 'chai'
+
+import {DomainBuilder} from '../../index.js'
+
+describe('DomainBuilder', () => {
+  describe('when a useCase is mocked', () => {
+    const domainBuilder = DomainBuilder.extend({domain: {get: () => {}}})
+    it('should return the mocked response', async () => {
+      const domain = domainBuilder
+        .for({useCase: 'get_products'})
+        .respondWith({success: 'mocked-response'})
+        .build()
+      expect(await domain.get('get_products').execute()).to.equal(
+        'mocked-response'
+      )
+    })
+  })
+
+  describe('when config is mocked', () => {
+    const domainBuilder = DomainBuilder.extend({
+      domain: {get: () => {}},
+      config: 'moked-config'
+    })
+    it('should return the mocked response', async () => {
+      const domain = domainBuilder.build()
+      expect(await domain.get('config')).to.equal('moked-config')
+    })
+  })
+})

--- a/packages/sui-studio-utils/src/test/common/domainBuilderSpec.js
+++ b/packages/sui-studio-utils/src/test/common/domainBuilderSpec.js
@@ -20,11 +20,11 @@ describe('DomainBuilder', () => {
   describe('when config is mocked', () => {
     const domainBuilder = DomainBuilder.extend({
       domain: {get: () => {}},
-      config: 'moked-config'
+      config: 'mocked-config'
     })
     it('should return the mocked response', async () => {
       const domain = domainBuilder.build()
-      expect(await domain.get('config')).to.equal('moked-config')
+      expect(await domain.get('config')).to.equal('mocked-config')
     })
   })
 })

--- a/packages/sui-studio-utils/src/test/common/index.js
+++ b/packages/sui-studio-utils/src/test/common/index.js
@@ -1,0 +1,1 @@
+import './domainBuilderSpec.js'

--- a/packages/sui-studio-utils/src/test/server/serverSpec.js
+++ b/packages/sui-studio-utils/src/test/server/serverSpec.js
@@ -1,0 +1,1 @@
+import '../common/index.js'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Sometime we need to mock a config property in order to test different escenarios in a test or demo environment. In order to do this, we have added the possibility to mock the config when extending the domain itself.

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

```js
DomainBuilder.extend({
      domain: {get: () => {}},
      config: 'mocked-config'
    })
```
