### PR TITLE
feat(packages/sui-bundler): use gzip compression

### DIFF
--- a/packages/sui-bundler/webpack.config.client.dev.js
+++ b/packages/sui-bundler/webpack.config.client.dev.js
@@ -53,7 +53,7 @@ const webpackConfig = {
   cache: {
     type: 'filesystem',
     cacheDirectory,
-    compression: 'brotli'
+    compression: 'gzip'
   },
   target: 'web',
   optimization: {

--- a/packages/sui-bundler/webpack.config.dev.js
+++ b/packages/sui-bundler/webpack.config.dev.js
@@ -55,7 +55,7 @@ const webpackConfig = {
   cache: {
     type: 'filesystem',
     cacheDirectory,
-    compression: 'brotli'
+    compression: 'gzip'
   },
   target: 'web',
   optimization: {

--- a/packages/sui-bundler/webpack.config.server.js
+++ b/packages/sui-bundler/webpack.config.server.js
@@ -41,7 +41,7 @@ const webpackConfig = {
   cache: {
     type: 'filesystem',
     cacheDirectory,
-    compression: !isProduction ? 'brotli' : false
+    compression: !isProduction ? 'gzip' : false
   },
   externals: [webpackNodeExternals()],
   plugins: [new webpack.DefinePlugin({'global.GENTLY': false})],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR uses `gzip` instead of `brotli`. Looks like `brotli` that when `brotli` is enabled webpack takes more time than with `gzip` to bootstrap 

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
