### PR TITLE
feat(packages/sui-bundler): set dev server overlay to false

### DIFF
--- a/packages/sui-bundler/bin/sui-bundler-dev.js
+++ b/packages/sui-bundler/bin/sui-bundler-dev.js
@@ -39,6 +39,7 @@ if (!module.parent) {
       []
     )
     .option('-w, --watch', 'Watch files and restart the server on change', DEFAULT_WATCH)
+    .option('-y, --overlay', 'Show error overlay')
     .on('--help', () => {
       console.log('  Examples:')
       console.log('')
@@ -66,7 +67,7 @@ const start = async ({config = webpackConfig, packagesToLink = program.opts().li
   const port = await choosePort(DEFAULT_PORT)
   const urls = prepareUrls(protocol, HOST, port)
 
-  const {linkAll} = program.opts()
+  const {linkAll, overlay = false} = program.opts()
 
   const configVars = JSON.stringify({packagesToLink, linkAll})
   const version = `${__dirname}|${configVars}`
@@ -81,7 +82,7 @@ const start = async ({config = webpackConfig, packagesToLink = program.opts().li
   }
 
   const compiler = createCompiler(nextConfig, urls)
-  const serverConfig = createDevServerConfig(nextConfig, urls.lanUrlForConfig)
+  const serverConfig = createDevServerConfig({config: nextConfig, overlay})
   const devServer = new WebpackDevServer(
     {
       ...serverConfig,

--- a/packages/sui-bundler/factories/createDevServerConfig.js
+++ b/packages/sui-bundler/factories/createDevServerConfig.js
@@ -7,17 +7,26 @@ const {HOST, HTTPS} = process.env
 const protocol = HTTPS === 'true' ? 'https' : 'http'
 const host = HOST || '0.0.0.0'
 
+const getOverlayValue = overlay => {
+  return overlay
+    ? {
+        errors: true,
+        warnings: false
+      }
+    : false
+}
+
 const getWatchOptions = ({context, watch}) => {
   if (!watch) return false
   return {ignored: ignoredFiles(context)}
 }
 
 /** @returns {import('webpack-dev-server').Configuration} */
-module.exports = config => ({
+module.exports = ({config, overlay}) => ({
   allowedHosts: 'all',
   client: {
     logging: 'none',
-    overlay: false,
+    overlay: getOverlayValue(overlay),
     progress: false
   },
   // Enable gzip compression of generated files

--- a/packages/sui-bundler/factories/createDevServerConfig.js
+++ b/packages/sui-bundler/factories/createDevServerConfig.js
@@ -17,10 +17,7 @@ module.exports = config => ({
   allowedHosts: 'all',
   client: {
     logging: 'none',
-    overlay: {
-      errors: true,
-      warnings: false
-    },
+    overlay: false,
     progress: false
   },
   // Enable gzip compression of generated files


### PR DESCRIPTION
## Description
Disabling errors overlay when on client dev environment.
Even though this overlay may be useful in some contexts, we're temporarily disabling it.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Screenshot
![image](https://github.com/SUI-Components/sui/assets/18154356/165b7e3d-7080-4f1d-8b11-5da9453719e4)

