### PR TITLE
feat(packages/sui-bundler): add resources as static folder

### DIFF
--- a/packages/sui-bundler/factories/createDevServerConfig.js
+++ b/packages/sui-bundler/factories/createDevServerConfig.js
@@ -38,6 +38,10 @@ module.exports = config => ({
     {
       directory: 'public',
       watch: getWatchOptions(config)
+    },
+    {
+      directory: 'resources',
+      watch: getWatchOptions(config)
     }
   ],
   hot: true,


### PR DESCRIPTION
## Description
This PR add resources as static folder. The agreement of statics folders will be as follows:
- `/public`: Automatically generated folder for the build and ignored in git.
- `/statics`: Folder where the server itself will expose its content from the root. For example, it is useful for hosting sitemaps.xml, robots.txt, etc.
- `/resources`: Folder that will be synchronized with the application's S3 bucket and exposed through a CDN. For example, it is useful for hosting images, JSONs, PDFs, etc.

Important: Only place strictly necessary items in `/statics`; the majority should go in `/resources` to be served by a CDN and not consume server resources.

## Related Issue
None

## Example
None
