### PR TITLE
fix(packages/sui-i18n): fix missed key warning when i18n.url

### DIFF
--- a/packages/sui-i18n/src/i18n.js
+++ b/packages/sui-i18n/src/i18n.js
@@ -193,6 +193,7 @@ export default class Rosetta {
   url(urlPattern, allowQueryParams) {
     return urlPattern
       .split('/')
+      .filter(Boolean)
       .map(token => slugify(this.t(token), allowQueryParams))
       .join('/')
   }


### PR DESCRIPTION
## Description
Fix missed key warning when i18n.url.

<img width="843" alt="image" src="https://github.com/SUI-Components/sui/assets/11008947/80bb3d17-ad61-4eae-bfd6-eb5e7d2e05ef">

