### PR TITLE
feat(packages/sui-ssr): 

### DIFF
--- a/packages/sui-ssr/hooks-types.js
+++ b/packages/sui-ssr/hooks-types.js
@@ -7,6 +7,7 @@ export default {
   PRE_HEALTH: 'pre_health',
   SETUP_CONTEXT: 'setup_context',
   PRE_SSR_HANDLER: 'pre_ssr_handler',
+  CSP_REPORT: 'csp-report',
   PRE_STATIC_PUBLIC: 'pre_static_public',
   ROUTE_MATCHING: 'route_matching'
 }

--- a/packages/sui-ssr/server/hooksFactory/index.js
+++ b/packages/sui-ssr/server/hooksFactory/index.js
@@ -114,6 +114,8 @@ export const hooksFactory = async () => {
       return next()
     },
     [TYPES.LOGGING]: NULL_MDWL,
+    [TYPES.CSP_REPORT]: (req, res) =>
+      res.status(200).json({message: 'Tracking disabled'}),
     [TYPES.PRE_STATIC_PUBLIC]: NULL_MDWL,
     [TYPES.SETUP_CONTEXT]: async (req, res, next) => {
       const startContextCreationTime = process.hrtime()

--- a/packages/sui-ssr/server/index.js
+++ b/packages/sui-ssr/server/index.js
@@ -1,4 +1,5 @@
 /* eslint no-console:0 */
+import bodyParser from 'body-parser'
 import compression from 'compression'
 import express from 'express'
 import basicAuth from 'express-basic-auth'
@@ -17,9 +18,9 @@ import {
 import ssrConf from './config.js'
 noOPConsole(console)
 
-if (process.env.CONSOLE) {
-  console._restore()
-}
+// if (process.env.CONSOLE) {
+console._restore()
+// }
 
 const app = express()
 
@@ -56,6 +57,13 @@ const _memoizedHtmlTemplatesMapping = {}
 
   app.use(hooks[TYPES.ROUTE_MATCHING])
   app.use(hooks[TYPES.LOGGING])
+
+  app.post(
+    `/${TYPES.CSP_REPORT}`,
+    bodyParser.json({type: 'application/csp-report'}),
+    hooks[TYPES.CSP_REPORT]
+  )
+
   runningUnderAuth && app.use(basicAuth(AUTH_DEFINITION))
   app.use(express.static('statics'))
 

--- a/packages/sui-ssr/server/index.js
+++ b/packages/sui-ssr/server/index.js
@@ -18,9 +18,9 @@ import {
 import ssrConf from './config.js'
 noOPConsole(console)
 
-// if (process.env.CONSOLE) {
-console._restore()
-// }
+if (process.env.CONSOLE) {
+  console._restore()
+}
 
 const app = express()
 

--- a/packages/sui-ssr/server/middlewares/ssr.js
+++ b/packages/sui-ssr/server/middlewares/ssr.js
@@ -37,6 +37,8 @@ try {
 const HEAD_OPENING_TAG = '<head>'
 const HEAD_CLOSING_TAG = '</head>'
 
+const CSP_REPORT_PATH = '/csp-report'
+
 const formatServerTimingHeader = metrics =>
   Object.entries(metrics)
     .reduce((acc, [name, value]) => `${acc}${name};dur=${value},`, '')
@@ -201,6 +203,10 @@ export default async (req, res, next) => {
   // Otherwise some undesired/duplicated html could be attached to the error pages if an error occurs
   const {bodyAttributes, headString, htmlAttributes} =
     renderHeadTagsToString(headTags)
+
+  res.set({
+    'Content-Security-Policy-Report-Only': `default-src 'self'; report-uri ${CSP_REPORT_PATH}`
+  })
 
   res.set({
     'Server-Timing': formatServerTimingHeader({

--- a/packages/sui-ssr/server/middlewares/ssr.js
+++ b/packages/sui-ssr/server/middlewares/ssr.js
@@ -205,14 +205,11 @@ export default async (req, res, next) => {
     renderHeadTagsToString(headTags)
 
   res.set({
-    'Content-Security-Policy-Report-Only': `default-src 'self'; report-uri ${CSP_REPORT_PATH}`
-  })
-
-  res.set({
     'Server-Timing': formatServerTimingHeader({
       ...performance,
       ...ssrPerformance
-    })
+    }),
+    'Content-Security-Policy-Report-Only': `default-src 'self'; report-uri ${CSP_REPORT_PATH}`
   })
   res.write(HtmlBuilder.buildHead({headTplPart, headString, htmlAttributes}))
   res.flush()


### PR DESCRIPTION
## Description
Add the CSP report HTTP header and create a new link so each site can handle the report.
This header will be useful to us to know what resources we need and where they come from (the report will only contain resources from other domains), and this way, once we know what they are, we can create a list of allowed domains. Finally, we will use the CSP header which directly blocks any resources that are not in our allowed list.

More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only


## Example

https://github.com/SUI-Components/sui/assets/55990391/5999f95e-69e6-4aa4-a578-ec57d79b4840


<img width="1411" alt="image" src="https://github.com/SUI-Components/sui/assets/55990391/4aa48ac6-523b-4f91-a981-55c861a29b4c">



