### PR TITLE
feat(packages/sui-react-router): avoid extra render during first load

### DIFF
--- a/packages/sui-react-router/src/Router.js
+++ b/packages/sui-react-router/src/Router.js
@@ -65,7 +65,7 @@ const Router = ({
   const [state, setState] = useState({router, params, components})
 
   useEffect(() => {
-    let prevState = {}
+    let prevState = null
     const handleTransition = (err, nextState) => {
       if (err) {
         if (onError) return onError(err)
@@ -73,8 +73,17 @@ const Router = ({
       }
 
       // avoid not needed re-renders of the state if the prevState and the nextState
-      // are the same reference
-      if (prevState === nextState) return
+      // are the same reference or if the first render
+
+      if (!prevState) {
+        prevState = nextState
+        return
+      }
+
+      if (prevState === nextState) {
+        return
+      }
+
       prevState = nextState
 
       const {components, params, location, routes} = nextState

--- a/packages/sui-react-router/src/Router.js
+++ b/packages/sui-react-router/src/Router.js
@@ -65,7 +65,9 @@ const Router = ({
   const [state, setState] = useState({router, params, components})
 
   useEffect(() => {
-    let prevState = null
+    let prevState = {}
+    let isSkipped = !!matchContext
+
     const handleTransition = (err, nextState) => {
       if (err) {
         if (onError) return onError(err)
@@ -75,8 +77,8 @@ const Router = ({
       // avoid not needed re-renders of the state if the prevState and the nextState
       // are the same reference or if the first render
 
-      if (!prevState) {
-        prevState = nextState
+      if (isSkipped) {
+        isSkipped = false
         return
       }
 

--- a/packages/sui-react-router/src/Router.js
+++ b/packages/sui-react-router/src/Router.js
@@ -79,6 +79,7 @@ const Router = ({
 
       if (isSkipped) {
         isSkipped = false
+        prevState = nextState
         return
       }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR avoid an extra re-render in the `Router` component. Normally this causes the application to re-render twice during first load

## Related Issue
None

## Example
None
