### PR TITLE
fix(packages/sui-react-web-vitals): fix path normalizer

### DIFF
--- a/packages/sui-react-web-vitals/src/index.js
+++ b/packages/sui-react-web-vitals/src/index.js
@@ -34,7 +34,7 @@ export const DEVICE_TYPES = {
 }
 
 const getNormalizedPathname = pathname => {
-  return pathname.replaceAll('*', '_')
+  return pathname.replaceAll('*', '_').replace(/\\/g, '')
 }
 
 export default function WebVitalsReporter({


### PR DESCRIPTION
## Description
To fix some tag values not being collected by Datadog. 

Prior to this, data coming from pathnames as regexps was not being properly collected by Datadog.

## Related Issue
n/a

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
