### PR TITLE
fix(packages/sui-ssr): safe check of type

### DIFF
--- a/packages/sui-ssr/server/initialContextValue/index.js
+++ b/packages/sui-ssr/server/initialContextValue/index.js
@@ -15,7 +15,7 @@ export const INITIAL_CONTEXT_VALUE = '__INITIAL_CONTEXT_VALUE__'
 export const getInitialContextValue = context =>
   Object.keys(context)
     .filter(
-      contextKey => typeof context[contextKey].getInitialData === 'function'
+      contextKey => typeof context[contextKey]?.getInitialData === 'function'
     )
     .reduce((acc, contextKey) => {
       acc[contextKey] = context[contextKey].getInitialData()


### PR DESCRIPTION
## Description
In some web app implementations when is a new user then `cookies` on SSR will be `undefined`. If the web app doesn't inject an empty string, this line will fail on SSR.

<img width="954" alt="image" src="https://github.com/SUI-Components/sui/assets/45286922/965267ca-ff17-4811-b0cd-20949140322e">


## Related Issue
@danilucaci reproduced the error on habitaclia
