### PR TITLE
feat(packages/sui-polyfills): Added polyfill for matchAll

### DIFF
--- a/packages/sui-polyfills/src/index.js
+++ b/packages/sui-polyfills/src/index.js
@@ -21,6 +21,7 @@ require('core-js/features/string/starts-with')
 require('core-js/features/string/trim')
 require('core-js/features/string/pad-end')
 require('core-js/features/string/pad-start')
+require('core-js/features/string/match-all')
 
 require('core-js/features/url')
 require('core-js/features/url-search-params')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The `i18n.interpolate` function uses the `matchAll` method that does not work on Safari browsers older than version 13 and we have some users reporting errors because of this.

## Description
<!--- Describe your changes in detail -->

Add the `matchAll` polyfill

