### PR TITLE
feat(packages/sui-i18n): Intl.FormatNumber extended options

### DIFF
--- a/packages/sui-i18n/README.md
+++ b/packages/sui-i18n/README.md
@@ -328,7 +328,7 @@ const defaultOptions = {
   useGrouping: true // should display grouping separators even if the locale prefers otherwise
 }
 
-i18n.defaultNumberFormatOptions = {...defaultOptions} 
+i18n.defaultNumberFormatOptions = defaultOptions
 i18n.n(1000) //=> 1.000
 i18n.n(10000) //=> 10.000
 ```

--- a/packages/sui-i18n/README.md
+++ b/packages/sui-i18n/README.md
@@ -324,11 +324,11 @@ i18n.n(1000) //=> 1000
 i18n.n(10000) //=> 10.000
 
 // With forced useGrouping option
-const extendedOptions = {
+const defaultOptions = {
   useGrouping: true // should display grouping separators even if the locale prefers otherwise
 }
 
-i18n.extendedIntlNumberOptions = {...extendedOptions} 
+i18n.defaultNumberFormatOptions = {...defaultOptions} 
 i18n.n(1000) //=> 1.000
 i18n.n(10000) //=> 10.000
 ```

--- a/packages/sui-i18n/README.md
+++ b/packages/sui-i18n/README.md
@@ -310,7 +310,7 @@ i18n.c(1000) //=> £1,000
 i18n.c(1000000) //=> £1,000,000
 ```
 
-We can format numbers with a extended Intl.FormatNumber options
+We can format numbers with a extended Intl.NumberFormat options
 ```javascript
 import I18n from '@s-ui/i18n'
 import Polyglot from '@s-ui/i18n/lib/adapters/polyglot'

--- a/packages/sui-i18n/README.md
+++ b/packages/sui-i18n/README.md
@@ -310,6 +310,29 @@ i18n.c(1000) //=> £1,000
 i18n.c(1000000) //=> £1,000,000
 ```
 
+We can format numbers with a extended Intl.FormatNumber options
+```javascript
+import I18n from '@s-ui/i18n'
+import Polyglot from '@s-ui/i18n/lib/adapters/polyglot'
+
+const i18n = new I18n({adapter: new Polyglot()})
+
+i18n.culture = 'es-ES'
+
+// With default es-ES options
+i18n.n(1000) //=> 1000
+i18n.n(10000) //=> 10.000
+
+// With forced useGrouping option
+const extendedOptions = {
+  useGrouping: true // should display grouping separators even if the locale prefers otherwise
+}
+
+i18n.extendedIntlNumberOptions = {...extendedOptions} 
+i18n.n(1000) //=> 1.000
+i18n.n(10000) //=> 10.000
+```
+
 #### Currency symbol
 
 Get the currency symbol.

--- a/packages/sui-i18n/README.md
+++ b/packages/sui-i18n/README.md
@@ -310,7 +310,7 @@ i18n.c(1000) //=> £1,000
 i18n.c(1000000) //=> £1,000,000
 ```
 
