### PR TITLE
feat(packages/sui-react-head): Wrap the Meta component to invert the …

### DIFF
--- a/packages/sui-react-head/src/index.tsx
+++ b/packages/sui-react-head/src/index.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable react/prop-types */
 
 import * as React from 'react'
-import { HeadProvider, Link, Meta, Style, Title } from 'react-head'
+import {
+  HeadProvider, Link, Meta as MetaPrimitive, Style, Title
+} from 'react-head'
 
 import Body from './Body'
 import Html from './Html'
@@ -21,6 +23,21 @@ interface HeadProps {
     name: string
     content: string
   }>
+}
+
+interface MetaProps extends React.ComponentProps<typeof MetaPrimitive> {}
+
+interface MetaTagInverterProps extends React.MetaHTMLAttributes<HTMLMetaElement> {
+  'data-rh': string
+}
+
+const MetaTagInverter: React.FC<MetaTagInverterProps> = ({ 'data-rh': rh, ...others }) => {
+  return <meta {...others} data-rh={rh} />
+}
+
+const Meta: React.FC<MetaProps> = (props) => {
+  // @ts-expect-error
+  return <MetaPrimitive {...props} tag={MetaTagInverter} />
 }
 
 const Head: React.FC<HeadProps> = ({
@@ -59,8 +76,8 @@ const Head: React.FC<HeadProps> = ({
       {renderTags({ tagsArray: metaTagsToRender, Component: Meta })}
       {renderTags({ tagsArray: linkTagsToRender, Component: Link })}
       {renderStyles({ stylesArray: stylesTagsToRender, Component: Style })}
-      {(bodyAttributes != null) && <Body attributes={bodyAttributes} />}
-      {(htmlAttributes != null) && <Html attributes={htmlAttributes} />}
+      {bodyAttributes != null && <Body attributes={bodyAttributes} />}
+      {htmlAttributes != null && <Html attributes={htmlAttributes} />}
     </>
   )
 }


### PR DESCRIPTION
## Description
We've identified an issue with the preview of WhatsApp ads in one particular situation: sharing from an Android device.

When sharing from an iOS device, the preview appears as follows:
![image](https://user-images.githubusercontent.com/1387225/235635521-a6867f78-d1d3-4235-a1b8-eb210fadcd32.png)

However, when sharing from an Android device, the preview is displayed like this:
![image](https://user-images.githubusercontent.com/1387225/235635473-3e4f494d-d9cf-4a92-84d2-487313392095.png)


We investigated and found the problem. Android doesn't recognize the meta property attribute unless it's the first attribute listed. This behavior occurs exclusively in server-side rendering (SSR).

Example:
![image](https://user-images.githubusercontent.com/1387225/235635604-7c7a6150-e236-44c5-9a0b-1203c044944e.png)

If we move the data-rh attribute after property it works properly

![image](https://user-images.githubusercontent.com/1387225/235635697-e901e43d-afd7-4ba5-869a-72af1e6d273e.png)

This problem occurs on the following websites:

- Fotocasa
- Milanuncios
- Coches.net
- Motos.net

Currently, a version has been uploaded to Fotocasa (using a tag from the sui-react-head module) that solves the issue. Applying this fix would resolve the problem.

### Explanation of the technical solution:


We are using the react-head library, which exposes the Meta component:

![image](https://user-images.githubusercontent.com/1387225/235638292-7f12396c-c192-453e-b810-7d78a3e15894.png)

Internally, this component injects the provided tag with the data-rh attribute at the beginning:


![image](https://user-images.githubusercontent.com/1387225/235638544-ef4a3326-75d1-4e63-b839-e13148039a28.png)

The proposed solution involves wrapping the tag component to reverse the order of the attributes.

