### PR TITLE
Feat/sui critical css allow url array

### DIFF
--- a/packages/sui-critical-css/README.md
+++ b/packages/sui-critical-css/README.md
@@ -1,4 +1,5 @@
 # sui-critical-css
+
 > Extract Critical CSS from a set of URLs for an app
 
 ## How it works
@@ -9,9 +10,10 @@
 4. After doing this for each route, then creates a `critical.json` file that could be read for every path to extract the critical-css.
 5. Use then `@s-ui/critical-css-middleware` to extract to use in your Express app the CSS.
 
-## How to use to extract 
+## How to use to extract
 
 Install package to your project:
+
 ```
 npm install @s-ui/critical-css -D
 ```
@@ -49,7 +51,7 @@ const routes = {
     url: '/es'
   },
   '/:lang/catalogo-productos': {
-    url: '/es/catalogo-productos'
+    url: ['/es/catalogo-productos', '/en/catalogo-productos']
   }
 }
 

--- a/packages/sui-critical-css/src/extract-from-app.js
+++ b/packages/sui-critical-css/src/extract-from-app.js
@@ -14,7 +14,9 @@ const configForMobileDevice = devices.m
 
 export const createUrlFrom = ({hostname, pathOptions}) => {
   const path = typeof pathOptions === 'string' ? pathOptions : pathOptions.url
-  return `${hostname}${path}`
+  return Array.isArray(path)
+    ? path.map(current => `${hostname}${current}`)
+    : `${hostname}${path}`
 }
 
 const waitForHealthCheck = ({healthCheckUrl}) => {

--- a/packages/sui-critical-css/src/extract-from-url.js
+++ b/packages/sui-critical-css/src/extract-from-url.js
@@ -87,9 +87,10 @@ export async function extractCSSFromUrl({
       response => !response.ok() && response.status() !== 304
     )
 
-    console.log('xd', current)
-
-    if (current) await closeAll(`Response status code ${current.status()}`)
+    if (current)
+      await closeAll(
+        `Response status code ${current.status()} for url ${current.url()}`
+      )
 
     console.log('[ok] Got response')
 

--- a/packages/sui-critical-css/src/extract-from-url.js
+++ b/packages/sui-critical-css/src/extract-from-url.js
@@ -59,9 +59,16 @@ export async function extractCSSFromUrl({
 
     await page.coverage.startCSSCoverage()
 
-    const response = await page
-      .goto(url, {waitUntil: 'networkidle'})
-      .catch(error => ({error}))
+    const urls = Array.isArray(url) ? url : [url]
+    const responses = []
+
+    for (url in urls) {
+      const response = await page
+        .goto(url, {waitUntil: 'networkidle'})
+        .catch(error => ({error}))
+
+      responses.push(response)
+    }
 
     const closeAll = async error => {
       await page.close()
@@ -70,12 +77,17 @@ export async function extractCSSFromUrl({
       if (error) throw new Error(`[ko] ${error}`)
     }
 
-    if (!response) await closeAll('Response is not present')
+    if (!responses.length) await closeAll('Response is not present')
 
-    if (response.error) await closeAll(response.error)
+    const error = responses.find(response => response.error)
 
-    if (!response.ok() && response.status() !== 304)
-      await closeAll(`Response status code ${response.status()} for url ${url}`)
+    if (error) await closeAll(error)
+
+    const current = responses.find(
+      response => !response.ok() && response.status() !== 304
+    )
+
+    if (current) await closeAll(`Response status code ${current.status()}`)
 
     console.log('[ok] Got response')
 

--- a/packages/sui-critical-css/src/extract-from-url.js
+++ b/packages/sui-critical-css/src/extract-from-url.js
@@ -87,6 +87,8 @@ export async function extractCSSFromUrl({
       response => !response.ok() && response.status() !== 304
     )
 
+    console.log('xd', current)
+
     if (current) await closeAll(`Response status code ${current.status()}`)
 
     console.log('[ok] Got response')

--- a/packages/sui-sass-loader/package.json
+++ b/packages/sui-sass-loader/package.json
@@ -18,10 +18,10 @@
     "sass": "1"
   },
   "devDependencies": {
-    "css-loader": "6",
-    "mini-css-extract-plugin": "2",
-    "sass": "1",
+    "css-loader": "6.7.1",
+    "mini-css-extract-plugin": "2.6.1",
+    "sass": "1.54.5",
     "sass-loader": "12",
-    "webpack": "5"
+    "webpack": "5.74.0"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR allow to set different pathnames for a same route when critical css is generated. This will allow us to generate the critical css for example for different experiment variations.

## Related Issue
None

## Example

```js
// scripts/get-critical-css-for-routes.js
import {extractCSSFromApp} from '@s-ui/critical-css'
const config = {
  hostname: 'http://localhost'
}
const routes = {
  '/:lang': {
    url: '/es'
  },
  '/:lang/catalogo-productos': {
    url: ['/es/catalogo-productos', '/es/catalogo-productos?suipde_experiment=variation_b']
  }
}
extractCSSFromApp({config, routes})
```
