### PR TITLE
Fix/interpolate with multiple nesting keys

### DIFF
--- a/packages/sui-i18n/src/i18n.js
+++ b/packages/sui-i18n/src/i18n.js
@@ -211,7 +211,8 @@ export default class Rosetta {
       let {key, children} = match.groups
 
       // Handle nested matches
-      if (interpolateRegExp.test(children)) {
+      const nestedRegExp = /%\[(?<key>[\S\s]*?)\b\](?<children>[\S\s]*?)\[\1\]%/gi
+      if (nestedRegExp.test(children)) {
         children = this.interpolate(children, values)
       }
 

--- a/packages/sui-i18n/src/i18n.js
+++ b/packages/sui-i18n/src/i18n.js
@@ -2,6 +2,8 @@ import {slugify} from '@s-ui/js/lib/string/slugify.js'
 
 import DefaultAdapter from './adapters/default.js'
 
+const INTERPOLATE_REGEX = /%\[(?<key>[\S\s]*?)\b\](?<children>[\S\s]*?)\[\1\]%/gi
+
 export default class Rosetta {
   constructor({adapter = new DefaultAdapter()} = {}) {
     this._culture = null
@@ -195,14 +197,13 @@ export default class Rosetta {
 
   // Interpolate each text chunk, returning an array of all the transformed chunks.
   interpolate(key, values = {}) {
-    // Redeclare the RegExp on each call to make it stateless
-    const interpolateRegExp = /%\[(?<key>[\S\s]*?)\b\](?<children>[\S\s]*?)\[\1\]%/gi
-
     // Perform basic replace for static values
     const str = this.t(key, values)
 
     // Identify all the occurrences which are like: %[key]children[key]%, save {key, children} in a group for every match
-    const matches = str.matchAll(interpolateRegExp)
+    // Reset the state of the regex to start from the beginning
+    INTERPOLATE_REGEX.lastIndex = 0
+    const matches = str.matchAll(INTERPOLATE_REGEX)
 
     let remaining = str
 
@@ -211,8 +212,9 @@ export default class Rosetta {
       let {key, children} = match.groups
 
       // Handle nested matches
-      const nestedRegExp = /%\[(?<key>[\S\s]*?)\b\](?<children>[\S\s]*?)\[\1\]%/gi
-      if (nestedRegExp.test(children)) {
+      // We need to reset the lastIndex to 0 to start the search from the beginning
+      INTERPOLATE_REGEX.lastIndex = 0
+      if (INTERPOLATE_REGEX.test(children)) {
         children = this.interpolate(children, values)
       }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The interpolate function is using a statefull regex but it is being reused without reseting its inner state, in order to handle its statefull nature we need to reset the inner state lastIndex every time we need to reuse it to match something from the beginning.

## Example

I found the bug by providing this literal: %[item1]Para verificar tu perfil, por favor revisa el email que te hemos enviado a: %[email][email]%.[item1]%%[item2]¿Este no es tu email? %[changeEmail]Cámbialo ahora[changeEmail]%.[item2]%%[item3]¿No lo has recibido? Revisa tu carpeta de spam o añade pushinfojobs@push.infojobs.net a remitentes seguros.[item3]%%[item4]¿Aún no lo has recibido? %[resend]Te lo reenviamos[resend]%[item4]%

It was handling correctly the first and third nested elements but the second was not able to handle it due to the use of global regex
