### PR TITLE
feat(packages/sui-pde): add decide listener

### DIFF
--- a/packages/sui-pde/src/adapters/default.js
+++ b/packages/sui-pde/src/adapters/default.js
@@ -15,6 +15,14 @@ export default class DefaultAdapter {
     return null
   }
 
+  addDecideListener() {
+    return null
+  }
+
+  removeNotificationListener() {
+    return null
+  }
+
   decide() {
     return null
   }

--- a/packages/sui-pde/src/adapters/optimizely/index.js
+++ b/packages/sui-pde/src/adapters/optimizely/index.js
@@ -126,6 +126,10 @@ export default class OptimizelyAdapter {
    * @returns {object} decision
    */
   decide({name, attributes}) {
+    if (!this._hasUserConsents) {
+      return {enabled: false, flagKey: name}
+    }
+
     const user = this._optimizely.createUserContext(this._userId, {
       ...this._applicationAttributes,
       ...attributes

--- a/packages/sui-pde/src/adapters/optimizely/index.js
+++ b/packages/sui-pde/src/adapters/optimizely/index.js
@@ -14,9 +14,9 @@ const DEFAULT_EVENTS_OPTIONS = {
 
 const DEFAULT_TIMEOUT = 500
 
-const {enums: LOG_LEVEL} = optimizelySDK
+const {enums} = optimizelySDK
 
-const LOGGER_LEVEL = process.env.NODE_ENV === 'production' ? LOG_LEVEL.error : LOG_LEVEL.info
+const LOGGER_LEVEL = process.env.NODE_ENV === 'production' ? enums.error : enums.info
 
 export default class OptimizelyAdapter {
   /**
@@ -123,17 +123,32 @@ export default class OptimizelyAdapter {
    * @param {Object} params
    * @param {string} params.name
    * @param {object} [params.attributes]
-   * @returns {string=} variation name
+   * @returns {object} decision
    */
   decide({name, attributes}) {
-    if (!this._hasUserConsents) return null
-
     const user = this._optimizely.createUserContext(this._userId, {
       ...this._applicationAttributes,
       ...attributes
     })
 
     return user.decide(name)
+  }
+
+  /**
+   * @param {Object} params
+   * @param {function} params.onDecide
+   * @returns {number} notificationId
+   */
+  addDecideListener({onDecide}) {
+    return this._optimizely.notificationCenter.addNotificationListener(enums.NOTIFICATION_TYPES.DECISION, onDecide)
+  }
+
+  /**
+   * @param {Object} params
+   * @param {number} params.notificationId
+   */
+  removeNotificationListener({notificationId}) {
+    this._optimizely.notificationCenter.removeNotificationListener(notificationId)
   }
 
   /**

--- a/packages/sui-pde/src/adapters/optimizely/multiple.js
+++ b/packages/sui-pde/src/adapters/optimizely/multiple.js
@@ -64,6 +64,14 @@ class MultipleOptimizelyAdapter {
     return this.#adapters[adapterId].decide(props)
   }
 
+  addDecideListener({adapterId = defaultAdapterId, ...props}) {
+    return this.#adapters[adapterId].addDecideListener(props)
+  }
+
+  removeNotificationListener({adapterId = defaultAdapterId, ...props}) {
+    this.#adapters[adapterId].removeNotificationListener(props)
+  }
+
   getVariation({adapterId = defaultAdapterId, ...props}) {
     return this.#adapters[adapterId].getVariation(props)
   }

--- a/packages/sui-pde/src/pde.js
+++ b/packages/sui-pde/src/pde.js
@@ -37,6 +37,23 @@ export default class PDE {
     return this._adapter.decide({name, attributes, adapterId})
   }
 
+  /**
+   * @param {Object} params
+   * @param {function} params.onDecide
+   * @returns {string} notificationId
+   */
+  addDecideListener({onDecide}) {
+    return this._adapter.addDecideListener({onDecide})
+  }
+
+  /**
+   * @param {Object} params
+   * @param {number} params.notificationId
+   */
+  removeNotificationListener({notificationId}) {
+    this._adapter.removeNotificationListener({notificationId})
+  }
+
   getInitialData() {
     return this._adapter.getInitialData()
   }

--- a/packages/sui-pde/test/common/useDecisionSpec.js
+++ b/packages/sui-pde/test/common/useDecisionSpec.js
@@ -30,7 +30,7 @@ describe('useDecision hook', () => {
     let decide
 
     before(() => {
-      decide = sinon.stub().returns({
+      const decision = {
         variationKey: 'variation',
         enabled: true,
         variables: {},
@@ -38,10 +38,18 @@ describe('useDecision hook', () => {
         flagKey: 'flag',
         userContext: {},
         reasons: []
-      })
+      }
+      decide = sinon.stub().returns(decision)
+
+      const addDecideListener = ({onDecide}) =>
+        onDecide({type: 'flag', decisionInfo: {...decision, decisionEventDispatched: true}})
+      const removeNotificationListener = sinon.stub()
+
       // eslint-disable-next-line react/prop-types
       wrapper = ({children}) => (
-        <PdeContext.Provider value={{features: [], pde: {decide}}}>{children}</PdeContext.Provider>
+        <PdeContext.Provider value={{features: [], pde: {decide, addDecideListener, removeNotificationListener}}}>
+          {children}
+        </PdeContext.Provider>
       )
     })
 
@@ -226,9 +234,14 @@ describe('useDecision hook', () => {
     let wrapper
     beforeEach(() => {
       decide = sinon.stub().throws(new Error('fake activation error'))
+      const addDecideListener = sinon.stub()
+      const removeNotificationListener = sinon.stub()
+
       // eslint-disable-next-line react/prop-types
       wrapper = ({children}) => (
-        <PdeContext.Provider value={{features: [], pde: {decide}}}>{children}</PdeContext.Provider>
+        <PdeContext.Provider value={{features: [], pde: {decide, addDecideListener, removeNotificationListener}}}>
+          {children}
+        </PdeContext.Provider>
       )
     })
 
@@ -248,10 +261,15 @@ describe('useDecision hook', () => {
         track: sinon.spy()
       }
 
+      const addDecideListener = sinon.stub()
+      const removeNotificationListener = sinon.stub()
+
       stubFactory = decide => {
         // eslint-disable-next-line react/prop-types
         wrapper = ({children}) => (
-          <PdeContext.Provider value={{features: [], pde: {decide}}}>{children}</PdeContext.Provider>
+          <PdeContext.Provider value={{features: [], pde: {decide, addDecideListener, removeNotificationListener}}}>
+            {children}
+          </PdeContext.Provider>
         )
       }
     })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR:
- Fix an issue when consents are not accepted returning an object
- Fix issue where `ExperimentViewed` event was being sent for feature flags only

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
