### PR TITLE
fix(packages/sui-lint): Fix Unknown rule error when checking scss files

### DIFF
--- a/packages/sui-lint/package.json
+++ b/packages/sui-lint/package.json
@@ -38,7 +38,7 @@
     "prettier": "2.7.1",
     "stylelint": "14.11.0",
     "stylelint-config-prettier": "9.0.3",
-    "stylelint-config-recommended-scss": "9.0.1",
+    "stylelint-config-recommended-scss": "8.0.0",
     "stylelint-prettier": "2.0.0"
   }
 }

--- a/packages/sui-lint/package.json
+++ b/packages/sui-lint/package.json
@@ -38,7 +38,7 @@
     "prettier": "2.7.1",
     "stylelint": "14.11.0",
     "stylelint-config-prettier": "9.0.3",
-    "stylelint-config-recommended-scss": "7.0.0",
+    "stylelint-config-recommended-scss": "9.0.1",
     "stylelint-prettier": "2.0.0"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We are using an incompatible version between eslint and stylelint-config-recommended-scss causing the following error:
![image](https://github.com/SUI-Components/sui/assets/21960669/d481fcf5-62a9-4755-b203-f9deaf171fbe)


