### PR TITLE
fix(packages/sui-pde): fix error on access to experiments map

### DIFF
--- a/packages/sui-pde/src/adapters/optimizely/index.js
+++ b/packages/sui-pde/src/adapters/optimizely/index.js
@@ -159,9 +159,9 @@ export default class OptimizelyAdapter {
    * @returns {isActive: boolean, linkedExperiments: number[]}
    */
   isFeatureEnabled({featureKey, attributes}) {
-    const linkedExperimentNames = Object.keys(
-      this.getOptimizelyConfig().featuresMap[featureKey].experimentsMap
-    )
+    const experimentsMap =
+      this.getOptimizelyConfig().featuresMap[featureKey]?.experimentsMap || {}
+    const linkedExperimentNames = Object.keys(experimentsMap)
 
     // check for user consents only if featureKey is a feature that belongs to a feature test or if a userId is available
     if (


### PR DESCRIPTION
## Description
Fix execution errors on client trying to access to the `experimentsMap` key when a feature is not available anymore in Optimizely.