### PR TITLE
Add Hydration Mismatch Overlay for dev mode

### DIFF
--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -22,6 +22,8 @@
   "homepage": "https://github.com/SUI-Components/sui/tree/master/packages/sui-bundler#readme",
   "dependencies": {
     "@babel/core": "7.18.10",
+    "@builder.io/react-hydration-overlay": "0.0.8",
+    "@pmmmwh/react-refresh-webpack-plugin": "0.5.10",
     "@s-ui/helpers": "1",
     "@s-ui/sass-loader": "1",
     "address": "1.2.2",
@@ -36,22 +38,22 @@
     "escape-string-regexp": "4.0.0",
     "fast-glob": "3.2.11",
     "find-free-ports": "3.0.0",
+    "html-webpack-inject-attributes-plugin": "1.0.6",
     "html-webpack-plugin": "5.5.0",
     "https-browserify": "1.0.0",
     "mini-css-extract-plugin": "2.7.7",
-    "postcss": "8.4.31",
     "postcss-loader": "7.3.4",
+    "postcss": "8.4.31",
     "process": "0.11.10",
+    "react-refresh": "0.14.0",
     "sass": "1.54.5",
     "stream-http": "3.2.0",
     "strip-ansi": "6.0.1",
     "style-loader": "3.3.1",
     "url": "0.11.0",
-    "webpack": "5.82.1",
     "webpack-dev-server": "4.10.0",
     "webpack-manifest-plugin": "5.0.0",
     "webpack-node-externals": "3.0.0",
-    "@pmmmwh/react-refresh-webpack-plugin": "0.5.10",
-    "react-refresh": "0.14.0"
+    "webpack": "5.82.1"
   }
 }

--- a/packages/sui-bundler/webpack.config.client.dev.js
+++ b/packages/sui-bundler/webpack.config.client.dev.js
@@ -6,6 +6,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const {WebpackManifestPlugin} = require('webpack-manifest-plugin')
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
+const HtmlWebpackInjectAttributesPlugin = require('html-webpack-inject-attributes-plugin')
 const {withHydrationOverlayWebpack} = require('@builder.io/react-hydration-overlay/webpack')
 
 const {envVars, MAIN_ENTRY_POINT, config, cleanList, when} = require('./shared/index.js')
@@ -84,7 +85,10 @@ const webpackConfig = {
     }),
     new WebpackManifestPlugin({fileName: 'asset-manifest.json'}),
     new webpack.HotModuleReplacementPlugin(),
-    new ReactRefreshWebpackPlugin({overlay: false})
+    new ReactRefreshWebpackPlugin({overlay: false}),
+    new HtmlWebpackInjectAttributesPlugin({
+      crossorigin: 'anonymous'
+    })
   ],
   resolveLoader,
   module: {

--- a/packages/sui-bundler/webpack.config.client.dev.js
+++ b/packages/sui-bundler/webpack.config.client.dev.js
@@ -6,6 +6,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const {WebpackManifestPlugin} = require('webpack-manifest-plugin')
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
+const {withHydrationOverlayWebpack} = require('@builder.io/react-hydration-overlay/webpack')
 
 const {envVars, MAIN_ENTRY_POINT, config, cleanList, when} = require('./shared/index.js')
 const definePlugin = require('./shared/define.js')
@@ -122,4 +123,7 @@ const webpackConfig = {
   devtool: config.sourcemaps && config.sourcemaps.dev ? config.sourcemaps.dev : false
 }
 
-module.exports = webpackConfig
+module.exports = withHydrationOverlayWebpack({
+  appRootSelector: '#root',
+  isMainAppEntryPoint: entryPointName => entryPointName === 'app'
+})(webpackConfig)


### PR DESCRIPTION
Bringing *builder.io*'s [Hydration overlay](https://github.com/BuilderIO/hydration-overlay/) tool to help us debug hydration mismatch errors on dev environment.

## Description
Using `withHydrationOverlayWebpack` in web pack development configuration allows us to spot hydration mismatches and therefore prevent introducing potencial re-renderings on client and hence, performance issues.

![image](https://github.com/SUI-Components/sui/assets/18154356/8dfc64c0-e9e1-4989-aebe-ed2f1db8e1ba)

This [additional change](https://github.com/SUI-Components/sui/pull/1740/files#diff-3c38d2c065de8c4205a1963bf98939999af9b4b6ff3826f15ce6cea72bb7c5ebR90) is necessary to make it work. The hydration mismatch overlay only shows up when it detects errors containing the words `hydration` or `hydrating` (see here https://github.com/BuilderIO/hydration-overlay/blob/661aa0e17a50777fe9d7222fe0759d84798b1c3e/packages/lib/src/hydration-overlay-initializer.js#L5 ). Since the `app.js` script is being served from `localhost:8080` whereas the dev server is running on `localhost:3000`, an error from `app.js` would be coming from a different origin and pop up as a generic `Script error`, which would not be captured by `hydration-overlay`. Hence the requirement for a new dependency `html-webpack-inject-attributes-plugin`.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
