### PR TITLE
fix(packages/sui-js): upgrade qs version for security

### DIFF
--- a/packages/sui-js/package.json
+++ b/packages/sui-js/package.json
@@ -20,7 +20,7 @@
     "lodash.debounce": "4.0.8",
     "lodash.throttle": "4.1.1",
     "nanoid": "3.3.1",
-    "qs": "6.7.3",
+    "qs": "6.11.2",
     "remove-accents": "0.4.2"
   },
   "license": "MIT",


### PR DESCRIPTION
In this repository there is no this dependabot alert, but in Milanuncios web app repository dependabot is saying to upgrade qs.

## Description
Upgrade qs version for security in packages/sui-js

![image](https://github.com/SUI-Components/sui/assets/1105226/0612c835-5afb-43d5-a354-7fac1a4c906e)

