### PR TITLE
feat(packages/sui-domain): Add DomainError class

### DIFF
--- a/packages/sui-domain/src/DomainError.js
+++ b/packages/sui-domain/src/DomainError.js
@@ -1,0 +1,25 @@
+/**
+ * Base class for handling errors in the domain layer
+ */
+export default class DomainError extends Error {
+  constructor({code, message, cause}) {
+    super(message, {cause})
+    this.name = 'DomainError'
+    this.code = code
+  }
+
+  /**
+   * DomainError factory method
+   *
+   * @param {String} code Code to identify the error instance. It's required.
+   * @param {String} message Description for the error useful for giving more context.
+   * @param {Object} cause Keeps the original error useful for wrapping uncontrolled errors.
+   */
+  static create({code, message, cause}) {
+    if (!code) {
+      throw new Error('[DomainError] The code property is required.')
+    }
+
+    return new DomainError({code, message, cause})
+  }
+}

--- a/packages/sui-domain/src/index.js
+++ b/packages/sui-domain/src/index.js
@@ -1,3 +1,4 @@
+export {default as DomainError} from './DomainError.js'
 export {default as Entity} from './Entity.js'
 export {default as EntryPointFactory} from './EntryPointFactory.js'
 export {default as FetcherFactory} from './fetcher/factory.js'


### PR DESCRIPTION
## Description
This adds a new `DomainError` class to `@s-ui/domain` which is intended to be the base class for handling errors in the domain layer. This is part of the [Domain Error Handling agreements](https://docs.mpi-internal.com/scmspain/es-td-agreements/Frontend/agreements/domain/#error-handling) we have defined recently.

## Related Issue
[Domain Error Handling Issue](https://github.mpi-internal.com/scmspain/es-td-agreements/issues/190)

## Example
[Using DomainError guide](https://docs.mpi-internal.com/scmspain/es-td-agreements/Frontend/guides/domain-error-handling/business-error-handling/)
