### PR TITLE
feat(packages/sui-studio): Add jest compatibility with test path on studio-dev

### DIFF
--- a/packages/sui-studio/bin/sui-studio-dev.js
+++ b/packages/sui-studio/bin/sui-studio-dev.js
@@ -45,8 +45,10 @@ if (!category || !component) {
 
 const componentPath = path.join(PWD, 'components', category, component)
 const legacyTestPath = path.join(PWD, 'test', category, component)
+const jestPath = path.join(componentPath, '__tests__')
 
 const testPath = fs.existsSync(legacyTestPath) ? legacyTestPath : path.join(componentPath, 'test')
+const isJestTest = fs.existsSync(jestPath)
 
 const {cache, ...others} = config
 
@@ -59,7 +61,7 @@ const studioDevConfig = {
     alias: {
       ...config.resolve.alias,
       component: path.join(componentPath, 'src'),
-      test: testPath,
+      test: isJestTest ? jestPath : testPath,
       package: path.join(componentPath, 'package.json'),
       demo: path.join(componentPath, 'demo')
     }

--- a/packages/sui-studio/bin/sui-studio-dev.js
+++ b/packages/sui-studio/bin/sui-studio-dev.js
@@ -64,7 +64,7 @@ const studioDevConfig = {
     alias: {
       ...config.resolve.alias,
       component: path.join(componentPath, 'src'),
-      test: isJestTest ? jestPath : testPath,
+      test: testPath,
       package: path.join(componentPath, 'package.json'),
       demo: path.join(componentPath, 'demo')
     }

--- a/packages/sui-studio/bin/sui-studio-dev.js
+++ b/packages/sui-studio/bin/sui-studio-dev.js
@@ -55,7 +55,10 @@ const {cache, ...others} = config
 const studioDevConfig = {
   ...others,
   context: path.join(__dirname, '..', 'workbench', 'src'),
-  plugins: [...config.plugins, new webpack.DefinePlugin({__COMPONENT_ID__: JSON.stringify(componentID)})],
+  plugins: [
+    ...config.plugins,
+    new webpack.DefinePlugin({__COMPONENT_ID__: JSON.stringify(componentID), __DISABLE_TESTS__: isJestTest})
+  ],
   resolve: {
     ...config.resolve,
     alias: {

--- a/packages/sui-studio/workbench/src/components/Root/index.js
+++ b/packages/sui-studio/workbench/src/components/Root/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 import {useState} from 'react'
 
 import PropTypes from 'prop-types'
@@ -7,7 +8,10 @@ import Select from '../Select/index'
 import Test from '../Suite/index'
 
 const importComponent = () => import('component/index')
-const importTest = () => import('test/index.test')
+let importTest = null
+if (!__DISABLE_TESTS__) {
+  importTest = () => import('test/index.test')
+}
 
 const getFromStorage = (key, defaultValue) => window.sessionStorage[key] || defaultValue
 
@@ -38,19 +42,23 @@ export default function Root({componentID, contexts = {}, themes}) {
           initValue={actualStyle}
           onChange={updateOnChange(setActualStyle, 'actualStyle')}
         />
-        <button
-          className="Root-testSwitch"
-          onClick={() => {
-            updateOnChange(setShowTests, 'showTests')(showTests === 'show' ? 'hide' : 'show')
-          }}
-        >
-          {showTests === 'show' ? 'Close Tests' : 'Open Tests'}
-        </button>
+        {importTest ? (
+          <button
+            className="Root-testSwitch"
+            onClick={() => {
+              updateOnChange(setShowTests, 'showTests')(showTests === 'show' ? 'hide' : 'show')
+            }}
+          >
+            {showTests === 'show' ? 'Close Tests' : 'Open Tests'}
+          </button>
+        ) : null}
       </Header>
 
       <iframe src={iframeSrc} scrolling="yes" title="Demo" />
       <div className="Root-test" hidden={showTests === 'hide'}>
-        <Test open contexts={contexts} importComponent={importComponent} importTest={importTest} />
+        {importTest ? (
+          <Test open contexts={contexts} importComponent={importComponent} importTest={importTest} />
+        ) : null}
       </div>
     </div>
   )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

At Fotocasa Portal, we are integrating Jest into our tests. One of the problems we encountered was that we couldn't start the demos with studio-dev because it was searching for the path "test/index.test", leading to an error.
![Screenshot 2024-06-06 at 10 14 29](https://github.com/SUI-Components/sui/assets/74491547/cae4b065-7556-45d1-bc9e-3c8c7a851fc8)

This PR solves the problem by detecting if the component has a Jest test and then changing the test alias to later import the correct path.


## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

Demo on component with Jest test

![Screenshot 2024-06-07 at 13 46 05](https://github.com/SUI-Components/sui/assets/74491547/efff7837-8275-4959-9065-575c4a7ecb3f)
