### PR TITLE
feat(packages/sui-test-contract): use GITHUB_HEAD_REF and GITHUB_REF_NAME and add Tags info on console logging

### DIFF
--- a/packages/sui-test-contract/bin/sui-test-contract-publish.js
+++ b/packages/sui-test-contract/bin/sui-test-contract-publish.js
@@ -18,7 +18,7 @@ program
 const {brokerUrl} = program.opts()
 if (!brokerUrl) throw new Error('You need to specify the broker URL where the contracts will be published.')
 const contractsDir = path.resolve(process.cwd(), 'contract/documents')
-const {GHA_REF, GITHUB_REF, GITHUB_SHA, TRAVIS_PULL_REQUEST_BRANCH, TRAVIS_BRANCH, TRAVIS_COMMIT, TRAVIS_PULL_REQUEST_SHA} =
+const {GHA_REF, GITHUB_REF, GHA_SHA, GITHUB_SHA, TRAVIS_PULL_REQUEST_BRANCH, TRAVIS_BRANCH, TRAVIS_COMMIT, TRAVIS_PULL_REQUEST_SHA} =
   process.env
 
 const branch = TRAVIS_PULL_REQUEST_BRANCH || TRAVIS_BRANCH || GHA_REF || GITHUB_REF || exec('git rev-parse --abbrev-ref HEAD')

--- a/packages/sui-test-contract/bin/sui-test-contract-publish.js
+++ b/packages/sui-test-contract/bin/sui-test-contract-publish.js
@@ -18,11 +18,24 @@ program
 const {brokerUrl} = program.opts()
 if (!brokerUrl) throw new Error('You need to specify the broker URL where the contracts will be published.')
 const contractsDir = path.resolve(process.cwd(), 'contract/documents')
-const {GITHUB_HEAD_REF, GITHUB_REF, GITHUB_REF_NAME, GITHUB_SHA, TRAVIS_PULL_REQUEST_BRANCH, TRAVIS_BRANCH, 
-  TRAVIS_COMMIT, TRAVIS_PULL_REQUEST_SHA} = process.env
+const {
+  GITHUB_HEAD_REF,
+  GITHUB_REF,
+  GITHUB_REF_NAME,
+  GITHUB_SHA,
+  TRAVIS_PULL_REQUEST_BRANCH,
+  TRAVIS_BRANCH,
+  TRAVIS_COMMIT,
+  TRAVIS_PULL_REQUEST_SHA
+} = process.env
 
