### PR TITLE
feat(packages/sui-svg): add sui svg dist

### DIFF
--- a/packages/sui-svg/bin/sui-svg-dist.js
+++ b/packages/sui-svg/bin/sui-svg-dist.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+import {resolve} from 'path'
+
+import {build} from 'vite'
+
+const {pathname: root} = new URL('../src', import.meta.url)
+
+const outDir = resolve(process.cwd(), './public')
+const icons = resolve(process.cwd(), 'lib', '_demo.js')
+
+console.log('[sui-svg] Preparing build with icons...')
+
+await build({
+  root,
+  optimizeDeps: {
+    include: [
+      'classnames',
+      'prop-types',
+      'react',
+      'react/jsx-runtime',
+      'react-dom'
+    ]
+  },
+  resolve: {
+    alias: [
+      {
+        find: '@s-ui/svg-icons',
+        replacement: () => icons
+      },
+      {
+        find: /^~.+/,
+        replacement: val => val.replace(/^~/, '')
+      }
+    ]
+  },
+  build: {
+    outDir
+  }
+})
+
+console.log('[sui-svg] Build is ready! ✅')

--- a/packages/sui-svg/bin/sui-svg.js
+++ b/packages/sui-svg/bin/sui-svg.js
@@ -11,5 +11,6 @@ program.version(version, '    --version')
 
 program.command('build', 'Builds React components from svg files')
 program.command('demo', 'Loads a local static website')
+program.command('dist', 'Generates static website')
 
 program.parse(process.argv)


### PR DESCRIPTION
## Description
This PR add svg dist option to generate a build of the icons demo.
The output will be placed in `public` directory

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
```sh
sui-svg dist
```
