### PR TITLE
feat(packages/sui-domain): adapt entry point factory to be able to wo…

### DIFF
--- a/packages/sui-domain/src/EntryPointFactory.js
+++ b/packages/sui-domain/src/EntryPointFactory.js
@@ -1,5 +1,14 @@
 import createNotImplementedUseCase from './createNotImplementedUseCase.js'
 
+const METHODS_BY_FACTORY_TYPES = {
+  // Return a method from a whole default exported factory
+  WHOLE_FACTORY: (factory, method) => factory.default[method],
+  // Return a single default exported factory
+  DEFAULT_SINGLE_FACTORY: factory => factory.default,
+  // Return a single named exported factory
+  NAMED_SINGLE_FACTORY: ({factory}) => factory
+}
+
 export default ({useCases, config, logger, pde}) =>
   class EntryPoint {
     subscribers = {}
@@ -38,7 +47,18 @@ export default ({useCases, config, logger, pde}) =>
         ? useCase // for the whole factory we extract the single method from the array
         : [useCase] // for the single factory, the method is undefined as is default
 
-      const getMethod = isDynamicImportWholeFactory ? factory => factory.default[method] : factory => factory.default
+      const getMethodByFactoryType = receivedFactory => {
+        if (isDynamicImportWholeFactory) return METHODS_BY_FACTORY_TYPES.WHOLE_FACTORY
+
+        // according with the creational pattern entryPoint agreement
+        const hasNamedExportedMethod = Boolean(receivedFactory.factory)
+
+        return hasNamedExportedMethod
+          ? METHODS_BY_FACTORY_TYPES.NAMED_SINGLE_FACTORY
+          : METHODS_BY_FACTORY_TYPES.DEFAULT_SINGLE_FACTORY
+      }
+
+      const getMethod = factory => getMethodByFactoryType(factory)(factory, method)
 
       // if loader is undefined then is not implemented, otherwhise load async the useCase
       return loader === undefined

--- a/packages/sui-domain/test/common/EntryPointSpec.js
+++ b/packages/sui-domain/test/common/EntryPointSpec.js
@@ -13,6 +13,21 @@ const logger = {
 
 describe('EntryPointFactory', () => {
   describe('without logger', () => {
+    it('should be able to import a named exported UseCase', async () => {
+      const useCases = {
+        named_exported_single_use_case: () => import('./fixtures/NamedExportedSingleUseCase.js')
+      }
+      const EntryPoint = EntryPointFactory({config, useCases})
+      const domain = new EntryPoint()
+
+      const useCase = domain.get('named_exported_single_use_case')
+      const response = await useCase.execute()
+
+      expect(useCase.execute).to.be.a('function')
+      expect(useCase.$).to.be.an('object')
+      expect(response).to.eql(true)
+    })
+
     it('should be able to import the whole UseCase factory', async () => {
       const useCases = {
         use_case_from_factory_with_multiple_use_cases: [

--- a/packages/sui-domain/test/common/fixtures/NamedExportedSingleUseCase.js
+++ b/packages/sui-domain/test/common/fixtures/NamedExportedSingleUseCase.js
@@ -1,0 +1,15 @@
+class UseCase {
+  constructor({config}) {
+    this._config = config
+  }
+
+  static create({config}) {
+    return new UseCase({config})
+  }
+
+  execute() {
+    return Promise.resolve(true)
+  }
+}
+
+export const factory = UseCase.create


### PR DESCRIPTION
According to the new [domain agreements](https://github.mpi-internal.com/scmspain/es-td-agreements/blob/master/30-Frontend/00-agreements/01-domain.md#creational-pattern-agreements), use cases must be exported in a named way by means of a constant called `factory` that will be responsible for giving access to the `create method` of the use case.

## Description
This change must maintain backward compatibility with the current entry point behavior.

## Related Issue
N/A

## Example
```js
class GetMovieDetailsUseCase extends UseCase {
  /* ... */
  static create({config}) {
    return new GetMovieDetailsUseCase({repository: MovieRepository.create({config})})
  }
}

export const factory = GetMovieDetailsUseCase.create
```
