### PR TITLE
feat(packages/sui-studio): Add script to migrate component files to new structure

### DIFF
--- a/packages/sui-studio/bin/migrations/component-files.js
+++ b/packages/sui-studio/bin/migrations/component-files.js
@@ -17,7 +17,7 @@ const extractComponeName = content => {
 const hasMultipleExports = content => {
   const match = content.match(/^export /gm)
 
-  if (!match) return null
+  if (!match) return false
 
   return match.length > 1
 }
@@ -48,7 +48,7 @@ const migrateComponentFiles = async () => {
       console.log(`file exists: ${newPath}`)
       continue
     } else {
-      console.log('Does not exists')
+      console.log('Does not exist')
     }
 
     await rename(absolutePath, newPath)

--- a/packages/sui-studio/bin/migrations/component-files.js
+++ b/packages/sui-studio/bin/migrations/component-files.js
@@ -1,0 +1,71 @@
+/* eslint-disable no-console */
+
+const glob = require('fast-glob')
+const {resolve, dirname, join} = require('node:path')
+const {readFile, stat, rename, writeFile} = require('node:fs/promises')
+const pattern = /export default(?: function)? ([$A-Z_][0-9A-Z_$]*)/i
+
+const extractComponeName = content => {
+  const match = content.match(pattern)
+  if (!match) return null
+
+  const componentName = match[1]
+
+  return componentName ?? null
+}
+
+const hasMultipleExports = content => {
+  const match = content.match(/^export /gm)
+
+  if (!match) return null
+
+  return match.length > 1
+}
+
+const checkFileExists = path => {
+  return stat(path)
+    .then(() => true)
+    .catch(() => false)
+}
+
+const migrateComponentFiles = async () => {
+  const files = await glob(['components/**/index.js'], {
+    ignore: ['**/node_modules/**', '**/demo/**', '**/lib/**']
+  })
+
+  for (const file of files) {
+    // File path is relative to CWD
+    const absolutePath = resolve(process.cwd(), file)
+    const content = (await readFile(absolutePath)).toString('utf8')
+    const componentName = extractComponeName(content)
+
+    if (!componentName) continue
+
+    const dir = dirname(absolutePath)
+    const newPath = join(dir, `${componentName}.js`)
+
+    if (await checkFileExists(newPath)) {
+      console.log(`file exists: ${newPath}`)
+      continue
+    } else {
+      console.log('Does not exists')
+    }
+
+    await rename(absolutePath, newPath)
+
+    const indexTemplate =
+      [
+        `import ${componentName} from './${componentName}.js'`,
+        `export default ${componentName}`,
+        hasMultipleExports(content) && `export * from './${componentName}.js'`
+      ]
+        .filter(Boolean)
+        .join('\n') + '\n'
+
+    await writeFile(absolutePath, indexTemplate)
+
+    break
+  }
+}
+
+migrateComponentFiles()

--- a/packages/sui-studio/bin/migrations/component-files.js
+++ b/packages/sui-studio/bin/migrations/component-files.js
@@ -5,7 +5,7 @@ const {resolve, dirname, join} = require('node:path')
 const {readFile, stat, rename, writeFile} = require('node:fs/promises')
 const pattern = /export default(?: function)? ([$A-Z_][0-9A-Z_$]*)/i
 
-const extractComponeName = content => {
+const extractComponentName = content => {
   const match = content.match(pattern)
   if (!match) return null
 
@@ -37,7 +37,7 @@ const migrateComponentFiles = async () => {
     // File path is relative to CWD
     const absolutePath = resolve(process.cwd(), file)
     const content = (await readFile(absolutePath)).toString('utf8')
-    const componentName = extractComponeName(content)
+    const componentName = extractComponentName(content)
 
     if (!componentName) continue
 

--- a/packages/sui-studio/bin/migrations/component-files.js
+++ b/packages/sui-studio/bin/migrations/component-files.js
@@ -63,8 +63,6 @@ const migrateComponentFiles = async () => {
         .join('\n') + '\n'
 
     await writeFile(absolutePath, indexTemplate)
-
-    break
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds a new script to migrate existing components to a new structure with a `Component.js` file that contains all the component logic and an index re-export.

## Related Issue
Related to #1518 discussion

Share your thoughts if you have any suggestions/feedback or if you find an edge case I'm missing here! 🙏