### PR TITLE
feat(packages/eslint-plugin-sui): rephrase message for inlineErrorMissplace rule

### DIFF
--- a/packages/eslint-plugin-sui/src/rules/decorators.js
+++ b/packages/eslint-plugin-sui/src/rules/decorators.js
@@ -31,7 +31,7 @@ module.exports = {
         Your tracer decorator should be call always with the name of your class
       `,
       inlineErrorMissplace: dedent`
-        the inlineError decorator should be always the first
+        The inlineError decorator should always be closest to the execute method
       `
     }
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Rephrasing the message for this inlineError decorator rule.

Replacing this:
> the inlineError decorator should be always the first

for this:
> The inlineError decorator should always be closest to the execute method

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
