### PR TITLE
sui-test-contract: when response is not 2XX

### DIFF
--- a/packages/sui-test-contract/src/setup/index.js
+++ b/packages/sui-test-contract/src/setup/index.js
@@ -74,12 +74,15 @@ const setupContractTests = ({
           let url = `${apiUrl}${endpoint}`
 
           if (query) url = `${url}?${toQueryString(query)}`
-
-          const {data} = body
-            ? await fetcher[method](url, body, options)
-            : await fetcher[method](url, options)
-
-          if (data) expect(data).to.deep.equal(response)
+          try {
+            const {data} = body
+              ? await fetcher[method](url, body, options)
+              : await fetcher[method](url, options)
+            if (data) expect(data).to.deep.equal(response)
+          } catch (error) {
+            const data = error.response.data
+            if (data) expect(data).to.deep.equal(response)
+          }
         })
       }
     )

--- a/packages/sui-test-contract/test/server/setupSpec.js
+++ b/packages/sui-test-contract/test/server/setupSpec.js
@@ -32,6 +32,7 @@ const getAppleHandler = rest.get(
     return res(ctx.status(200), ctx.json(response))
   }
 )
+const notFoundResponse = {code: 'not-found'}
 
 setupContractTests({
   apiUrl: 'http://localhost:8181',
@@ -84,6 +85,16 @@ setupContractTests({
         ),
         response: gardenResponse,
         addMatchingRules: true
+      },
+      {
+        endpoint: '/apples/search/garden',
+        description: 'A request for getting a garden that fails',
+        state: 'I have not garden',
+        handler: rest.get(
+          'http://localhost:8181/apples/search/garden',
+          (req, res, ctx) => res(ctx.status(404), ctx.json(notFoundResponse))
+        ),
+        response: notFoundResponse
       }
     ]
   }

--- a/packages/sui-test-contract/test/server/setupSpec.js
+++ b/packages/sui-test-contract/test/server/setupSpec.js
@@ -167,6 +167,20 @@ describe('Contract files generated', () => {
     expect(response.matchingRules).to.not.exist
   })
 
+  it('should generate the contract when doing a not found request', () => {
+    const data = getContractFileData({
+      consumer,
+      description: 'A request for getting a garden that fails'
+    })
+    const {providerState, response, request} = data
+
+    expect(providerState).to.eql('I have not garden')
+    expect(request.method).to.eql('GET')
+    expect(response.body).to.eql(notFoundResponse)
+    expect(response.status).to.eql(404)
+    expect(response.matchingRules).to.not.exist
+  })
+
   it('should generate the contract with Pact matchers when doing a request for getting a garden', () => {
     const data = getContractFileData({
       consumer,


### PR DESCRIPTION
Include non 2xx responses in the contract flow

