### PR TITLE
feat(packages/sui-decorators): Add error to reporter

### DIFF
--- a/packages/sui-decorators/src/decorators/tracer/index.js
+++ b/packages/sui-decorators/src/decorators/tracer/index.js
@@ -58,7 +58,8 @@ export default ({metric = null} = {}) => {
                     reporter.send({
                       metricName,
                       status: error ? statusCodes.FAIL : statusCodes.SUCCESS,
-                      value: endTime - startTime
+                      value: endTime - startTime,
+                      error
                     })
                   } else {
                     reporter.send({


### PR DESCRIPTION
## Description
We have create a custom Reporter to send metrics to DataDog from clientSide. 
We would like to send some custom tags, and for goal we need to have access to the Error. 
So, the goal of this PR is to pass as a new prop the Error to the Reporter
