### PR TITLE
feat(packages/sui-theme): add mixin to hide scrollbars when required

### DIFF
--- a/packages/sui-theme/src/utils.scss
+++ b/packages/sui-theme/src/utils.scss
@@ -7,5 +7,6 @@
 @import './utils/list';
 @import './utils/opacity';
 @import './utils/string';
+@import './utils/scrollbars';
 @import './utils/text';
 @import './utils/url';

--- a/packages/sui-theme/src/utils/_scrollbars.scss
+++ b/packages/sui-theme/src/utils/_scrollbars.scss
@@ -1,0 +1,14 @@
+@mixin hide-scrollbar {
+  /* hide scrollbar on Chrome, Safari and Opera */
+  &::-webkit-scrollbar {
+    /* to make it work on iOS devices */
+    background: transparent;
+    display: none;
+    height: 0;
+    width: 0;
+  }
+
+  /* hide scrollbar on IE, Edge and Firefox */
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+}


### PR DESCRIPTION
## Description
This mixin allows for hiding the scrollbars on any container.
Compatible with all major browsers and devices. 

## Related Issue
N/A

## Example

````
    &--scrolling {
      @include hide-scrollbar;
      margin-bottom: $m-l;
      overflow-x: auto;
      padding-bottom: $p-m;
      scroll-snap-type: x mandatory;
    }
````

[hidescrollbar.webm](https://user-images.githubusercontent.com/18154356/220040233-9d8aaf14-1fcd-4b81-b49f-95017394affc.webm)


