### PR TITLE
Feat/webpack cache

### DIFF
--- a/packages/sui-bundler/shared/config.js
+++ b/packages/sui-bundler/shared/config.js
@@ -1,4 +1,5 @@
 /* Extract sui-bundler from package.json -> "config": {"sui-bundler": { ... }} */
+const path = require('path')
 const {config: packageJsonConfig = {}} = require(`${process.cwd()}/package.json`)
 
 const {'sui-bundler': config = {}} = packageJsonConfig
@@ -8,3 +9,4 @@ exports.config = config
 exports.supportLegacyBrowsers = supportLegacyBrowsers
 exports.extractComments = extractComments
 exports.sourceMap = (sourcemaps && sourcemaps.prod) || false
+exports.cacheDirectory = path.resolve(process.cwd(), '.sui/cache')

--- a/packages/sui-bundler/webpack.config.client.dev.js
+++ b/packages/sui-bundler/webpack.config.client.dev.js
@@ -11,7 +11,7 @@ const {envVars, MAIN_ENTRY_POINT, config, cleanList, when} = require('./shared/i
 const definePlugin = require('./shared/define.js')
 const manifestLoaderRules = require('./shared/module-rules-manifest-loader.js')
 const {aliasFromConfig, defaultAlias} = require('./shared/resolve-alias.js')
-const {supportLegacyBrowsers} = require('./shared/config.js')
+const {supportLegacyBrowsers, cacheDirectory} = require('./shared/config.js')
 
 const {resolveLoader} = require('./shared/resolve-loader.js')
 const createBabelRules = require('./shared/module-rules-babel.js')
@@ -52,7 +52,7 @@ const webpackConfig = {
   },
   cache: {
     type: 'filesystem',
-    cacheDirectory: path.resolve(process.cwd(), '.sui/cache'),
+    cacheDirectory,
     compression: 'gzip'
   },
   target: 'web',

--- a/packages/sui-bundler/webpack.config.client.dev.js
+++ b/packages/sui-bundler/webpack.config.client.dev.js
@@ -7,14 +7,14 @@ const {WebpackManifestPlugin} = require('webpack-manifest-plugin')
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 
-const {envVars, MAIN_ENTRY_POINT, config, cleanList, when} = require('./shared/index.js')
-const definePlugin = require('./shared/define.js')
-const manifestLoaderRules = require('./shared/module-rules-manifest-loader.js')
-const {aliasFromConfig, defaultAlias} = require('./shared/resolve-alias.js')
-const {supportLegacyBrowsers} = require('./shared/config.js')
+const {envVars, MAIN_ENTRY_POINT, config, cleanList, when} = require('@s-ui/bundler/shared/index.js')
+const definePlugin = require('@s-ui/bundler/shared/define.js')
+const manifestLoaderRules = require('@s-ui/bundler/shared/module-rules-manifest-loader.js')
+const {aliasFromConfig, defaultAlias} = require('@s-ui/bundler/shared/resolve-alias.js')
+const {supportLegacyBrowsers} = require('@s-ui/bundler/shared/config.js')
 
-const {resolveLoader} = require('./shared/resolve-loader.js')
-const createBabelRules = require('./shared/module-rules-babel.js')
+const {resolveLoader} = require('@s-ui/bundler/shared/resolve-loader.js')
+const createBabelRules = require('@s-ui/bundler/shared/module-rules-babel.js')
 
 const outputPath = path.join(process.cwd(), '.sui/public')
 
@@ -25,6 +25,7 @@ process.env.NODE_ENV = 'development'
 /** @typedef {import('webpack').Configuration} WebpackConfig */
 
 const webpackConfig = {
+  name: 'client',
   mode: 'development',
   context: path.resolve(PWD, 'src'),
   resolve: {
@@ -48,6 +49,11 @@ const webpackConfig = {
   stats: 'errors-only',
   entry: {
     app: [`webpack-hot-middleware/client?path=${CDN}__webpack_hmr`, MAIN_ENTRY_POINT]
+  },
+  cache: {
+    type: 'filesystem',
+    cacheDirectory: path.resolve(process.cwd(), '.sui/cache'),
+    compression: 'gzip'
   },
   target: 'web',
   optimization: {

--- a/packages/sui-bundler/webpack.config.client.dev.js
+++ b/packages/sui-bundler/webpack.config.client.dev.js
@@ -53,7 +53,7 @@ const webpackConfig = {
   cache: {
     type: 'filesystem',
     cacheDirectory,
-    compression: 'gzip'
+    compression: 'brotli'
   },
   target: 'web',
   optimization: {

--- a/packages/sui-bundler/webpack.config.client.dev.js
+++ b/packages/sui-bundler/webpack.config.client.dev.js
@@ -7,14 +7,14 @@ const {WebpackManifestPlugin} = require('webpack-manifest-plugin')
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 
-const {envVars, MAIN_ENTRY_POINT, config, cleanList, when} = require('@s-ui/bundler/shared/index.js')
-const definePlugin = require('@s-ui/bundler/shared/define.js')
-const manifestLoaderRules = require('@s-ui/bundler/shared/module-rules-manifest-loader.js')
-const {aliasFromConfig, defaultAlias} = require('@s-ui/bundler/shared/resolve-alias.js')
-const {supportLegacyBrowsers} = require('@s-ui/bundler/shared/config.js')
+const {envVars, MAIN_ENTRY_POINT, config, cleanList, when} = require('./shared/index.js')
+const definePlugin = require('./shared/define.js')
+const manifestLoaderRules = require('./shared/module-rules-manifest-loader.js')
+const {aliasFromConfig, defaultAlias} = require('./shared/resolve-alias.js')
+const {supportLegacyBrowsers} = require('./shared/config.js')
 
-const {resolveLoader} = require('@s-ui/bundler/shared/resolve-loader.js')
-const createBabelRules = require('@s-ui/bundler/shared/module-rules-babel.js')
+const {resolveLoader} = require('./shared/resolve-loader.js')
+const createBabelRules = require('./shared/module-rules-babel.js')
 
 const outputPath = path.join(process.cwd(), '.sui/public')
 

--- a/packages/sui-bundler/webpack.config.dev.js
+++ b/packages/sui-bundler/webpack.config.dev.js
@@ -55,7 +55,7 @@ const webpackConfig = {
   cache: {
     type: 'filesystem',
     cacheDirectory,
-    compression: 'gzip'
+    compression: 'brotli'
   },
   target: 'web',
   optimization: {

--- a/packages/sui-bundler/webpack.config.dev.js
+++ b/packages/sui-bundler/webpack.config.dev.js
@@ -9,7 +9,7 @@ const {envVars, MAIN_ENTRY_POINT, config, cleanList, when} = require('./shared/i
 const definePlugin = require('./shared/define.js')
 const manifestLoaderRules = require('./shared/module-rules-manifest-loader.js')
 const {aliasFromConfig, defaultAlias} = require('./shared/resolve-alias.js')
-const {supportLegacyBrowsers} = require('./shared/config.js')
+const {supportLegacyBrowsers, cacheDirectory} = require('./shared/config.js')
 
 const {resolveLoader} = require('./shared/resolve-loader.js')
 const createBabelRules = require('./shared/module-rules-babel.js')
@@ -54,7 +54,7 @@ const webpackConfig = {
   },
   cache: {
     type: 'filesystem',
-    cacheDirectory: path.resolve(process.cwd(), '.sui/cache'),
+    cacheDirectory,
     compression: 'gzip'
   },
   target: 'web',

--- a/packages/sui-bundler/webpack.config.dev.js
+++ b/packages/sui-bundler/webpack.config.dev.js
@@ -23,6 +23,7 @@ process.env.NODE_ENV = 'development'
 /** @typedef {import('webpack').Configuration} WebpackConfig */
 
 const webpackConfig = {
+  name: 'client-local',
   mode: 'development',
   context: path.resolve(PWD, 'src'),
   resolve: {
@@ -50,6 +51,11 @@ const webpackConfig = {
   devServer: {
     static: outputPath,
     hot: true
+  },
+  cache: {
+    type: 'filesystem',
+    cacheDirectory: path.resolve(process.cwd(), '.sui/cache'),
+    compression: 'gzip'
   },
   target: 'web',
   optimization: {

--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -11,7 +11,7 @@ const InlineChunkHtmlPlugin = require('./shared/inline-chunk-html-plugin.js')
 
 const {when, cleanList, envVars, MAIN_ENTRY_POINT, config} = require('./shared/index.js')
 const {aliasFromConfig} = require('./shared/resolve-alias.js')
-const {extractComments, sourceMap, supportLegacyBrowsers} = require('./shared/config.js')
+const {extractComments, sourceMap, supportLegacyBrowsers, cacheDirectory} = require('./shared/config.js')
 const {resolveLoader} = require('./shared/resolve-loader.js')
 const createBabelRules = require('./shared/module-rules-babel.js')
 const sassRules = require('./shared/module-rules-sass.js')
@@ -69,7 +69,7 @@ const webpackConfig = {
   },
   cache: {
     type: 'filesystem',
-    cacheDirectory: path.resolve(process.cwd(), '.sui/cache'),
+    cacheDirectory,
     compression: false
   },
   plugins: cleanList([

--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -35,6 +35,7 @@ const target = supportLegacyBrowsers ? ['web', 'es5'] : 'web'
 /** @type {WebpackConfig} */
 const webpackConfig = {
   devtool: sourceMap,
+  name: 'client',
   mode: 'production',
   target,
   context: path.resolve(CWD, 'src'),
@@ -65,6 +66,11 @@ const webpackConfig = {
     minimize: true,
     minimizer: [minifyJs({extractComments, sourceMap}), minifyCss()].filter(Boolean),
     runtimeChunk: true
+  },
+  cache: {
+    type: 'filesystem',
+    cacheDirectory: path.resolve(process.cwd(), '.sui/cache'),
+    compression: false
   },
   plugins: cleanList([
     new webpack.ProvidePlugin({

--- a/packages/sui-bundler/webpack.config.server.js
+++ b/packages/sui-bundler/webpack.config.server.js
@@ -3,6 +3,7 @@ const webpackNodeExternals = require('webpack-node-externals')
 const path = require('path')
 
 const {config, when, cleanList} = require('./shared/index.js')
+const {cacheDirectory} = require('./shared/config.js')
 const createBabelRules = require('./shared/module-rules-babel.js')
 const manifestLoaderRules = require('./shared/module-rules-manifest-loader.js')
 const {aliasFromConfig} = require('./shared/resolve-alias.js')
@@ -39,7 +40,7 @@ const webpackConfig = {
   },
   cache: {
     type: 'filesystem',
-    cacheDirectory: path.resolve(process.cwd(), '.sui/cache'),
+    cacheDirectory,
     compression: !isProduction ? 'gzip' : false
   },
   externals: [webpackNodeExternals()],

--- a/packages/sui-bundler/webpack.config.server.js
+++ b/packages/sui-bundler/webpack.config.server.js
@@ -41,7 +41,7 @@ const webpackConfig = {
   cache: {
     type: 'filesystem',
     cacheDirectory,
-    compression: !isProduction ? 'gzip' : false
+    compression: !isProduction ? 'brotli' : false
   },
   externals: [webpackNodeExternals()],
   plugins: [new webpack.DefinePlugin({'global.GENTLY': false})],

--- a/packages/sui-bundler/webpack.config.server.js
+++ b/packages/sui-bundler/webpack.config.server.js
@@ -12,10 +12,13 @@ const filename = '[name].[chunkhash:8].js'
 
 /** @typedef {import('webpack').Configuration} WebpackConfig */
 
+const isProduction = process.env.NODE_ENV === 'production'
+
 /** @type {WebpackConfig} */
 const webpackConfig = {
+  name: 'server',
   context: path.resolve(process.cwd(), 'src'),
-  mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
+  mode: isProduction ? 'production' : 'development',
   resolve: {
     alias: {...aliasFromConfig},
     extensions: ['.js', '.json'],
@@ -33,6 +36,11 @@ const webpackConfig = {
     checkWasmTypes: false,
     minimize: true,
     nodeEnv: false
+  },
+  cache: {
+    type: 'filesystem',
+    cacheDirectory: path.resolve(process.cwd(), '.sui/cache'),
+    compression: !isProduction ? 'gzip' : false
   },
   externals: [webpackNodeExternals()],
   plugins: [new webpack.DefinePlugin({'global.GENTLY': false})],

--- a/packages/sui-ssr/bin/sui-ssr-dev.js
+++ b/packages/sui-ssr/bin/sui-ssr-dev.js
@@ -14,7 +14,7 @@ const webpack = require('webpack')
 const webpackDevMiddleware = require('webpack-dev-middleware')
 const webpackHotMiddleware = require('webpack-hot-middleware')
 const nodemon = require('nodemon')
-const clientConfig = require('@s-ui/bundler/webpack.config.server.dev.js')
+const clientConfig = require('@s-ui/bundler/webpack.config.client.dev.js')
 const linkLoaderConfigBuilder = require('@s-ui/bundler/loaders/linkLoaderConfigBuilder.js')
 
 const serverConfigFactory = require('../compiler/server.js')
@@ -76,7 +76,7 @@ const start = ({packagesToLink, linkAll}) => {
   const app = express()
   const clientCompiler = webpack(
     linkLoaderConfigBuilder({
-      config: require('@s-ui/bundler/webpack.config.server.dev.js'),
+      config: clientConfig,
       linkAll,
       packagesToLink
     })
@@ -135,6 +135,7 @@ const start = ({packagesToLink, linkAll}) => {
       const script = nodemon({
         script: `${SERVER_OUTPUT_PATH}/index.js`,
         watch: [SERVER_OUTPUT_PATH],
+        nodeArgs: '--inspect',
         delay: 200
       })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR enables caching in Webpack. This should speed up significantly the bundling time when the cache is already generated. It's enabled for both development and production builds. Cache for production builds could be useful to speed up CI.

## Example
Starting a development server of a large SSR application

Without cache

![Screenshot 2024-01-04 at 11 48 08](https://github.com/SUI-Components/sui/assets/6877967/7090eca8-9c7e-4a33-9fa8-ea0cca8d4d64)

With cache

![Screenshot 2024-01-04 at 11 48 03](https://github.com/SUI-Components/sui/assets/6877967/8117fdcc-d1eb-48d7-ae92-46069e87ede4)
