### PR TITLE
feat(packages/sui-decorators): Create @Deprecated() decorator

### DIFF
--- a/packages/eslint-plugin-sui/src/index.js
+++ b/packages/eslint-plugin-sui/src/index.js
@@ -2,6 +2,8 @@ const FactoryPattern = require('./rules/factory-pattern.js')
 const SerializeDeserialize = require('./rules/serialize-deserialize.js')
 const CommonJS = require('./rules/commonjs.js')
 const Decorators = require('./rules/decorators.js')
+const DecoratorDeprecated = require('./rules/decorator-deprecated.js')
+const DecoratorDeprecatedRemarkMethod = require('./rules/decorator-deprecated-remark-method.js')
 const LayersArch = require('./rules/layers-architecture.js')
 
 // ------------------------------------------------------------------------------
@@ -15,6 +17,8 @@ module.exports = {
     'serialize-deserialize': SerializeDeserialize,
     commonjs: CommonJS,
     decorators: Decorators,
-    'layers-arch': LayersArch
+    'layers-arch': LayersArch,
+    'decorator-deprecated': DecoratorDeprecated,
+    'decorator-deprecated-remark-method': DecoratorDeprecatedRemarkMethod
   }
 }

--- a/packages/eslint-plugin-sui/src/rules/decorator-deprecated-remark-method.js
+++ b/packages/eslint-plugin-sui/src/rules/decorator-deprecated-remark-method.js
@@ -3,9 +3,71 @@
  */
 'use strict'
 
+const dedent = require('string-dedent')
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+function getElementName(node, {isAClass, isAMethod, isArrowFunction}) {
+  if (isAClass) {
+    const className = node.id?.name ?? 'UnknownClass'
+    return `class ${className}`
+  }
+
+  if (isArrowFunction) {
+    const methodNode = node.parent
+    const classNode = methodNode?.parent?.parent
+    const className = classNode.id?.name ?? 'UnknownClass'
+    const methodName = methodNode.key?.name ?? 'UnknownMethod'
+
+    return `method ${className}.${methodName}`
+  }
+
+  if (isAMethod) {
+    const classNode = node.parent?.parent
+    const className = classNode.id?.name ?? 'UnknownClass'
+    const methodName = node.key?.name ?? 'UnknownMethod'
+
+    return `method ${className}.${methodName}`
+  }
+
+  return 'unknown'
+}
+
+function getDecoratorsNode(node, {isAClass, isAMethod, isArrowFunction}) {
+  if (isAClass) {
+    return node.decorators
+  }
+
+  if (isArrowFunction) {
+    const methodNode = node.parent
+    return methodNode.decorators ?? []
+  }
+
+  if (isAMethod) {
+    return node.decorators ?? []
+  }
+
+  return []
+}
+
+function remarkElement(node, {isAClass, isAMethod, isArrowFunction}) {
+  if (isAClass) {
+    return node.id
+  }
+
+  if (isArrowFunction) {
+    const methodNode = node.parent
+    return methodNode.key
+  }
+
+  if (isAMethod) {
+    return node.key
+  }
+
+  return node
+}
 
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
@@ -18,34 +80,45 @@ module.exports = {
     },
     fixable: 'code',
     schema: [],
