### PR TITLE
feat(packages/sui-lint): update line length to 120 characters

### DIFF
--- a/packages/sui-lint/.prettierrc.js
+++ b/packages/sui-lint/.prettierrc.js
@@ -8,7 +8,7 @@ module.exports = {
   /* Support optional chaining new ES feature -> ? */
   optionalChaining: true,
   /* Specify the line length that the printer will wrap on. */
-  printWidth: 80,
+  printWidth: 120,
   /* Print semicolons at the ends of statements. */
   semi: false,
   /* Use single quotes instead of double quotes. */


### PR DESCRIPTION
## Description
New screens are wider and have larger resolutions so it seems it's about time to be able to read our code on longer than 80-character lines.

Code chunk with 80-character lines:
![image](https://github.com/SUI-Components/sui/assets/18154356/6f675228-6077-408b-9184-ed8d2fbb2b4a)

Same code chunk with 120-character lines:
![image](https://github.com/SUI-Components/sui/assets/18154356/4433b080-11bc-403f-a1bd-0647d93b46a1)

## Related Issue
N/A

## Example
N/A
