### PR TITLE
fix(packages/sui-mono): fix package name regex

### DIFF
--- a/packages/sui-mono/src/check.js
+++ b/packages/sui-mono/src/check.js
@@ -20,7 +20,7 @@ const DEPS_UPGRADE_COMMIT_TYPE = 'upgrade'
 const DEPS_UPGRADE_COMMIT_TYPE_TO_PUSH = 'feat'
 const DEPS_UPGRADE_PACKAGES = ['deps', 'deps-dev']
 const DEPS_UPGRADE_BRANCH_PREFIX = 'dependabot/npm_and_yarn/'
-const SCOPE_REGEX = /packages\/[a-z]+-[a-z]+/
+const SCOPE_REGEX = /packages\/(([a-z]+)-?)+/ // matches "packages/sui-any-package-name"
 
 const isCommitBreakingChange = commit => {
   const {body, footer} = commit


### PR DESCRIPTION
This PR solves the current issue we have in the master build: https://github.com/SUI-Components/sui/actions/runs/7500241868/job/20418527951#step:12:22

![build error](https://github.com/SUI-Components/sui/assets/2622119/d91376bb-200c-40be-941c-a1c37c0a4b4d)
