### PR TITLE
Test/domain builder using spies

### DIFF
--- a/packages/sui-studio-utils/README.md
+++ b/packages/sui-studio-utils/README.md
@@ -43,8 +43,29 @@ domain.get('current_user_use_case').execute().then((products) => {
   console.log(products) // ['pineapple', 'apple', 'strawberry', 'coffee']
 })
 ```
+### Spying use cases
 
+> You can spy a use case with the 'for' and 'respondWith' functions. This will allow you to check if the use case has been called and with which arguments. This feature is very useful in tests.
 
+```js
+import { DomainBuilder } from '@s-ui/studio-tools'
+import myDomain from 'domain'
+import sinon from 'sinon'
+
+describe('when the use case is called', () => {
+  it('should be able to spy on the use case', async () => {
+    const spy = sinon.spy(() => {
+      return ['avocado', 'banana', 'peaches', 'pisto']
+    })
+    const domain = DomainBuilder.extend({ myDomain })
+      .for({useCase: 'get_products'})
+      .respondWith({ success: spy }).build()
+    const response = await domain.get('get_products').execute()
+    expect(response).toEqual(['avocado', 'banana', 'peaches', 'pisto'])
+    expect(spy.called).toBe(true)
+  })
+})
+```
 ### Mocking the configuration
 
 ```js

--- a/packages/sui-studio-utils/src/test/common/domainBuilderSpec.js
+++ b/packages/sui-studio-utils/src/test/common/domainBuilderSpec.js
@@ -1,14 +1,28 @@
 /* eslint-env mocha */
 import {expect} from 'chai'
+import sinon from 'sinon'
 
 import {DomainBuilder} from '../../index.js'
 
 describe('DomainBuilder', () => {
+  const domain = {get: () => {}}
   describe('when a useCase is mocked', () => {
-    const domainBuilder = DomainBuilder.extend({domain: {get: () => {}}})
+    const domainBuilder = DomainBuilder.extend({domain})
     it('should return the mocked response', async () => {
       const domain = domainBuilder.for({useCase: 'get_products'}).respondWith({success: 'mocked-response'}).build()
       expect(await domain.get('get_products').execute()).to.equal('mocked-response')
+    })
+  })
+
+  describe('when a useCase is spied', () => {
+    const domainBuilder = DomainBuilder.extend({domain})
+    const spy = sinon.spy(() => {
+      return 'spied-response'
+    })
+    it('should return the mocked response', async () => {
+      const domain = domainBuilder.for({useCase: 'get_products'}).respondWith({success: spy}).build()
+      expect(await domain.get('get_products').execute()).to.equal('spied-response')
+      sinon.assert.calledOnce(spy)
     })
   })
 


### PR DESCRIPTION
Use DomainBuilder to extend a use case and test it with a sinon spy

## Description
While I was coding a test I realized it could be useful to pass a sinon spy to the DomainBuilder in order to verify if a use case has been called. I started to implement the feature, but then I realized it was already supported, so in this PR is only adding a test for this feature, in order to be example for others.

Also the Readme file was improved with an example of use.
