### PR TITLE
Feat sui web vitals reporter simplify pathname normalizer when route has a RegExp

### DIFF
--- a/packages/sui-react-web-vitals/src/index.js
+++ b/packages/sui-react-web-vitals/src/index.js
@@ -18,9 +18,9 @@ export const METRICS = {
 
 // https://github.com/GoogleChrome/web-vitals#metric
 const RATING = {
-  good: 'good',
-  needsImprovement: 'needs-improvement',
-  poor: 'poor'
+  GOOD: 'good',
+  NEEDS_IMPROVEMENT: 'needs-improvement',
+  POOR: 'poor'
 }
 
 const DEFAULT_METRICS_REPORTING_ALL_CHANGES = [
@@ -103,7 +103,7 @@ export default function WebVitalsReporter({
       const isExcluded =
         !pathname || (Array.isArray(pathnames) && !pathnames.includes(pathname))
 
-      if (isExcluded || !logger?.cwv || rating === RATING.good) return
+      if (isExcluded || !logger?.cwv || rating === RATING.GOOD) return
 
       const target = getTarget({name, attribution})
 

--- a/packages/sui-react-web-vitals/src/index.js
+++ b/packages/sui-react-web-vitals/src/index.js
@@ -53,8 +53,8 @@ const getPathname = route => {
   return route?.path || route?.regexp?.toString()
 }
 
-const getPathIsRegexp = route => {
-  return !route?.path
+const getHasPathOnRoute = route => {
+  return route?.path
 }
 
 export default function WebVitalsReporter({
@@ -99,7 +99,7 @@ export default function WebVitalsReporter({
     const handleAllChanges = ({attribution, name, rating, value}) => {
       const amount = name === METRICS.CLS ? value * 1000 : value
       const pathname = getPathname(route)
-      const pathIsRegexp = getPathIsRegexp(route)
+      const hasPathOnRoute = getHasPathOnRoute(route)
       const isExcluded =
         !pathname || (Array.isArray(pathnames) && !pathnames.includes(pathname))
 
@@ -110,7 +110,7 @@ export default function WebVitalsReporter({
       logger.cwv({
         name: `cwv.${name.toLowerCase()}`,
         amount,
-        path: pathIsRegexp ? getNormalizedPathname(pathname) : pathname,
+        path: hasPathOnRoute ? pathname : getNormalizedPathname(pathname),
         target,
         loadState: attribution.loadState
       })
@@ -119,7 +119,7 @@ export default function WebVitalsReporter({
     const handleChange = ({name, value}) => {
       const onReport = onReportRef.current
       const pathname = getPathname(route)
-      const pathIsRegexp = getPathIsRegexp(route)
+      const hasPathOnRoute = getHasPathOnRoute(route)
       const routeid = getRouteid()
       const type = getDeviceType()
       const isExcluded =
@@ -131,7 +131,7 @@ export default function WebVitalsReporter({
         onReport({
           name,
           amount: value,
-          pathname: pathIsRegexp ? getNormalizedPathname(pathname) : pathname,
+          pathname: hasPathOnRoute ? pathname : getNormalizedPathname(pathname),
           routeid,
           type
         })
@@ -152,7 +152,7 @@ export default function WebVitalsReporter({
           },
           {
             key: 'pathname',
-            value: pathIsRegexp ? getNormalizedPathname(pathname) : pathname
+            value: hasPathOnRoute ? pathname : getNormalizedPathname(pathname)
           },
           ...(routeid
             ? [

--- a/packages/sui-react-web-vitals/src/index.js
+++ b/packages/sui-react-web-vitals/src/index.js
@@ -54,7 +54,7 @@ const getPathname = route => {
 }
 
 const getPathIsRegexp = route => {
-  return Boolean(route?.path)
+  return !route?.path
 }
 
 export default function WebVitalsReporter({

--- a/packages/sui-react-web-vitals/src/index.js
+++ b/packages/sui-react-web-vitals/src/index.js
@@ -87,9 +87,9 @@ export default function WebVitalsReporter({
 
     const getTarget = ({name, attribution}) => {
       switch (name) {
-        case 'CLS':
+        case METRICS.CLS:
           return attribution.largestShiftTarget
-        case 'LCP':
+        case METRICS.LCP:
           return attribution.element
         default:
           return attribution.eventTarget

--- a/packages/sui-react-web-vitals/src/index.js
+++ b/packages/sui-react-web-vitals/src/index.js
@@ -54,7 +54,7 @@ const getPathname = route => {
 }
 
 const getHasPathOnRoute = route => {
-  return route?.path
+  return Boolean(route?.path)
 }
 
 export default function WebVitalsReporter({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Improve pathname normalizer for routes with regexps as it's been an issue when collecting data.
As of now, a simple character replacement was applied to some characters. Now, all non-alphanumeric characters will be stripped of the regexp literal and sent as `pathname` to avoid missing data.  
Also, some minor variable renaming.

## Related Issue
N/A

## Example

Before:

````
'/\\/.*\\x2D(\\d{4,9})\\x2D[a-z]{2,4}(vo|vn).aspx$/'
    .replaceAll('*', '_')
    .replace(/\\/g, '')
    .replace(/\//g, '')
    .replaceAll('._', ':');

OUTPUT:
':x2D(d{4,9})x2D[a-z]{2,4}(vo|vn).aspx$'
````

After:

````
'/\\/.*\\x2D(\\d{4,9})\\x2D[a-z]{2,4}(vo|vn).aspx$/'
    .replace(/[^a-z0-9]/gi, '');

OUTPUT:
'x2Dd49x2Daz24vovnaspx'
````