-    messages: {}
+    messages: {
+      remarkWarningMessage: dedent`
+        The {{methodName}} is marked as a deprecated.
+      `
+    }
   },
   create: function (context) {
-    // TODO: Check using decorator in a Class.
+    function highlightNode(node) {
+      const isAClass = node.type === 'ClassDeclaration'
+      const isArrowFunction = node.type === 'ArrowFunctionExpression'
+      const isAMethod = node.type === 'MethodDefinition'
+
+      const nodeName = getElementName(node, {isAClass, isAMethod, isArrowFunction})
+      const decorators = getDecoratorsNode(node, {isAClass, isAMethod, isArrowFunction})
+      const hasDecorators = decorators?.length > 0
+
+      // Get the @Deprecated() decorator from node decorators
+      const deprecatedDecoratorNode =
+        hasDecorators && decorators?.find(decorator => decorator?.expression?.callee?.name === 'Deprecated')
+
+      if (!deprecatedDecoratorNode) return
+      console.log(nodeName, deprecatedDecoratorNode)
+
+      const nodeToRemark = remarkElement(node, {isAClass, isAMethod, isArrowFunction})
+
+      // RULE: Mark method with a warning
+      context.report({
+        node: nodeToRemark,
+        messageId: 'remarkWarningMessage',
+        data: {
+          methodName: nodeName
+        }
+      })
+    }
 
     return {
-      MethodDefinition(node) {
-        // Method
-        const method = node
-
-        // Method decorators
-        const methodDecorators = method.decorators
-        const hasDecorators = methodDecorators?.length > 0
-
-        if (!hasDecorators) return
-
-        // Get the @Deprecated() decorator from method
-        const deprecatedDecoratorNode =
-          hasDecorators && methodDecorators?.find(decorator => decorator?.expression?.callee?.name === 'Deprecated')
-
-        if (!deprecatedDecoratorNode) return
-
-        // RULE: Mark method with a warning
-        context.report({
-          node: method.key,
-          message: 'This method is marked as a deprecated.'
-        })
-      }
+      ClassDeclaration: highlightNode,
+      ArrowFunctionExpression: highlightNode,
+      MethodDefinition: highlightNode
     }
   }
 }

--- a/packages/eslint-plugin-sui/src/rules/decorator-deprecated-remark-method.js
+++ b/packages/eslint-plugin-sui/src/rules/decorator-deprecated-remark-method.js
@@ -1,0 +1,51 @@
+/**
+ * @fileoverview Ensure that method using @Deprecated() displays a warning alert
+ */
+'use strict'
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Ensure that method using @Deprecated() displays a warning alert',
+      recommended: true,
+      url: 'https://github.mpi-internal.com/scmspain/es-td-agreements/blob/master/30-Frontend/00-agreements'
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {}
+  },
+  create: function (context) {
+    // TODO: Check using decorator in a Class.
+
+    return {
+      MethodDefinition(node) {
+        // Method
+        const method = node
+
+        // Method decorators
+        const methodDecorators = method.decorators
+        const hasDecorators = methodDecorators?.length > 0
+
+        if (!hasDecorators) return
+
+        // Get the @Deprecated() decorator from method
+        const deprecatedDecoratorNode =
+          hasDecorators && methodDecorators?.find(decorator => decorator?.expression?.callee?.name === 'Deprecated')
+
+        if (!deprecatedDecoratorNode) return
+
+        // RULE: Mark method with a warning
+        context.report({
+          node: method.key,
+          message: 'This method is marked as a deprecated.'
+        })
+      }
+    }
+  }
+}

