### PR TITLE
feat(packages/sui-studio): update studio generate install to avoid in…

### DIFF
--- a/packages/sui-studio/bin/sui-studio-generate.js
+++ b/packages/sui-studio/bin/sui-studio-generate.js
@@ -309,7 +309,9 @@ export default () => <${componentInPascal} />
   writeFile(COMPONENT_TEST_FILE, removeRepeatedNewLines(testTemplate))
 ]).then(() => {
   console.log(colors.gray(`[${packageName}]: Installing the dependencies`))
-  const install = spawn('npm', ['install'], {cwd: COMPONENT_PATH})
+  const install = spawn('npm', [
+    'install --legacy-peer-deps --no-audit --no-fund --production=false'
+  ])
 
   install.stdout.on('data', data =>
     console.log(colors.gray(`[${packageName}]: ${data.toString()}`))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR:
- Add some needed flags to the post generate install
- `--no-audit` argument can be used to disable sending of audit reports to the configured registries
- `--no-fund` argument will hide the message displayed at the end of each install that acknowledges the number of dependencies looking for funding
- `--production=false` install both dev deps and deps no matter what NODE_ENV is
