### PR TITLE
fix(packages/sui-test): fix NaN when use timeout param in client test

### DIFF
--- a/packages/sui-test/bin/sui-test-browser.js
+++ b/packages/sui-test/bin/sui-test-browser.js
@@ -52,7 +52,7 @@ runner({
   ignorePattern,
   pattern,
   srcPattern,
-  timeout,
+  ...(timeout && {timeout: Number(timeout)}),
   watch
 })
   .then(output => {


### PR DESCRIPTION
## Description
Fix `NaN` when use timeout param in client test.

## Example

From
![image](https://user-images.githubusercontent.com/11008947/235869415-60f0ecaa-3e92-4cc0-8070-8bec4e60a8d8.png)

Throw
![image](https://user-images.githubusercontent.com/11008947/235869521-751258b2-27bf-4633-afb8-16a0b7eaee01.png)

Solution
![image](https://user-images.githubusercontent.com/11008947/235869810-7f7d4d49-b5a8-4870-903e-8f22e464d1fc.png)