--- a/packages/eslint-plugin-sui/src/rules/decorator-deprecated.js
+++ b/packages/eslint-plugin-sui/src/rules/decorator-deprecated.js
@@ -1,0 +1,115 @@
+/**
+ * @fileoverview Ensure that @Deprecated() decorator is used as expected
+ */
+'use strict'
+
+const dedent = require('string-dedent')
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Ensure that @Deprecated() decorator is used as expected',
+      recommended: true,
+      url: 'https://github.mpi-internal.com/scmspain/es-td-agreements/blob/master/30-Frontend/00-agreements'
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      notFoundDecoratorArgumentError: dedent`
+            The @Deprecated() decorator must have arguments.
+        `,
+      notFoundKeyDecoratorArgumentError: dedent`
+            The @Deprecated() decorator must have a key property.
+        `,
+      notFoundMessageDecoratorArgumentError: dedent`
+            The @Deprecated() decorator must have a message property.
+        `
+    }
+  },
+  create: function (context) {
+    // TODO: Check using decorator in a Class.
+    return {
+      MethodDefinition(node) {
+        // Method
+        const method = node
+        const methodName = method.key?.name
+
+        // Method decorators
+        const methodDecorators = method.decorators
+        const hasDecorators = methodDecorators?.length > 0
+
+        if (!hasDecorators) return
+
+        // Get the @Deprecated() decorator from method
+        const deprecatedDecoratorNode =
+          hasDecorators && methodDecorators?.find(decorator => decorator?.expression?.callee?.name === 'Deprecated')
+
+        if (!deprecatedDecoratorNode) return
+
+        const methodArguments = deprecatedDecoratorNode?.expression?.arguments
+        const hasArgument = methodArguments.length === 1
+        const argumentDecorator = hasArgument && methodArguments[0]
+        const isObjectExpression = hasArgument && argumentDecorator.type === 'ObjectExpression'
+        const argumentsAreInvalid = !hasArgument || !isObjectExpression
+
+        // Get decorator arguments: key and message
+        const keyProperty =
+          !argumentsAreInvalid && argumentDecorator.properties?.find(prop => prop?.key?.name === 'key')
+        const messageProperty =
+          !argumentsAreInvalid && argumentDecorator.properties?.find(prop => prop?.key?.name === 'message')
+
+        // RULE: Decorator must have 1 argument as an object with Key and Message properties
+        if (argumentsAreInvalid || (!keyProperty && !messageProperty)) {
+          context.report({
+            node: deprecatedDecoratorNode,
+            messageId: 'notFoundDecoratorArgumentError',
+            *fix(fixer) {
+              yield fixer.insertTextBefore(
+                deprecatedDecoratorNode,
+                `\n  @Deprecated({key: '${methodName}', message: 'The ${methodName} function is deprecated.'})`
+              )
+              yield fixer.remove(deprecatedDecoratorNode)
+            }
+          })
+          return
+        }
+
+        // RULE: Decorator must have a key property and generates it if it doesn't exist
+        if (!keyProperty && messageProperty) {
+          context.report({
+            node: deprecatedDecoratorNode,
+            messageId: 'notFoundKeyDecoratorArgumentError',
+            *fix(fixer) {
+              yield fixer.insertTextBefore(
+                deprecatedDecoratorNode,
+                `\n  @Deprecated({key: '${methodName}', message: '${messageProperty.value.value}'})`
+              )
+              yield fixer.remove(deprecatedDecoratorNode)
+            }
+          })
+        }
+
+        // RULE: Decorator must have a message property and generates it if it doesn't exist
+        if (keyProperty && !messageProperty) {
+          context.report({
+            node: deprecatedDecoratorNode,
+            messageId: 'notFoundMessageDecoratorArgumentError',
+            *fix(fixer) {
+              yield fixer.insertTextBefore(
+                deprecatedDecoratorNode,
+                `\n  @Deprecated({key: '${keyProperty.value.value}', message: 'The ${methodName} function is deprecated.'})`
+              )
+              yield fixer.remove(deprecatedDecoratorNode)
+            }
+          })
+        }
+      }
+    }
+  }
+}

--- a/packages/eslint-plugin-sui/src/utils/decorators.js
+++ b/packages/eslint-plugin-sui/src/utils/decorators.js
@@ -1,0 +1,76 @@
+function getDecoratorsByNode(node, {isAClass, isAMethod, isArrowFunction}) {
+  if (isAClass) {
+    return node.decorators
+  }
+
+  if (isArrowFunction) {
+    const methodNode = node.parent
+    return methodNode.decorators ?? []
+  }
+
+  if (isAMethod) {
+    return node.decorators ?? []
+  }
+
+  return []
+}
+
+function getElementName(node, {isAClass, isAMethod, isArrowFunction}) {
+  if (isAClass) {
+    const className = node.id?.name ?? 'UnknownClass'
+    return `${className}`
+  }
+
+  if (isArrowFunction) {
+    const methodNode = node.parent
+    const classNode = methodNode?.parent?.parent
+    const className = classNode.id?.name ?? 'UnknownClass'
+    const methodName = methodNode.key?.name ?? 'UnknownMethod'
+
+    return `${className}.${methodName}`
+  }
+
+  if (isAMethod) {
+    const classNode = node.parent?.parent
+    const className = classNode.id?.name ?? 'UnknownClass'
+    const methodName = node.key?.name ?? 'UnknownMethod'
+
+    return `${className}.${methodName}`
+  }
+
+  return 'unknown'
+}
+
+function getElementMessageName(elementName, {isAClass, isAMethod, isArrowFunction}) {
+  if (isAClass) {
+    return `class ${elementName}`
+  }
+
+  if (isAMethod || isArrowFunction) {
+    return `method ${elementName}`
+  }
+
+  return 'Unknown'
+}
+
+function remarkElement(node, {isAClass, isAMethod, isArrowFunction}) {
+  if (isAClass) {
+    return node.id
+  }
+
+  if (isArrowFunction) {
+    const methodNode = node.parent
+    return methodNode.key
+  }
+
+  if (isAMethod) {
+    return node.key
+  }
+
+  return node
+}
+
+module.exports.getDecoratorsByNode = getDecoratorsByNode
+module.exports.getElementMessageName = getElementMessageName
+module.exports.getElementName = getElementName
+module.exports.remarkElement = remarkElement

