### PR TITLE
fix(packages/sui-bundler): avoid setting key when there is no cache

### DIFF
--- a/packages/sui-bundler/bin/sui-bundler-dev.js
+++ b/packages/sui-bundler/bin/sui-bundler-dev.js
@@ -75,7 +75,10 @@ const start = async ({config = webpackConfig, packagesToLink = program.opts().li
     linkAll,
     packagesToLink
   })
-  nextConfig.cache.version = version
+
+  if (nextConfig.cache) {
+    nextConfig.cache.version = version
+  }
 
   const compiler = createCompiler(nextConfig, urls)
   const serverConfig = createDevServerConfig(nextConfig, urls.lanUrlForConfig)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes small issue with sui studio because it doesn't have cache

## Related Issue
None

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
