### PR TITLE
feat(packages/sui-react-web-vitals): replace wildcard on pathname tag value

### DIFF
--- a/packages/sui-react-web-vitals/src/index.js
+++ b/packages/sui-react-web-vitals/src/index.js
@@ -22,6 +22,10 @@ export const DEVICE_TYPES = {
   MOBILE: 'mobile'
 }
 
+const getNormalizedPathname = pathname => {
+  return pathname.replaceAll('*', '_')
+}
+
 export default function WebVitalsReporter({
   metrics = Object.values(METRICS),
   pathnames,
@@ -85,7 +89,7 @@ export default function WebVitalsReporter({
           },
           {
             key: 'pathname',
-            value: pathname
+            value: getNormalizedPathname(pathname)
           },
           ...(type
             ? [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Replace wildcard `*` with `_` on pathname tag value so that it works when sending data to DataDog.
<!--- Describe your changes in detail -->

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
![image](https://user-images.githubusercontent.com/18154356/230391622-279c105c-cb0a-4f6d-bbcf-de0faf9d975a.png)

Having a pathname value of `/*` would yield the same data as a pathname value of `/`, which is not useful to analyze data from apps where pathnames `/*` and `/` mean different pages.