--- a/packages/sui-decorators/src/decorators/deprecated/index.js
+++ b/packages/sui-decorators/src/decorators/deprecated/index.js
@@ -1,0 +1,46 @@
+import isNode from '../../helpers/isNode.js'
+
+const noop = () => {}
+
+const getListener = () => {
+  const listener = isNode ? global.__SUI_DECORATOR_DEPRECATED_REPORTER__ : window.__SUI_DECORATOR_DEPRECATED_REPORTER__
+  return listener || noop
+}
+
+const _runner = ({instance, original, config} = {}) => {
+  return function (...args) {
+    const listener = getListener()
+    listener(config)
+
+    const {message} = config
+
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(message)
+    }
+
+    return original.apply(instance, args)
+  }
+}
+
+export function Deprecated(config = {message: ''}) {
+  return function (target, fnName, descriptor) {
+    const {value: fn, configurable, enumerable} = descriptor
+
+    return Object.assign(
+      {},
+      {
+        configurable,
+        enumerable,
+        value(...args) {
+          const _fnRunner = _runner({
+            instance: this,
+            original: fn,
+            config
+          })
+
+          return _fnRunner.apply(this, args)
+        }
+      }
+    )
+  }
+}

--- a/packages/sui-decorators/src/index.js
+++ b/packages/sui-decorators/src/index.js
@@ -1,6 +1,7 @@
 import {cache, invalidateCache} from './decorators/cache/index.js'
+import {Deprecated} from './decorators/deprecated/index.js'
 import inlineError from './decorators/error.js'
 import streamify from './decorators/streamify.js'
 import tracer from './decorators/tracer/index.js'
 
-export {cache, invalidateCache, streamify, inlineError, tracer}
+export {cache, Deprecated, invalidateCache, streamify, inlineError, tracer}

