### PR TITLE
[feature][sui-pde] Remove Experiment Viewed event by default.

### DIFF
--- a/packages/sui-pde/README.md
+++ b/packages/sui-pde/README.md
@@ -229,6 +229,18 @@ const optimizelyAdapter = new OptimizelyAdapter({
 })
 ```
 
+#### Track Experiment Viewed
+
+In order to reduce unnecessary calls to Segment, the `Experiment Viewed` event is disabled by default.
+
+If you need to track how many times your experiment has been viewed, you should set the `shouldTrackExperimentViewed` argument to true.
+
+```js
+const {isActive, variables} = useFeature('myFeatureKey',  undefined, undefined, undefined, true)
+```
+
+A refactoring task is pending to transition the hook's positional parameters to named parameters.
+
 #### Attributes
 
 In order to pass by attributes, you'll able to do so by adding the second argument as `attributes` when using the useFeature hook. Something like this:

--- a/packages/sui-pde/src/hooks/useFeature.js
+++ b/packages/sui-pde/src/hooks/useFeature.js
@@ -61,7 +61,8 @@ export default function useFeature(
   featureKey,
   attributes,
   queryString,
-  adapterId
+  adapterId,
+  shouldTrackExperimentViewed
 ) {
   const {pde} = useContext(PdeContext)
   if (pde === null)
@@ -91,18 +92,20 @@ export default function useFeature(
       adapterId
     })
 
-    trackFeatureFlagViewed({
-      isActive,
-      trackExperimentViewed: strategy.trackExperiment,
-      featureKey
-    })
-    trackLinkedExperimentsViewed({
-      linkedExperiments,
-      trackExperimentViewed: strategy.trackExperiment,
-      pde,
-      attributes,
-      adapterId
-    })
+    if (shouldTrackExperimentViewed) {
+      trackFeatureFlagViewed({
+        isActive,
+        trackExperimentViewed: strategy.trackExperiment,
+        featureKey
+      })
+      trackLinkedExperimentsViewed({
+        linkedExperiments,
+        trackExperimentViewed: strategy.trackExperiment,
+        pde,
+        attributes,
+        adapterId
+      })
+    }
     return {isActive, variables}
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/packages/sui-pde/test/common/useFeatureSpec.js
+++ b/packages/sui-pde/test/common/useFeatureSpec.js
@@ -128,9 +128,19 @@ describe('when pde context is set', () => {
         })
 
         it('should send the on state experiment viewed', () => {
-          renderHook(() => useFeature('activeFeatureFlagKey'), {
-            wrapper
-          })
+          renderHook(
+            () =>
+              useFeature(
+                'activeFeatureFlagKey',
+                undefined,
+                undefined,
+                undefined,
+                true
+              ),
+            {
+              wrapper
+            }
+          )
           expect(window.analytics.track.args[0][0]).to.equal(
             'Experiment Viewed'
           )
@@ -142,12 +152,32 @@ describe('when pde context is set', () => {
 
         describe.client('when a feature is seen twice', () => {
           it('should only track one experiment viewed event', () => {
-            renderHook(() => useFeature('repeatedFeatureFlagKey'), {
-              wrapper
-            })
-            renderHook(() => useFeature('repeatedFeatureFlagKey'), {
-              wrapper
-            })
+            renderHook(
+              () =>
+                useFeature(
+                  'repeatedFeatureFlagKey',
+                  undefined,
+                  undefined,
+                  undefined,
+                  true
+                ),
+              {
+                wrapper
+              }
+            )
+            renderHook(
+              () =>
+                useFeature(
+                  'repeatedFeatureFlagKey',
+                  undefined,
+                  undefined,
+                  undefined,
+                  true
+                ),
+              {
+                wrapper
+              }
+            )
             expect(window.analytics.track.args.length).to.equal(1)
           })
         })
@@ -184,9 +214,19 @@ describe('when pde context is set', () => {
         })
 
         it('should send the off state experiment viewed', () => {
-          renderHook(() => useFeature('notActiveFeatureFlagKey'), {
-            wrapper
-          })
+          renderHook(
+            () =>
+              useFeature(
+                'notActiveFeatureFlagKey',
+                undefined,
+                undefined,
+                undefined,
+                true
+              ),
+            {
+              wrapper
+            }
+          )
           expect(window.analytics.track.args[0][0]).to.equal(
             'Experiment Viewed'
           )
@@ -238,9 +278,19 @@ describe('when pde context is set', () => {
     })
 
     it('should send experiment viewed event for every test asociated and the experiment viewed associated to the feature flag itself', () => {
-      renderHook(() => useFeature('featureKey4', {attribute1: 'value'}), {
-        wrapper
-      })
+      renderHook(
+        () =>
+          useFeature(
+            'featureKey4',
+            {attribute1: 'value'},
+            undefined,
+            undefined,
+            true
+          ),
+        {
+          wrapper
+        }
+      )
 
       // feature being called
       expect(window.analytics.track.args[0][0]).to.equal('Experiment Viewed')
@@ -315,12 +365,32 @@ describe('when pde context is set', () => {
           stubFactory(isFeatureEnabled)
         })
         it('should send only one experiment viewed event', () => {
-          renderHook(() => useFeature('repeatedFeatureFlagKey'), {
-            wrapper
-          })
-          renderHook(() => useFeature('repeatedFeatureFlagKey'), {
-            wrapper
-          })
+          renderHook(
+            () =>
+              useFeature(
+                'repeatedFeatureFlagKey',
+                undefined,
+                undefined,
+                undefined,
+                true
+              ),
+            {
+              wrapper
+            }
+          )
+          renderHook(
+            () =>
+              useFeature(
+                'repeatedFeatureFlagKey',
+                undefined,
+                undefined,
+                undefined,
+                true
+              ),
+            {
+              wrapper
+            }
+          )
           expect(window.analytics.track.args.length).to.equal(1)
         })
       })
@@ -338,12 +408,32 @@ describe('when pde context is set', () => {
           stubFactory(isFeatureEnabled)
         })
         it('should send two experiment viewed events', () => {
-          renderHook(() => useFeature('repeatedFeatureFlagKey'), {
-            wrapper
-          })
-          renderHook(() => useFeature('repeatedFeatureFlagKey'), {
-            wrapper
-          })
+          renderHook(
+            () =>
+              useFeature(
+                'repeatedFeatureFlagKey',
+                undefined,
+                undefined,
+                undefined,
+                true
+              ),
+            {
+              wrapper
+            }
+          )
+          renderHook(
+            () =>
+              useFeature(
+                'repeatedFeatureFlagKey',
+                undefined,
+                undefined,
+                undefined,
+                true
+              ),
+            {
+              wrapper
+            }
+          )
           expect(window.analytics.track.args.length).to.equal(2)
         })
       })


### PR DESCRIPTION
## Description
In order to reduce unnecessary calls to Segment, the Experiment Viewed event is disabled by default.

If you need to track how many times your experiment has been viewed, you should set the shouldTrackExperimentViewed argument to true.

## Related Issue
https://github.com/SUI-Components/sui/issues/1601

## Example

```js
    const {isActive} =  useFeature(
            'featureKey4',
            {attribute1: 'value'},
            undefined,
            undefined,
            true
          )
```
