### PR TITLE
Feat/use local ssl certificate development mode

### DIFF
--- a/packages/sui-ssr/README.md
+++ b/packages/sui-ssr/README.md
@@ -261,7 +261,7 @@ Configs accepted:
 
 > ⚠️ `createStylesFor` does not works as expected when sui-bundler configuration has `onlyHash` defined to `true`.
 
-- **`SSL`** (`undefined`): This is only for local development. It should be usefull to test locally pointing to production endpoints. Certificate should help to avoid CORS issues. This prop should receive and object with the following structure:
+- **`SSL`** (`undefined`): This configuration is intended solely for local development. It's useful for conducting local tests that target production endpoints. The inclusion of a certificate can help circumvent CORS issues. The property in question should be assigned an object that adheres to the following structure::
 
   ```json
   {

--- a/packages/sui-ssr/README.md
+++ b/packages/sui-ssr/README.md
@@ -177,7 +177,6 @@ jobs:
 
 > If you want that release commit does not trigger a Travis build you could use the flag `--skip-ci` and commit message will have `[skip ci]` string. See more information about [Travis skipping build docs](https://docs.travis-ci.com/user/customizing-the-build/#skipping-a-build)
 
-
 ## Use the ssr output as stream
 
 It uses the stdout stream so you can do things like:
@@ -262,6 +261,19 @@ Configs accepted:
 
 > ⚠️ `createStylesFor` does not works as expected when sui-bundler configuration has `onlyHash` defined to `true`.
 
+- **`SSL`** (`undefined`): This is only for local development. It should be usefull to test locally pointing to production endpoints. Certificate should help to avoid CORS issues. This prop should receive and object with the following structure:
+
+  ```json
+  {
+    "SSL": {
+      "development": {
+        "key": "./.ssl/key.pem", // replace this with the path to the certificate key file
+        "crt": "./.ssl/crt.pem" // replace this with the path to the certificate crt file
+      }
+    }
+  }
+  ```
+
 ## Critical CSS
 
 For development you will need start the server with env vars `CRITICAL_CSS_HOST` and `CRITICAL_CSS_PROTOCOL` to allow to the external service request your current page.
@@ -294,7 +306,6 @@ export default [
 ### Shared context data between server and client
 
 In case you need to share initial client data needed by a context provider, add an `getInitialData` to your context provider. It will be injected into the html as `window.__INITIAL_CONTEXT_VALUE__[you context key]`
-
 
 ## Link Packages
 

--- a/packages/sui-ssr/server/index.js
+++ b/packages/sui-ssr/server/index.js
@@ -27,6 +27,12 @@ app.set('x-powered-by', false)
 const EARLY_FLUSH_DEFAULT = true
 app.locals.earlyFlush = typeof ssrConf.earlyFlush !== 'undefined' ? ssrConf.earlyFlush : EARLY_FLUSH_DEFAULT
 
+const useSSL =
+  process?.env?.NODE_ENV === 'development' &&
+  Boolean(ssrConf?.SSL?.development) &&
+  Boolean(ssrConf?.SSL?.development?.key) &&
+  Boolean(ssrConf?.SSL?.development?.cert)
+
 const {PORT = 3000, AUTH_USERNAME, AUTH_PASSWORD} = process.env
 const runningUnderAuth = AUTH_USERNAME && AUTH_PASSWORD
 const AUTH_DEFINITION = {
@@ -96,5 +102,18 @@ const _memoizedHtmlTemplatesMapping = {}
   app.use(hooks[TYPES.NOT_FOUND])
   app.use(hooks[TYPES.INTERNAL_ERROR])
 
-  app.listen(PORT, () => console.log(`Server up & running 🌍 http://localhost:${PORT}`)) // eslint-disable-line
+  if (!useSSL) app.listen(PORT, () => console.log(`Server up & running 🌍 http://localhost:${PORT}`)) // eslint-disable-line
+
+  if (useSSL) {
+    const path = require('path')
+    const https = require('https')
+    const fs = require('fs')
+
+    const options = {
+      key: fs.readFileSync(path.join(process.env.PWD, ssrConf.SSL.development.key)),
+      cert: fs.readFileSync(path.join(process.env.PWD, ssrConf.SSL.development.cert))
+    }
+
+    https.createServer(options, app).listen(PORT, () => console.log(`Server up & running 🌍 https://localhost:${PORT}`)) // eslint-disable-line
+  }
 })()

--- a/packages/sui-ssr/server/index.js
+++ b/packages/sui-ssr/server/index.js
@@ -31,7 +31,7 @@ const useSSL =
   process?.env?.NODE_ENV === 'development' &&
   Boolean(ssrConf?.SSL?.development) &&
   Boolean(ssrConf?.SSL?.development?.key) &&
-  Boolean(ssrConf?.SSL?.development?.cert)
+  Boolean(ssrConf?.SSL?.development?.crt)
 
 const {PORT = 3000, AUTH_USERNAME, AUTH_PASSWORD} = process.env
 const runningUnderAuth = AUTH_USERNAME && AUTH_PASSWORD
@@ -111,7 +111,7 @@ const _memoizedHtmlTemplatesMapping = {}
 
     const options = {
       key: fs.readFileSync(path.join(process.env.PWD, ssrConf.SSL.development.key)),
-      cert: fs.readFileSync(path.join(process.env.PWD, ssrConf.SSL.development.cert))
+      cert: fs.readFileSync(path.join(process.env.PWD, ssrConf.SSL.development.crt))
     }
 
     https.createServer(options, app).listen(PORT, () => console.log(`Server up & running 🌍 https://localhost:${PORT}`)) // eslint-disable-line


### PR DESCRIPTION
Add SSL option to SUI-SSR

## Description
With this option, you will be able to run server with a local SSL certificate.

This feature is intended solely for local development. It's useful for conducting local tests that target production endpoints. The inclusion of a certificate can help to avoid CORS issues

This mode can be activaded only in developement environment, so NODE_ENV should be set as "development".

To activate it, should be added the following config to the project package.json:

```json
  {
    "SSL": {
      "development": {
        "key": "./.ssl/key.pem", // replace this with the path to the certificate key file
        "crt": "./.ssl/crt.pem" // replace this with the path to the certificate crt file
      }
    }
  }
  ```

