### PR TITLE
test(packages/sui-test): fix custom studio-utils alias

### DIFF
--- a/packages/sui-test/README.md
+++ b/packages/sui-test/README.md
@@ -29,6 +29,26 @@ Your tests must be in a `test` folder in your project root. Each test file shoul
 npm install @s-ui/test --save-dev
 ```
 
+# Config Options
+
+## Client (Karma) options
+
+- `alias` You can define the custom aliases you need to resolve in your client-side tests executions, see the following example:
+
+```json
+{
+  "config": {
+    "sui-test": {
+      "client": {
+        "alias": {
+          "my-package": "path/to/my-package"
+        }
+      }
+    }
+  }
+}
+```
+
 # CLI Options
 
 ```sh
@@ -101,7 +121,7 @@ npm install @s-ui/test --save-dev
 **describeOnLocal**: It will only run wrapped tests on local environment and won't be executed in CI.
 
 ```javascript
-import { describeOnLocal } from '@s-ui/test/lib/describers'
+import {describeOnLocal} from '@s-ui/test/lib/describers'
 
 describeOnLocal(() => {
   describe('Some test', () => {
@@ -112,8 +132,8 @@ describeOnLocal(() => {
 })
 ```
 
-
 ## Descriptor by environment patcher
+
 The descriptor by environment is a patch with the purpose of add some extra functionality to our mocha describe and it methods.
 
 ### How to import it?
@@ -121,10 +141,12 @@ The descriptor by environment is a patch with the purpose of add some extra func
 First of all, the patcher MUST BE APPLIED on each test that we want to have the extra methods so at the top of `ourExampleSpec.js` we will add the next code:
 
 ```javascript
-import { descriptorsByEnvironmentPatcher } from '@s-ui/test/lib/descriptor-environment-patcher'
+import {descriptorsByEnvironmentPatcher} from '@s-ui/test/lib/descriptor-environment-patcher'
 descriptorsByEnvironmentPatcher()
 ```
+
 And that's it, from that line you will have the next methods added to the base of the mocha lib:
+
 - describe.client
 - describe.server
 - describe.client.only
@@ -133,7 +155,9 @@ And that's it, from that line you will have the next methods added to the base o
 - it.server
 - it.client.only
 - it.server.only
+
 ### How can I use it?
+
 Just in the same way as you have been using the describe or it functions earlier:
 
 ```javascript
@@ -173,6 +197,7 @@ describe.client.only('Another use case', () => {
   })
 })
 ```
+
 ## Contributing
 
 Please refer to the [main repo contributing info](https://github.com/SUI-Components/sui/blob/master/CONTRIBUTING.md).

--- a/packages/sui-test/bin/karma/config.js
+++ b/packages/sui-test/bin/karma/config.js
@@ -6,7 +6,7 @@ const {envVars} = require('@s-ui/bundler/shared/index.js')
 const {getSWCConfig} = require('@s-ui/compiler-config')
 const {bundlerConfig, clientConfig, isWorkspace, isInnerPackage} = require('../../src/config.js')
 
-const {captureConsole = true} = clientConfig
+const {captureConsole = true, alias: webpackAlias = {}} = clientConfig
 const {sep} = path
 
 /**
@@ -18,6 +18,13 @@ const standardPrefix = isWorkspace() ? '../' : './'
 const prefix = isInnerPackage() ? '../../' : standardPrefix
 const pwd = process.env.PWD
 const swcConfig = getSWCConfig({isTypeScript: true})
+const customAlias = Object.keys(webpackAlias).reduce(
+  (aliases, aliasKey) => ({
+    ...aliases,
+    [aliasKey]: path.resolve(path.join(pwd, prefix, webpackAlias[aliasKey]))
+  }),
+  {}
+)
 const config = {
   singleRun: true,
   basePath: '',
@@ -47,7 +54,7 @@ const config = {
         'react/jsx-dev-runtime': path.resolve(pwd, prefix, 'node_modules/react/jsx-dev-runtime.js'),
         'react/jsx-runtime': path.resolve(pwd, prefix, 'node_modules/react/jsx-runtime.js'),
         '@s-ui/react-context': path.resolve(path.join(pwd, prefix, 'node_modules/@s-ui/react-context')),
-        'studio-utils': path.resolve(path.join(pwd, prefix, 'packages/ui/studio-utils'))
+        ...customAlias
       },
       modules: [path.resolve(process.cwd()), 'node_modules'],
       extensions: ['.mjs', '.js', '.jsx', '.ts', '.tsx', '.json'],


### PR DESCRIPTION
With this PR, it's possible to add custom aliases from the package.json config like this:
```json
{
  "config": {
    "sui-test": {
      "client": {
        "alias": {
          "my-package": "path/to/my-package"
        }
      }
    }
  }
}
```