### PR TITLE
fix(packages/babel-preset-sui): add is moder check for server transpi…

### DIFF
--- a/packages/babel-preset-sui/src/index.js
+++ b/packages/babel-preset-sui/src/index.js
@@ -6,7 +6,7 @@ const {
 
 const getTargets = ({targets = {}, isModern, isServer}) => {
   const {server, browser} = targets
-  if (isServer) return server ?? DEFAULT_SERVER_TARGETS
+  if (isModern && isServer) return server ?? DEFAULT_SERVER_TARGETS
 
   return (
     browser ??


### PR DESCRIPTION
## Description
This PR rollbacks transpilation target for the server like it previously was if no `isModern` flag is defined

![Screen Shot 2023-05-04 at 15 45 48](https://user-images.githubusercontent.com/6877967/236225188-30c4e94f-90a6-48c6-b3be-979785ff465c.png)