-const branch = TRAVIS_PULL_REQUEST_BRANCH || TRAVIS_BRANCH || GITHUB_HEAD_REF || GITHUB_REF_NAME || 
-  GITHUB_REF || exec('git rev-parse --abbrev-ref HEAD')
+const branch =
+  TRAVIS_PULL_REQUEST_BRANCH ||
+  TRAVIS_BRANCH ||
+  GITHUB_HEAD_REF ||
+  GITHUB_REF_NAME ||
+  GITHUB_REF ||
+  exec('git rev-parse --abbrev-ref HEAD')
 const consumerVersion = TRAVIS_PULL_REQUEST_SHA || TRAVIS_COMMIT || GITHUB_SHA
 
 const options = {

--- a/packages/sui-test-contract/bin/sui-test-contract-publish.js
+++ b/packages/sui-test-contract/bin/sui-test-contract-publish.js
@@ -18,11 +18,11 @@ program
 const {brokerUrl} = program.opts()
 if (!brokerUrl) throw new Error('You need to specify the broker URL where the contracts will be published.')
 const contractsDir = path.resolve(process.cwd(), 'contract/documents')
-const {GITHUB_REF, GITHUB_SHA, TRAVIS_PULL_REQUEST_BRANCH, TRAVIS_BRANCH, TRAVIS_COMMIT, TRAVIS_PULL_REQUEST_SHA} =
+const {GHA_REF, GITHUB_REF, GITHUB_SHA, TRAVIS_PULL_REQUEST_BRANCH, TRAVIS_BRANCH, TRAVIS_COMMIT, TRAVIS_PULL_REQUEST_SHA} =
   process.env
 
-const branch = TRAVIS_PULL_REQUEST_BRANCH || TRAVIS_BRANCH || GITHUB_REF || exec('git rev-parse --abbrev-ref HEAD')
-const consumerVersion = TRAVIS_PULL_REQUEST_SHA || TRAVIS_COMMIT || GITHUB_SHA
+const branch = TRAVIS_PULL_REQUEST_BRANCH || TRAVIS_BRANCH || GHA_REF || GITHUB_REF || exec('git rev-parse --abbrev-ref HEAD')
+const consumerVersion = TRAVIS_PULL_REQUEST_SHA || TRAVIS_COMMIT || GHA_SHA || GITHUB_SHA
 
 const options = {
   pactFilesOrDirs: [contractsDir],

--- a/packages/sui-test-contract/bin/sui-test-contract-publish.js
+++ b/packages/sui-test-contract/bin/sui-test-contract-publish.js
@@ -35,7 +35,8 @@ new Publisher(options)
   .publishPacts()
   .then(() => {
     console.log(`Pact contract for consumer version ${options.consumerVersion} published!`)
-    console.log(`Head over to ${brokerUrl} and login with to see your published contracts.`)
+    console.log(`Head over to ${brokerUrl} and login to see your published contracts.`)
+    console.log(`Tags: ${branch}`)
   })
   .catch(error => {
     throw new Error(`Pact contract publishing failed: ${error}`)

--- a/packages/sui-test-contract/bin/sui-test-contract-publish.js
+++ b/packages/sui-test-contract/bin/sui-test-contract-publish.js
@@ -18,10 +18,11 @@ program
 const {brokerUrl} = program.opts()
 if (!brokerUrl) throw new Error('You need to specify the broker URL where the contracts will be published.')
 const contractsDir = path.resolve(process.cwd(), 'contract/documents')
-const {GITHUB_HEAD_REF, GITHUB_REF, GITHUB_REF_NAME, GITHUB_SHA, TRAVIS_PULL_REQUEST_BRANCH, TRAVIS_BRANCH, TRAVIS_COMMIT, TRAVIS_PULL_REQUEST_SHA} =
-  process.env
+const {GITHUB_HEAD_REF, GITHUB_REF, GITHUB_REF_NAME, GITHUB_SHA, TRAVIS_PULL_REQUEST_BRANCH, TRAVIS_BRANCH, 
+  TRAVIS_COMMIT, TRAVIS_PULL_REQUEST_SHA} = process.env
 
-const branch = TRAVIS_PULL_REQUEST_BRANCH || TRAVIS_BRANCH || GITHUB_HEAD_REF || GITHUB_REF_NAME || GITHUB_REF || exec('git rev-parse --abbrev-ref HEAD')
+const branch = TRAVIS_PULL_REQUEST_BRANCH || TRAVIS_BRANCH || GITHUB_HEAD_REF || GITHUB_REF_NAME || 
+  GITHUB_REF || exec('git rev-parse --abbrev-ref HEAD')
 const consumerVersion = TRAVIS_PULL_REQUEST_SHA || TRAVIS_COMMIT || GITHUB_SHA
 
 const options = {

--- a/packages/sui-test-contract/bin/sui-test-contract-publish.js
+++ b/packages/sui-test-contract/bin/sui-test-contract-publish.js
@@ -18,11 +18,11 @@ program
 const {brokerUrl} = program.opts()
 if (!brokerUrl) throw new Error('You need to specify the broker URL where the contracts will be published.')
 const contractsDir = path.resolve(process.cwd(), 'contract/documents')
-const {GHA_REF, GITHUB_REF, GHA_SHA, GITHUB_SHA, TRAVIS_PULL_REQUEST_BRANCH, TRAVIS_BRANCH, TRAVIS_COMMIT, TRAVIS_PULL_REQUEST_SHA} =
+const {GITHUB_HEAD_REF, GITHUB_REF, GITHUB_REF_NAME, GITHUB_SHA, TRAVIS_PULL_REQUEST_BRANCH, TRAVIS_BRANCH, TRAVIS_COMMIT, TRAVIS_PULL_REQUEST_SHA} =
   process.env
 
-const branch = TRAVIS_PULL_REQUEST_BRANCH || TRAVIS_BRANCH || GHA_REF || GITHUB_REF || exec('git rev-parse --abbrev-ref HEAD')
-const consumerVersion = TRAVIS_PULL_REQUEST_SHA || TRAVIS_COMMIT || GHA_SHA || GITHUB_SHA
+const branch = TRAVIS_PULL_REQUEST_BRANCH || TRAVIS_BRANCH || GITHUB_HEAD_REF || GITHUB_REF_NAME || GITHUB_REF || exec('git rev-parse --abbrev-ref HEAD')
+const consumerVersion = TRAVIS_PULL_REQUEST_SHA || TRAVIS_COMMIT || GITHUB_SHA
 
 const options = {
   pactFilesOrDirs: [contractsDir],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We need to have `GITHUB_HEAD_REF` and `GITHUB_REF_NAME` so they can be used to compute our `branch`, then `tags` values. 
Also, to make the publishing process more informative, we need to add the tags data to the output.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
