### PR TITLE
feat(packages/sui-react-web-vitals): rollback to log targets with empty values again

### DIFF
--- a/packages/sui-react-web-vitals/src/index.js
+++ b/packages/sui-react-web-vitals/src/index.js
@@ -102,7 +102,7 @@ export default function WebVitalsReporter({
       const isAllowed = allowed.includes(pathname) || allowed.includes(routeid)
       const target = getTarget({name, attribution})
 
-      if (!isAllowed || !logger?.cwv || rating === RATING.GOOD || !target) return
+      if (!isAllowed || !logger?.cwv || rating === RATING.GOOD) return
 
       const {loadState, eventType} = attribution
 


### PR DESCRIPTION
## Description

The empty values are a [bug](https://github.com/GoogleChrome/web-vitals/issues/335#issuecomment-1625311650) of the library, in principle, we eliminate them for not sending them to Open Search, and eliminate noise, but not having the target empties gives us a distortion of the real percentages of the attributions, and that is why we resubmit them.