### PR TITLE
Feat/add no unstable nested components

### DIFF
--- a/packages/sui-lint/eslintrc.js
+++ b/packages/sui-lint/eslintrc.js
@@ -32,7 +32,8 @@ const REACT_RULES = {
   'react/no-unknown-property': RULES.ERROR,
   'react/prop-types': RULES.ERROR,
   'react/react-in-jsx-scope': RULES.OFF,
-  'react/require-render-return': RULES.WARNING
+  'react/require-render-return': RULES.WARNING,
+  'react/no-unstable-nested-components': RULES.WARNING
 }
 
 const TESTING_RULES = {


### PR DESCRIPTION
This PR add [no-unstable-nested-components](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unstable-nested-components.md) as warning since could lead to performance issues and bugs

## Related Issue
None
