### PR TITLE
feat(packages/sui-react-web-vitals): improve LCP and INP reporting

### DIFF
--- a/packages/sui-react-web-vitals/src/index.js
+++ b/packages/sui-react-web-vitals/src/index.js
@@ -8,19 +8,23 @@ import useMount from '@s-ui/react-hooks/lib/useMount/index.js'
 import {useRouter} from '@s-ui/react-router'
 
 export const METRICS = {
-  TTFB: 'TTFB',
-  LCP: 'LCP',
   CLS: 'CLS',
+  FCP: 'FCP',
   FID: 'FID',
   INP: 'INP',
-  FCP: 'FCP'
+  LCP: 'LCP',
+  TTFB: 'TTFB'
 }
 
 const DEFAULT_METRICS_REPORTING_ALL_CHANGES = [METRICS.LCP, METRICS.INP]
 
 const DEFAULT_CWV_THRESHOLDS = {
+  [METRICS.CLS]: 100,
+  [METRICS.FCP]: 1800,
+  [METRICS.FID]: 100,
+  [METRICS.INP]: 200,
   [METRICS.LCP]: 2500,
-  [METRICS.INP]: 200
+  [METRICS.TTFB]: 800
 }
 
 export const DEVICE_TYPES = {

--- a/packages/sui-react-web-vitals/src/index.js
+++ b/packages/sui-react-web-vitals/src/index.js
@@ -60,7 +60,7 @@ export default function WebVitalsReporter({
       return deviceType || browser?.deviceType
     }
 
-    const handleChange = ({name, value}) => {
+    const handleChange = ({attribution, name, value}) => {
       const onReport = onReportRef.current
       const pathname = getPathname()
       const routeid = getRouteid()

--- a/packages/sui-react-web-vitals/src/index.js
+++ b/packages/sui-react-web-vitals/src/index.js
@@ -38,13 +38,13 @@ const getNormalizedPathname = pathname => {
 }
 
 export default function WebVitalsReporter({
-  cwvThresholds = DEFAULT_CWV_THRESHOLDS,
+  children,
   deviceType,
   metrics = Object.values(METRICS),
   metricsAllChanges = DEFAULT_METRICS_REPORTING_ALL_CHANGES,
   onReport,
   pathnames,
-  children
+  thresholds = DEFAULT_CWV_THRESHOLDS
 }) {
   const {logger, browser} = useContext(SUIContext)
   const router = useRouter()
@@ -81,7 +81,7 @@ export default function WebVitalsReporter({
 
       const amount = name === METRICS.CLS ? value * 1000 : value
 
-      if (amount < cwvThresholds[name]) return
+      if (amount < thresholds[name]) return
 
       logger.metric({
         label: `cwv|${name.toLowerCase()}`,
@@ -160,11 +160,9 @@ export default function WebVitalsReporter({
 
 WebVitalsReporter.propTypes = {
   /**
-   * An object with METRICS as keys and thresholds as values
-   * Thresholds by default are those above which Google considers the page as "needs improvement"
-   * Lower thresholds could be set for fine-tuning, higher thresholds could be set for less noise when reporting all changes
+   * An optional children node
    */
-  cwvThresholds: PropTypes.object,
+  children: PropTypes.node,
   /**
    * An optional string to identify the device type. Choose between: desktop, tablet and mobile
    */
@@ -178,15 +176,17 @@ WebVitalsReporter.propTypes = {
    */
   metricsAllChanges: PropTypes.arrayOf(PropTypes.oneOf(Object.values(METRICS))),
   /**
-   * An optional array of pathnames that you want to track
-   */
-  pathnames: PropTypes.arrayOf(PropTypes.string),
-  /**
    * An optional callback to be used to track core web vitals
    */
   onReport: PropTypes.func,
   /**
-   * An optional children node
+   * An optional array of pathnames that you want to track
    */
-  children: PropTypes.node
+  pathnames: PropTypes.arrayOf(PropTypes.string),
+  /**
+   * An object with METRICS as keys and thresholds as values
+   * Thresholds by default are those above which Google considers the page as "needs improvement"
+   * Lower thresholds could be set for fine-tuning, higher thresholds could be set for less noise when reporting all changes
+   */
+  thresholds: PropTypes.object
 }

--- a/packages/sui-react-web-vitals/src/index.js
+++ b/packages/sui-react-web-vitals/src/index.js
@@ -77,12 +77,14 @@ export default function WebVitalsReporter({
       const isExcluded =
         !pathname || (Array.isArray(pathnames) && !pathnames.includes(pathname))
 
-      if (isExcluded || !logger?.metric || amount < thresholds[name]) return
+      if (isExcluded || !logger?.log || amount < thresholds[name]) return
 
-      logger.metric({
-        name: `cwv|${name.toLowerCase()}`,
-        tags: {amount, ...attribution}
-      })
+      logger.log(
+        JSON.stringify({
+          name: `cwv|${name.toLowerCase()}`,
+          tags: {amount, ...attribution}
+        })
+      )
     }
 
     const handleChange = ({name, value}) => {

--- a/packages/sui-react-web-vitals/src/index.js
+++ b/packages/sui-react-web-vitals/src/index.js
@@ -60,57 +60,6 @@ export default function WebVitalsReporter({
       return deviceType || browser?.deviceType
     }
 
-    const handleAllChanges = ({name, value, attribution}) => {
-      const pathname = getPathname()
-      const routeid = getRouteid()
-      const type = getDeviceType()
-      const isExcluded =
-        !pathname ||
-        (Array.isArray(pathnames) && !pathnames.includes(pathname)) ||
-        !METRICS_REPORTING_ALL_CHANGES.includes(name)
-
-      if (isExcluded) {
-        return
-      }
-
-      if (!logger?.distribution) {
-        return
-      }
-
-      const amount = name === METRICS.CLS ? value * 1000 : value
-
-      logger.distribution({
-        name: 'cwv',
-        amount,
-        tags: [
-          {
-            key: 'name',
-            value: name.toLowerCase()
-          },
-          {
-            key: 'pathname',
-            value: getNormalizedPathname(pathname)
-          },
-          ...(routeid
-            ? [
-                {
-                  key: 'routeid',
-                  value: routeid
-                }
-              ]
-            : []),
-          ...(type
-            ? [
-                {
-                  key: 'type',
-                  value: type
-                }
-              ]
-            : [])
-        ]
-      })
-    }
-
     const handleChange = ({name, value}) => {
       const onReport = onReportRef.current
       const pathname = getPathname()
@@ -173,11 +122,8 @@ export default function WebVitalsReporter({
     }
 
     metrics.forEach(metric => {
-      reporter[`on${metric}`](handleChange)
-    })
-
-    metrics.forEach(metric => {
-      reporter[`on${metric}`](handleAllChanges, {reportAllChanges: true})
+      const reportAllChanges = METRICS_REPORTING_ALL_CHANGES.includes(metric)
+      reporter[`on${metric}`](handleChange, {...reportAllChanges})
     })
   })
 

--- a/packages/sui-react-web-vitals/src/index.js
+++ b/packages/sui-react-web-vitals/src/index.js
@@ -81,8 +81,9 @@ export default function WebVitalsReporter({
 
       logger.log(
         JSON.stringify({
-          name: `cwv|${name.toLowerCase()}`,
-          tags: {amount, ...attribution}
+          name: `cwv.${name.toLowerCase()}`,
+          amount,
+          ...attribution
         })
       )
     }

--- a/packages/sui-react-web-vitals/src/index.js
+++ b/packages/sui-react-web-vitals/src/index.js
@@ -64,6 +64,7 @@ export default function WebVitalsReporter({
       const pathname = getPathname()
       const routeid = getRouteid()
       const type = getDeviceType()
+      const {eventTarget} = attribution || {}
       const isExcluded =
         !pathname || (Array.isArray(pathnames) && !pathnames.includes(pathname))
 
@@ -73,43 +74,9 @@ export default function WebVitalsReporter({
 
       const amount = name === METRICS.CLS ? value * 1000 : value
 
-      logger.log({
-        name: 'cwv',
-        amount,
-        tags: [
-          {
-            key: 'name',
-            value: name.toLowerCase()
-          },
-          {
-            key: 'pathname',
-            value: getNormalizedPathname(pathname)
-          },
-          ...(routeid
-            ? [
-                {
-                  key: 'routeid',
-                  value: routeid
-                }
-              ]
-            : []),
-          ...(type
-            ? [
-                {
-                  key: 'type',
-                  value: type
-                }
-              ]
-            : []),
-          ...(attribution
-            ? [
-                {
-                  key: 'attribution',
-                  value: attribution
-                }
-              ]
-            : [])
-        ]
+      logger.metric({
+        label: `cwv|${name.toLowerCase()}|${routeid}|${type}`,
+        message: `${amount}|${eventTarget}`
       })
     }
 

--- a/packages/sui-react-web-vitals/src/index.js
+++ b/packages/sui-react-web-vitals/src/index.js
@@ -69,8 +69,6 @@ export default function WebVitalsReporter({
 
     const handleAllChanges = ({attribution, name, value}) => {
       const pathname = getPathname()
-      const routeid = getRouteid()
-      const type = getDeviceType()
       const {eventTarget} = attribution || {}
       const isExcluded =
         !pathname || (Array.isArray(pathnames) && !pathnames.includes(pathname))
@@ -82,7 +80,7 @@ export default function WebVitalsReporter({
       if (amount < cwvThresholds[name]) return
 
       logger.metric({
-        label: `cwv|${name.toLowerCase()}|${routeid}|${type}`,
+        label: `cwv|${name.toLowerCase()}`,
         message: `${amount}|${eventTarget}`
       })
     }

--- a/packages/sui-react-web-vitals/src/index.js
+++ b/packages/sui-react-web-vitals/src/index.js
@@ -72,15 +72,12 @@ export default function WebVitalsReporter({
     }
 
     const handleAllChanges = ({attribution, name, value}) => {
+      const amount = name === METRICS.CLS ? value * 1000 : value
       const pathname = getPathname()
       const isExcluded =
         !pathname || (Array.isArray(pathnames) && !pathnames.includes(pathname))
 
-      if (isExcluded) return
-
-      const amount = name === METRICS.CLS ? value * 1000 : value
-
-      if (amount < thresholds[name]) return
+      if (isExcluded || !logger?.metric || amount < thresholds[name]) return
 
       logger.metric({
         name: `cwv|${name.toLowerCase()}`,
@@ -109,9 +106,7 @@ export default function WebVitalsReporter({
         return
       }
 
-      if (!logger?.distribution) {
-        return
-      }
+      if (!logger?.distribution) return
 
       const amount = name === METRICS.CLS ? value * 1000 : value
 

--- a/packages/sui-react-web-vitals/src/index.js
+++ b/packages/sui-react-web-vitals/src/index.js
@@ -174,7 +174,7 @@ WebVitalsReporter.propTypes = {
    */
   metrics: PropTypes.arrayOf(PropTypes.oneOf(Object.values(METRICS))),
   /**
-   * An optional array of core web vitals. Choose between: TTFB, LCP, FID, CLS and INP. Defaults to LCP and INP.
+   * An optional array of core web vitals that will report on all changes. Choose between: TTFB, LCP, FID, CLS and INP. Defaults to LCP and INP.
    */
   metricsAllChanges: PropTypes.arrayOf(PropTypes.oneOf(Object.values(METRICS))),
   /**

--- a/packages/sui-react-web-vitals/src/index.js
+++ b/packages/sui-react-web-vitals/src/index.js
@@ -73,7 +73,6 @@ export default function WebVitalsReporter({
 
     const handleAllChanges = ({attribution, name, value}) => {
       const pathname = getPathname()
-      const {eventTarget} = attribution || {}
       const isExcluded =
         !pathname || (Array.isArray(pathnames) && !pathnames.includes(pathname))
 
@@ -84,8 +83,8 @@ export default function WebVitalsReporter({
       if (amount < thresholds[name]) return
 
       logger.metric({
-        label: `cwv|${name.toLowerCase()}`,
-        message: `${amount}|${eventTarget}`
+        name: `cwv|${name.toLowerCase()}`,
+        tags: {amount, ...attribution}
       })
     }
 


### PR DESCRIPTION
## Description
Adding necessary features so that `reportAllChanges: true` can be configured for specific metrics, which provides more fine-grained data about **CWV** metrics. By default, setting it for `LCP` and `INP`. Also, by importing the `web-vitals/attribution` build, we're also able to collect the elements of the page related to the recorded performance metrics.

Enabling custom thresholds for metrics via props to allow for fine-tuning of performance metrics, reduce noise on reporting or simply go with Google's defined thresholds for **CWV**.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
n/a

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
