### PR TITLE
fix(packages/sui-lint): disable correct decorator rule to avoid lint error

### DIFF
--- a/packages/sui-lint/eslintrc.js
+++ b/packages/sui-lint/eslintrc.js
@@ -240,10 +240,10 @@ module.exports = {
         'sui/factory-pattern': RULES.WARNING,
         'sui/serialize-deserialize': RULES.WARNING,
         'sui/decorators': RULES.WARNING,
-        // 'sui/decorator-async-inline-error': RULES.WARNING,
+        'sui/decorator-async-inline-error': RULES.WARNING,
         'sui/decorator-deprecated': RULES.ERROR,
-        'sui/decorator-deprecated-remark-method': RULES.WARNING,
-        'sui/decorator-inline-error': RULES.WARNING
+        'sui/decorator-deprecated-remark-method': RULES.WARNING
+        // 'sui/decorator-inline-error': RULES.WARNING
       }
     },
     {


### PR DESCRIPTION
## Description
Disables correct decorator rule to avoid lint error (previous rule disabled was not the cause).

Related with: #1811 