--- a/packages/sui-decorators/test/browser/DeprecatedSpec.js
+++ b/packages/sui-decorators/test/browser/DeprecatedSpec.js
@@ -1,0 +1,48 @@
+import {expect} from 'chai'
+import sinon from 'sinon'
+
+import {Deprecated} from '../../src/decorators/deprecated/index.js'
+
+describe('Deprecated decorator', () => {
+  beforeEach(() => {
+    sinon.stub(console, 'warn')
+    window.__SUI_DECORATOR_DEPRECATED_REPORTER__ = undefined
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it('should exist', () => {
+    expect(Deprecated).to.exist
+    expect(Deprecated).to.be.a('function')
+  })
+
+  it('should write a console.warn into console', async () => {
+    class Buzz {
+      @Deprecated({key: 'returnASuccessPromise', message: 'This method is deprecated'})
+      returnASuccessPromise() {
+        return Promise.resolve(true)
+      }
+    }
+
+    const buzz = new Buzz()
+    expect(await buzz.returnASuccessPromise()).to.be.eql(true)
+    expect(console.warn.calledOnce).to.be.true
+  })
+
+  it('should call to listener', async () => {
+    window.__SUI_DECORATOR_DEPRECATED_REPORTER__ = sinon.spy()
+
+    class Buzz {
+      @Deprecated({key: 'returnASuccessPromise', message: 'This method is deprecated'})
+      returnASuccessPromise() {
+        return Promise.resolve(true)
+      }
+    }
+
+    const buzz = new Buzz()
+    expect(await buzz.returnASuccessPromise()).to.be.eql(true)
+    expect(window.__SUI_DECORATOR_DEPRECATED_REPORTER__.calledOnce).to.be.true
+  })
+})

--- a/packages/sui-decorators/test/server/DeprecatedSpec.js
+++ b/packages/sui-decorators/test/server/DeprecatedSpec.js
@@ -1,0 +1,48 @@
+import {expect} from 'chai'
+import sinon from 'sinon'
+
+import {Deprecated} from '../../src/decorators/deprecated/index.js'
+
+describe('Deprecated decorator', () => {
+  beforeEach(() => {
+    sinon.stub(console, 'warn')
+    global.__SUI_DECORATOR_DEPRECATED_REPORTER__ = undefined
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it('should exist', () => {
+    expect(Deprecated).to.exist
+    expect(Deprecated).to.be.a('function')
+  })
+
+  it('should write a console.warn into console', async () => {
+    class Buzz {
+      @Deprecated({key: 'returnASuccessPromise', message: 'This method is deprecated'})
+      returnASuccessPromise() {
+        return Promise.resolve(true)
+      }
+    }
+
+    const buzz = new Buzz()
+    expect(await buzz.returnASuccessPromise()).to.be.eql(true)
+    expect(console.warn.calledOnce).to.be.true
+  })
+
+  it('should call to listener to enable monitoring', async () => {
+    global.__SUI_DECORATOR_DEPRECATED_REPORTER__ = sinon.spy()
+
+    class Buzz {
+      @Deprecated({key: 'returnASuccessPromise', message: 'This method is deprecated'})
+      returnASuccessPromise() {
+        return Promise.resolve(true)
+      }
+    }
+
+    const buzz = new Buzz()
+    expect(await buzz.returnASuccessPromise()).to.be.eql(true)
+    expect(global.__SUI_DECORATOR_DEPRECATED_REPORTER__.calledOnce).to.be.true
+  })
+})

--- a/packages/sui-lint/eslintrc.js
+++ b/packages/sui-lint/eslintrc.js
@@ -239,7 +239,9 @@ module.exports = {
       rules: {
         'sui/factory-pattern': RULES.WARNING,
         'sui/serialize-deserialize': RULES.WARNING,
-        'sui/decorators': RULES.WARNING
+        'sui/decorators': RULES.WARNING,
+        'sui/decorator-deprecated': RULES.ERROR,
+        'sui/decorator-deprecated-remark-method': RULES.WARNING
       }
     },
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Frontend Tech Community has agreed to create, use, and standardize the `@Deprecated()` decorator. It will help us to manage the death code and monitor it to keep our code as clean as possible. 

### New decorator: `@Deprecated()`

Imagine you are refactoring a code, or disabling a functionality. How sure you are, that your code is not being used? For those cases, if you use the `@Deprecated()` decorator, you will be able to see a `console.warn` on your terminal or browser console (it's disabled on production by default). 

If you want to monitor the health of your code, this decorator brings you the possibility to integrate yourself into your application and send it to your desired platform. 

This decorator has 2 required parameters: 

- `key`: Used to enable you the possibility of monitoring and know how many times the deprecated code has been called. 
- `message`: Used to display the message into the terminal or browser console. It's enabled only for `non-production` environments.

### Linting Rules

With this Pull Request, also we will add some linting rules for this decorator to help the DX and make our life easier. 

The linting rules are: 
- The `@Deprecated()` decorator **MUST** be used only on `Classes` and `Methods`.
  - An ESLint error will appear. 
  - A quick fix to remove it will appear.
- The `@Deprecated()` decorator **MUST** have a `key` provided.
  - An ESLint error will appear
  - A quick fix to autocomplete the `key` will appear with the current method/class name. 
- The `@Deprecated()` decorator **MUST** have a `message` provided. 
  - An ESLint error will appear
  - A quick fix to autocomplete the `key` will appear with the current method/class name. 
- A method/class with a `@Deprecated()` decorator, will be highlighted as a warning.
  - An ESLint error will appear. 

### Example of usage: 

```javascript 
@Deprecated({ key: 'DummyUseCase#execute', message: 'The [DummyUseCase#execute] method is deprecated. Use the [SuperDummyUseCase#execute] instead' })
function execute() {
  if(error) {
    throw new Error('this is not ok')
  }
  return 'this is ok'
}

``` 

### Example of visualisation on your Browser Console
![image](https://github.com/user-attachments/assets/e4f4bd2d-8eed-472a-b8f7-576a6ecd6c5c)

## Example

### Client test ✅
<img width="750" alt="image" src="https://github.com/SUI-Components/sui/assets/3933098/82416ff3-7598-40c4-8de6-4d6a549050a0">

### Server test ✅
<img width="525" alt="image" src="https://github.com/SUI-Components/sui/assets/3933098/74a3c5a2-81e9-4d61-b8b7-6d462df49b86">


