### PR TITLE
fix(packages/sui-ssr): use custom env variable instead of NODE_ENV to…

### DIFF
--- a/packages/sui-ssr/bin/sui-ssr-dev.js
+++ b/packages/sui-ssr/bin/sui-ssr-dev.js
@@ -3,6 +3,7 @@
 
 const {WEBPACK_PORT = 8080} = process.env
 process.env.CDN = `http://localhost:${WEBPACK_PORT}/`
+process.env.DEV_SERVER = 'true'
 
 const program = require('commander')
 const {exec} = require('child_process')

--- a/packages/sui-ssr/server/utils/factory.js
+++ b/packages/sui-ssr/server/utils/factory.js
@@ -29,7 +29,7 @@ export default ({path, fs, config: ssrConf = {}, assetsManifest}) => {
   }
 
   const publicFolder = req => {
-    if (process.env.NODE_ENV !== 'production') {
+    if (process.env.DEV_SERVER === 'true') {
       return DEFAULT_DEV_PUBLIC_FOLDER
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use custom env variable to check if development server is being used. Some application relies on `NODE_ENV=development` even when building
