### PR TITLE
feat(packages/sui-react-web-vitals): adding device perf params to logger.cwv tracks

### DIFF
--- a/packages/sui-react-web-vitals/src/index.js
+++ b/packages/sui-react-web-vitals/src/index.js
@@ -103,6 +103,8 @@ export default function WebVitalsReporter({
 
       const target = getTarget({name, attribution})
 
+      const {effectiveConnection, deviceMemory, hardwareConcurrency} = browser || {}
+
       logger.cwv({
         name: `cwv.${name.toLowerCase()}`,
         amount,
@@ -111,7 +113,10 @@ export default function WebVitalsReporter({
         target,
         loadState: attribution.loadState,
         visibilityState: document.visibilityState,
-        ...(attribution.eventType && {eventType: attribution.eventType})
+        ...(attribution.eventType && {eventType: attribution.eventType}),
+        effectiveConnection,
+        deviceMemory,
+        hardwareConcurrency
       })
     }
 


### PR DESCRIPTION
Adding device perf params to logger.cwv tracks

## Description
To distinguish interactions based on connection quality, and device performance in OpenSearch CWV logs we need to add these parameters to the logged data.

**effectiveConnection, deviceMemory, hardwareConcurrency**

_example data sent to Mushroom_
![imatge](https://github.com/SUI-Components/sui/assets/17271365/3a946c6b-7e09-4038-9ddf-685e24961085)

This data can be calculated and setted in suiContextFactory in our webapps

```
const hardwareConcurrency = isClient && navigator.hardwareConcurrency
const effectiveConnection = isClient && navigator.connection?.effectiveType
const deviceMemory = isClient && navigator.deviceMemory
```
must be added to browser property in the Context
```
{
  ...
  browser: {
    ...
    effectiveConnection,
    deviceMemory,
    hardwareConcurrency
  }
}

```
