### PR TITLE
Feature/update webpack dev middleware versions

### DIFF
--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -51,7 +51,7 @@
     "strip-ansi": "6.0.1",
     "style-loader": "3.3.1",
     "url": "0.11.0",
-    "webpack-dev-server": "4.10.0",
+    "webpack-dev-server": "5.0.4",
     "webpack-manifest-plugin": "5.0.0",
     "webpack-node-externals": "3.0.0",
     "webpack": "5.82.1"

--- a/packages/sui-bundler/package.json
+++ b/packages/sui-bundler/package.json
@@ -51,7 +51,7 @@
     "strip-ansi": "6.0.1",
     "style-loader": "3.3.1",
     "url": "0.11.0",
-    "webpack-dev-server": "5.0.4",
+    "webpack-dev-server": "4.15.2",
     "webpack-manifest-plugin": "5.0.0",
     "webpack-node-externals": "3.0.0",
     "webpack": "5.82.1"

--- a/packages/sui-ssr/package.json
+++ b/packages/sui-ssr/package.json
@@ -38,7 +38,7 @@
     "noop-console": "0.8.0",
     "parse5": "6.0.1",
     "ua-parser-js": "0.7.33",
-    "webpack-dev-middleware": "6.1.1",
+    "webpack-dev-middleware": "6.1.2",
     "webpack-hot-middleware": "2.25.4",
     "nodemon": "3.0.1"
   }

--- a/packages/sui-widget-embedder/package.json
+++ b/packages/sui-widget-embedder/package.json
@@ -19,6 +19,6 @@
     "@s-ui/react-hooks": "1",
     "commander": "8.3.0",
     "copy-paste": "1.3.0",
-    "webpack-dev-middleware": "5.3.3"
+    "webpack-dev-middleware": "5.3.4"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use patched versions of `webpack-dev-middleware` to avoid vulnerabilities.
https://github.com/webpack/webpack-dev-middleware/security/advisories/GHSA-wr3j-pwj9-hqq6

