### PR TITLE
feat(packages/sui-studio): add __tests__ to npmignore

### DIFF
--- a/packages/sui-studio/bin/sui-studio-generate.js
+++ b/packages/sui-studio/bin/sui-studio-generate.js
@@ -168,6 +168,7 @@ node_modules`
 demo
 src
 test
+__tests__
 `
   ),
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allow to ignore `__tests__` folder when a package is published

With that, we will avoid something like the screenshot below, allowing reduce the size of our packages


![image (6)](https://github.com/SUI-Components/sui/assets/1263588/9ea973db-ef78-4e9c-99ed-3631177d9630)



## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
