### PR TITLE
🔍: Upgrade Axios to 1.6.2 to fix the sui-domain and sui-mockmock vulnerabilities

### DIFF
--- a/packages/sui-domain/package.json
+++ b/packages/sui-domain/package.json
@@ -17,6 +17,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "axios": "0.21.2"
+    "axios": "1.6.2"
   }
 }

--- a/packages/sui-mockmock/package.json
+++ b/packages/sui-mockmock/package.json
@@ -22,7 +22,7 @@
     "sinon": "10.0.0"
   },
   "devDependencies": {
-    "axios": "0.21.2"
+    "axios": "1.6.2"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Description

Upgrade Axios to 1.6.2 to fix the [sui-domain](https://github.com/SUI-Components/sui/security/dependabot/37) and [sui-mockmock](https://github.com/SUI-Components/sui/security/dependabot/38) vulnerabilities

