### PR TITLE
feat(packages/sui-react-web-vitals): add distribution metric support

### DIFF
--- a/packages/sui-react-web-vitals/README.md
+++ b/packages/sui-react-web-vitals/README.md
@@ -53,13 +53,17 @@ const Root = withAllContexts(context)(Router)
 ReactDOM.render(<Root />, document.getElementById('root'))
 ```
 
-The `timing` method from the `logger` will be called with an object that follows the next schema
+The `distribution` method from the `logger` will be called with an object that follows the next schema
 
 ```json
 {
-  "name": "LCP",
+  "name": "cwv",
   "amount": 10,
   "tags": [
+    {
+      "key": "name",
+      "value": "CLS"
+    }
     {
       "key": "pathname",
       "value": "/products/:id"

--- a/packages/sui-react-web-vitals/src/index.js
+++ b/packages/sui-react-web-vitals/src/index.js
@@ -69,14 +69,20 @@ export default function WebVitalsReporter({
         return
       }
 
-      if (!logger?.timing) {
+      if (!logger?.distribution) {
         return
       }
 
-      logger.timing({
-        name,
-        amount: value,
+      const amount = name === METRICS.CLS ? value * 1000 : value
+
+      logger.distribution({
+        name: 'cwv',
+        amount,
         tags: [
+          {
+            key: 'name',
+            value: name.toLowerCase()
+          },
           {
             key: 'pathname',
             value: pathname


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR:
- Try sending distribution metrics by default instead of timing one. This way percentiles could be computed across dimensions
- CLS value should be an integer since our logger can only compute integer values
