### PR TITLE
sui-lint ignore-patterns option

### DIFF
--- a/packages/sui-lint/bin/sui-lint-js.js
+++ b/packages/sui-lint/bin/sui-lint-js.js
@@ -12,9 +12,10 @@ program
   .option('--add-fixes')
   .option('--staged')
   .option('--fix', 'fix automatically problems with js files')
+  .option('--ignore-pattern <ignorePattern...>', 'Path pattern to ignore for linting')
   .parse(process.argv)
 
-const {addFixes, fix, staged} = program.opts()
+const {addFixes, fix, ignorePattern = [], staged} = program.opts()
 
 const {CI} = process.env
 const EXTENSIONS = ['js', 'jsx', 'ts', 'tsx']
@@ -23,7 +24,7 @@ const DEFAULT_PATTERN = './'
 const LINT_FORMATTER = 'stylish'
 const baseConfig = {
   ...config,
-  ignorePatterns: IGNORE_PATTERNS.concat(getGitIgnoredFiles())
+  ignorePatterns: IGNORE_PATTERNS.concat(getGitIgnoredFiles()).concat(ignorePattern)
 }
 
 ;(async function main() {

--- a/packages/sui-lint/bin/sui-lint-js.js
+++ b/packages/sui-lint/bin/sui-lint-js.js
@@ -12,10 +12,10 @@ program
   .option('--add-fixes')
   .option('--staged')
   .option('--fix', 'fix automatically problems with js files')
-  .option('--ignore-pattern <ignorePattern...>', 'Path pattern to ignore for linting')
+  .option('--ignore-patterns <ignorePatterns...>', 'Path patterns to ignore for linting')
   .parse(process.argv)
 
-const {addFixes, fix, ignorePattern = [], staged} = program.opts()
+const {addFixes, fix, ignorePatterns = [], staged} = program.opts()
 
 const {CI} = process.env
 const EXTENSIONS = ['js', 'jsx', 'ts', 'tsx']
@@ -24,7 +24,7 @@ const DEFAULT_PATTERN = './'
 const LINT_FORMATTER = 'stylish'
 const baseConfig = {
   ...config,
-  ignorePatterns: IGNORE_PATTERNS.concat(getGitIgnoredFiles()).concat(ignorePattern)
+  ignorePatterns: IGNORE_PATTERNS.concat(getGitIgnoredFiles()).concat(ignorePatterns)
 }
 
 ;(async function main() {


### PR DESCRIPTION
## Description
Sometimes (on CI, on a local environment...) you may want to skip some additional folders when running `sui-lint js`. On a monorepo, a common example could be the components' `demo` or the `test-e2e` folders. 

## Related Issue
N/A

## Example
`npx @s-ui/lint js -- --ignore-patterns demo test-e2e`
...this will allow you to skip `demo` folders and sub-folders as well as `test-e2e`.