### PR TITLE
add adv-ui package to sui-test mocha compiler

### DIFF
--- a/packages/sui-test/bin/mocha/register.js
+++ b/packages/sui-test/bin/mocha/register.js
@@ -8,7 +8,7 @@ if (esmOverride) {
 }
 
 const libDir = /lib/
-const paths = [/@babel\/runtime/, /@s-ui/, /mocks/, /src/, /test/, libDir, ...regexToAdd]
+const paths = [/@babel\/runtime/, /@s-ui/, /@adv-ui/, /mocks/, /src/, /test/, libDir, ...regexToAdd]
 
 require('@babel/register')({
   ignore: [],


### PR DESCRIPTION
SUI-TEST / MOCHA / ADV-UI

## Description
The adv-ui package was not in the babel build for mocha. This caused that when we imported adv-ui packages into our portals and wanted to run server tests, they crashed.

## Related Issue
[SCMI-111632](https://jira.ets.mpi-internal.com/browse/SCMI-111632)

