### PR TITLE
fix(packages/sui-pde): Prevent error when accessing to getOptimizelyConfig method

### DIFF
--- a/packages/sui-pde/src/adapters/optimizely/index.js
+++ b/packages/sui-pde/src/adapters/optimizely/index.js
@@ -160,7 +160,7 @@ export default class OptimizelyAdapter {
    */
   isFeatureEnabled({featureKey, attributes}) {
     const experimentsMap =
-      this.getOptimizelyConfig().featuresMap[featureKey]?.experimentsMap || {}
+      this.getOptimizelyConfig()?.featuresMap[featureKey]?.experimentsMap || {}
     const linkedExperimentNames = Object.keys(experimentsMap)
 
     // check for user consents only if featureKey is a feature that belongs to a feature test or if a userId is available


### PR DESCRIPTION
## Description
In some rare cases, users and clients gets a CORS error when requesting for optimizely datafiles (https://cdn.optimizely.com/datafiles), so at this point the application crashes. The CORS error maybe is generated by some antivirus extensions, but we need to cover the code to prevent the error.