### PR TITLE
feat(packages/sui-test-contract): make jobs execution halt on contract publish errors

### DIFF
--- a/packages/sui-test-contract/bin/sui-test-contract-publish.js
+++ b/packages/sui-test-contract/bin/sui-test-contract-publish.js
@@ -37,6 +37,6 @@ new Publisher(options)
     console.log(`Pact contract for consumer version ${options.consumerVersion} published!`)
     console.log(`Head over to ${brokerUrl} and login with to see your published contracts.`)
   })
-  .catch(e => {
-    console.log('Pact contract publishing failed: ', e)
+  .catch(error => {
+    throw new Error(`Pact contract publishing failed: ${error}`)
   })


### PR DESCRIPTION
## Description
When there are some errors executing `sui-test-contract publish` command in CI, the job where the command is being executed will never fail neither stop. So we need to explicitly throw an error.