### PR TITLE
feat(packages/sui-react-web-vitals): add routeid to reporter 

### DIFF
--- a/packages/sui-react-web-vitals/src/index.js
+++ b/packages/sui-react-web-vitals/src/index.js
@@ -48,6 +48,12 @@ export default function WebVitalsReporter({
       return route?.path || route?.regexp?.toString()
     }
 
+    const getRoutename = () => {
+      const {routes} = router
+      const route = routes[routes.length - 1]
+      return route?.id || null
+    }
+
     const getDeviceType = () => {
       return deviceType || browser?.deviceType
     }
@@ -55,6 +61,7 @@ export default function WebVitalsReporter({
     const handleReport = ({name, value}) => {
       const onReport = onReportRef.current
       const pathname = getPathname()
+      const routename = getRoutename()
       const type = getDeviceType()
       const isExcluded =
         !pathname || (Array.isArray(pathnames) && !pathnames.includes(pathname))
@@ -68,6 +75,7 @@ export default function WebVitalsReporter({
           name,
           amount: value,
           pathname,
+          routename,
           type
         })
         return
@@ -91,6 +99,14 @@ export default function WebVitalsReporter({
             key: 'pathname',
             value: getNormalizedPathname(pathname)
           },
+          ...(routename
+            ? [
+                {
+                  key: 'routename',
+                  value: routename
+                }
+              ]
+            : []),
           ...(type
             ? [
                 {

--- a/packages/sui-react-web-vitals/src/index.js
+++ b/packages/sui-react-web-vitals/src/index.js
@@ -48,7 +48,7 @@ export default function WebVitalsReporter({
       return route?.path || route?.regexp?.toString()
     }
 
-    const getRoutename = () => {
+    const getRouteid = () => {
       const {routes} = router
       const route = routes[routes.length - 1]
       return route?.id
@@ -61,7 +61,7 @@ export default function WebVitalsReporter({
     const handleReport = ({name, value}) => {
       const onReport = onReportRef.current
       const pathname = getPathname()
-      const routename = getRoutename()
+      const routeid = getRouteid()
       const type = getDeviceType()
       const isExcluded =
         !pathname || (Array.isArray(pathnames) && !pathnames.includes(pathname))
@@ -75,7 +75,7 @@ export default function WebVitalsReporter({
           name,
           amount: value,
           pathname,
-          routename,
+          routeid,
           type
         })
         return
@@ -99,11 +99,11 @@ export default function WebVitalsReporter({
             key: 'pathname',
             value: getNormalizedPathname(pathname)
           },
-          ...(routename
+          ...(routeid
             ? [
                 {
-                  key: 'routename',
-                  value: routename
+                  key: 'routeid',
+                  value: routeid
                 }
               ]
             : []),

--- a/packages/sui-react-web-vitals/src/index.js
+++ b/packages/sui-react-web-vitals/src/index.js
@@ -51,7 +51,7 @@ export default function WebVitalsReporter({
     const getRoutename = () => {
       const {routes} = router
       const route = routes[routes.length - 1]
-      return route?.id || null
+      return route?.id
     }
 
     const getDeviceType = () => {


### PR DESCRIPTION
Add _routeid_ tag to Web Vitals Reporter as read from route `id` prop.

<!--- Provide a general summary of your changes in the Title above -->

## Description
In order to provide an easier way to read Web Performance dashboards, we can now provide an `id` to a `route` that will be sent as `routeid` along with the other tags.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
N/A

## Example
```
        <Route path={HOME} id="home" getComponent={loadHomePage({appName})} />
```