### PR TITLE
:mag: feat(packages/sui-polyfills): add polyfill for string is|to wellFormed

### DIFF
--- a/packages/sui-polyfills/src/index.js
+++ b/packages/sui-polyfills/src/index.js
@@ -31,6 +31,8 @@ require('core-js/features/map/map-keys')
 
 require('core-js/features/symbol')
 
+require('core-js/proposals/well-formed-unicode-strings')
+
 require('element-polyfill/polyfills/element.parent-node.append.js')
 
 require('./element-closest.js')


### PR DESCRIPTION
Add a corejs polyfill for `String.prototype.{is,to}WellFormed` since it is not available in all browsers and we need it in Fotocasa.

## Description
Add a corejs polyfill for `String.prototype.{is,to}WellFormed` since it is not available in all browsers and we need it in Fotocasa.