### PR TITLE
feat(packages/sui-mono): upgrade git-url-parse dependency to major 13

### DIFF
--- a/packages/sui-mono/package.json
+++ b/packages/sui-mono/package.json
@@ -12,7 +12,7 @@
     "commander": "8.3.0",
     "conventional-changelog": "3.1.25",
     "enquirer": "2.3.6",
-    "git-url-parse": "12.0.0",
+    "git-url-parse": "13.0.0",
     "glob": "8.0.3",
     "word-wrap": "1.2.3"
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Due to vulnerabilities on the `parse-url` package on versions < 8.1.0, an upgrade of `sui-mono`'s `git-url-parse` dependency is necessary. Major `13` is using `parse-url` major `8` so that would solve the security issue. We're publishing a beta version of `sui-mono` (`2.34.0-beta.0`) so we can safely test this [apparently breaking change](https://github.com/IonicaBizau/git-url-parse/releases/tag/13.0.0).

![image](https://github.com/SUI-Components/sui/assets/18154356/3a20c00b-db35-4c91-a9fc-89df5dd835b4)

## Related Issue
N/A

## Example
N/A