-We can format numbers with a extended Intl.NumberFormat options
+We can format numbers with an extended Intl.NumberFormat options
 ```javascript
 import I18n from '@s-ui/i18n'
 import Polyglot from '@s-ui/i18n/lib/adapters/polyglot'

--- a/packages/sui-i18n/src/i18n.js
+++ b/packages/sui-i18n/src/i18n.js
@@ -7,7 +7,7 @@ export default class Rosetta {
     this._culture = null
     this._currency = null
     this._languages = null
-    this._extendedIntlNumberOptions = null
+    this._defaultNumberFormatOptions = null
 
     this.translator = adapter
   }
@@ -31,8 +31,8 @@ export default class Rosetta {
 
   // According to Intl.NumberFormat options
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#options
-  set extendedIntlNumberOptions(options) {
-    this._extendedIntlNumberOptions = options
+  set defaultNumberFormatOptions(options) {
+    this._defaultNumberFormatOptions = options
   }
 
   get culture() {
@@ -128,8 +128,8 @@ export default class Rosetta {
 
     return typeof Intl !== 'undefined'
       ? new Intl.NumberFormat(culture || this._culture, {
-          ...options,
-          ...this._extendedIntlNumberOptions
+          ...this._defaultNumberFormatOptions,
+          ...options
         }).format(number)
       : number
   }

--- a/packages/sui-i18n/src/i18n.js
+++ b/packages/sui-i18n/src/i18n.js
@@ -7,6 +7,7 @@ export default class Rosetta {
     this._culture = null
     this._currency = null
     this._languages = null
+    this._extendedIntlNumberOptions = null
 
     this.translator = adapter
   }
@@ -26,6 +27,12 @@ export default class Rosetta {
 
   set currency(currency) {
     this._currency = currency
+  }
+
+  // According to Intl.NumberFormat options
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#options
+  set extendedIntlNumberOptions(options) {
+    this._extendedIntlNumberOptions = options
   }
 
   get culture() {
@@ -120,7 +127,10 @@ export default class Rosetta {
     }
 
     return typeof Intl !== 'undefined'
-      ? new Intl.NumberFormat(culture || this._culture, options).format(number)
+      ? new Intl.NumberFormat(culture || this._culture, {
+          ...options,
+          ...this._extendedIntlNumberOptions
+        }).format(number)
       : number
   }
 

--- a/packages/sui-i18n/test/i18nSpec.js
+++ b/packages/sui-i18n/test/i18nSpec.js
@@ -169,6 +169,25 @@ describe('I18N', () => {
         it('should display grouping separators even if the locale prefers otherwise', () => {
           expect(i18n.n(1000)).to.eql('1.000')
         })
+
+        it('The default value can be overwritten from the execution of the i18n.n method', () => {
+          expect(i18n.n(1000, {useGrouping: false})).to.eql('1000')
+        })
+      })
+
+      describe('default options backward compatibility', () => {
+        beforeEach(() => {
+          i18n.culture = 'es-ES'
+          i18n.defaultNumberFormatOptions = null
+        })
+        afterEach(() => {
+          i18n.culture = ''
+        })
+
+        it('it preserves backward compatibility if defaultNumberFormatOptions has no value and options are no setted inside i18n.n', () => {
+          expect(i18n.n(1000)).to.eql('1000')
+          expect(i18n.n(10000)).to.eql('10.000')
+        })
       })
 
       describe('properly formats minor types like', () => {

--- a/packages/sui-i18n/test/i18nSpec.js
+++ b/packages/sui-i18n/test/i18nSpec.js
@@ -156,14 +156,14 @@ describe('I18N', () => {
         expect(i18n.t(`${key}.literalOne`)).to.eql('TranslateDynamicEsES')
       })
 
-      describe('properly number format with extended options', () => {
+      describe('properly number format with default options', () => {
         beforeEach(() => {
           i18n.culture = 'es-ES'
-          i18n.extendedIntlNumberOptions = {useGrouping: true}
+          i18n.defaultNumberFormatOptions = {useGrouping: true}
         })
         afterEach(() => {
           i18n.culture = ''
-          i18n.extendedIntlNumberOptions = null
+          i18n.defaultNumberFormatOptions = null
         })
 
         it('should display grouping separators even if the locale prefers otherwise', () => {

--- a/packages/sui-i18n/test/i18nSpec.js
+++ b/packages/sui-i18n/test/i18nSpec.js
@@ -156,6 +156,21 @@ describe('I18N', () => {
         expect(i18n.t(`${key}.literalOne`)).to.eql('TranslateDynamicEsES')
       })
 
+      describe('properly number format with extended options', () => {
+        beforeEach(() => {
+          i18n.culture = 'es-ES'
+          i18n.extendedIntlNumberOptions = {useGrouping: true}
+        })
+        afterEach(() => {
+          i18n.culture = ''
+          i18n.extendedIntlNumberOptions = null
+        })
+
+        it('should display grouping separators even if the locale prefers otherwise', () => {
+          expect(i18n.n(1000)).to.eql('1.000')
+        })
+      })
+
       describe('properly formats minor types like', () => {
         describe('percentage', () => {
           it('from a non-decimal amount when ', () => {


### PR DESCRIPTION
## Intl.NumberFormat extended options

## Description
In **coches.net**, we need the thousands points in the prices to be visible so as not to create confusion in the users of the price they are seeing. Currently the RAE standard says that it should only be in the numbers of more than 5 digits, but we believe that it is necessary to improve the reading of the data that is also in the thousands.

in order to meet this UX requirement, we added the possibility of being able to pass to **`Intl.NumberFormat`** a specific configuration to customize the type of formatting of the numbers according to the configuration described in **https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#options.**

## Related Issue
[MTR-66511](https://jira.ets.mpi-internal.com/browse/MTR-66511) & [MTR-64776](https://jira.ets.mpi-internal.com/browse/MTR-64776)

## Example
```javascript
import I18n from '@s-ui/i18n'
import Polyglot from '@s-ui/i18n/lib/adapters/polyglot'

const i18n = new I18n({adapter: new Polyglot()})

i18n.culture = 'es-ES'

// With default es-ES options
i18n.n(1000) //=> 1000
i18n.n(10000) //=> 10.000

// With forced useGrouping option
const defaultOptions = {
  useGrouping: true // should display grouping separators even if the locale prefers otherwise
}

i18n.defaultNumberFormatOptions = {...defaultOptions} 
i18n.n(1000) //=> 1.000
i18n.n(10000) //=> 10.000
```
