### PR TITLE
FEAT (sui-test & sui-studio) binary option: no coverage inline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9639,9 +9639,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.57",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.57.tgz",
-      "integrity": "sha512-xS65H/tqgOwUBa5UmOuNSLuslDo7zho0y/lgQw35pnrqiZh7UOWHCeL/Bt6noJATbA6tpQJGCifsFsIRZj1Fqg==",
+      "version": "1.5.58",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.58.tgz",
+      "integrity": "sha512-al2l4r+24ZFL7WzyPTlyD0fC33LLzvxqLCwurtBibVPghRGO9hSTl+tis8t1kD7biPiH/en4U0I7o/nQbYeoVA==",
       "license": "ISC"
     },
     "node_modules/element-polyfill": {
@@ -27010,7 +27010,7 @@
         "@s-ui/helpers": "1",
         "@s-ui/react-context": "1",
         "@s-ui/react-router": "1",
-        "@s-ui/test": "no-coverage-inline",
+        "@s-ui/test": "8",
         "@testing-library/react": "10.4.9",
         "@testing-library/react-hooks": "4.0.1",
         "@testing-library/user-event": "13.5.0",
@@ -27058,120 +27058,6 @@
         "@s-ui/i18n": "1"
       }
     },
-    "packages/sui-studio/node_modules/@babel/core": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.10.tgz",
-      "integrity": "sha512-JQM6k6ENcBFKVtWvLavlvi/mPcpYZ3+R+2EySDEMSMbp7Mn4FexlbbJVrx2R7Ijhr01T8gyqrOaABWIOgxeUyw==",
-      "license": "MIT",
-      "dependencies": {
-        "@ampproject/remapping": "^2.1.0",
-        "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.18.10",
-        "@babel/helper-compilation-targets": "^7.18.9",
-        "@babel/helper-module-transforms": "^7.18.9",
-        "@babel/helpers": "^7.18.9",
-        "@babel/parser": "^7.18.10",
-        "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.18.10",
-        "@babel/types": "^7.18.10",
-        "convert-source-map": "^1.7.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.1",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "packages/sui-studio/node_modules/@s-ui/test": {
-      "version": "8.41.0-no-coverage-inline.0",
-      "resolved": "https://registry.npmjs.org/@s-ui/test/-/test-8.41.0-no-coverage-inline.0.tgz",
-      "integrity": "sha512-ksuoEFvoVa3zSXVScLCPYWp/1bnXriCXxGoz+c2rEIupO2+X7JVYeZtXWIeOVhhJNLDx7stTYZzXK7bc7ZiE1g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "7.18.10",
-        "@babel/plugin-transform-modules-commonjs": "7.24.8",
-        "@babel/register": "7.18.9",
-        "@faker-js/faker": "8.0.2",
-        "@s-ui/compiler-config": "1",
-        "@s-ui/helpers": "1",
-        "@swc/core": "1.3.14",
-        "@swc/register": "0.1.10",
-        "babel-loader": "8.3.0",
-        "babel-plugin-dynamic-import-node": "2.3.3",
-        "babel-plugin-istanbul": "6.0.0",
-        "babel-preset-sui": "3",
-        "chai": "3.5.0",
-        "commander": "8.3.0",
-        "diff": "5.1.0",
-        "karma": "6.4.3",
-        "karma-chrome-launcher": "3.2.0",
-        "karma-coverage": "2.2.1",
-        "karma-firefox-launcher": "2.1.2",
-        "karma-mocha": "2.0.1",
-        "karma-spec-reporter": "0.0.34",
-        "karma-webpack": "5.0.0",
-        "mocha": "10.0.0",
-        "process": "0.11.10",
-        "stream-browserify": "3.0.0",
-        "swc-loader": "0.2.6",
-        "tty-browserify": "0.0.1",
-        "util": "0.12.4",
-        "webpack": "5.94.0"
-      },
-      "bin": {
-        "sui-test": "bin/sui-test.js"
-      }
-    },
-    "packages/sui-studio/node_modules/@s-ui/test/node_modules/chai": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-      "integrity": "sha512-eRYY0vPS2a9zt5w5Z0aCeWbrXTEyvk7u/Xf71EzNObrjSCPgMm1Nku/D/u2tiqHBX5j40wWhj54YJLtgn8g55A==",
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^1.0.1",
-        "deep-eql": "^0.1.3",
-        "type-detect": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "packages/sui-studio/node_modules/@s-ui/test/node_modules/deep-eql": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "integrity": "sha512-6sEotTRGBFiNcqVoeHwnfopbSpi5NbH1VWJmYCVkmxMmaVTT0bUTrNaGyBwhgP4MZL012W/mkzIn3Da+iDYweg==",
-      "license": "MIT",
-      "dependencies": {
-        "type-detect": "0.1.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "packages/sui-studio/node_modules/@s-ui/test/node_modules/deep-eql/node_modules/type-detect": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-      "integrity": "sha512-5rqszGVwYgBoDkIm2oUtvkfZMQ0vk29iDMU0W2qCa3rG0vPDNczCMT4hV/bLBgLg8k8ri6+u3Zbt+S/14eMzlA==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "packages/sui-studio/node_modules/@s-ui/test/node_modules/type-detect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-      "integrity": "sha512-f9Uv6ezcpvCQjJU0Zqbg+65qdcszv3qUQsZfjdRbWiZ7AMenrX1u0lNk9EoWWX6e1F+NULyg27mtdeZ5WhpljA==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "packages/sui-studio/node_modules/chai": {
       "version": "4.3.10",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
@@ -27189,12 +27075,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "packages/sui-studio/node_modules/convert-source-map": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "license": "MIT"
     },
     "packages/sui-studio/node_modules/deep-eql": {
       "version": "4.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -276,9 +276,9 @@
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.2.tgz",
-      "integrity": "sha512-LV76g+C502biUK6AyZ3LK10vDpDyCzZnhZFXkH1L75zHPj68+qc8Zfpx2th+gzwA2MzyK+1g/3EPl62yFnVttQ==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.3.tgz",
+      "integrity": "sha512-HK7Bi+Hj6H+VTHA3ZvBis7V/6hu9QuTrnMXNybfUf2iiuU/N97I8VjB+KbhFF8Rld/Lx5MzoCwPCpPjfK+n8Cg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.22.6",
@@ -6587,13 +6587,13 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.11.tgz",
-      "integrity": "sha512-sMEJ27L0gRHShOh5G54uAAPaiCOygY/5ratXuiyb2G46FmlSpc9eFCzYVyDiPxfNbwzA7mYahmjQc5q+CZQ09Q==",
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.12.tgz",
+      "integrity": "sha512-CPWT6BwvhrTO2d8QVorhTCQw9Y43zOu7G9HigcfxvepOU6b8o3tcWad6oVgZIsZCTt42FFv97aA7ZJsbM4+8og==",
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.22.6",
-        "@babel/helper-define-polyfill-provider": "^0.6.2",
+        "@babel/helper-define-polyfill-provider": "^0.6.3",
         "semver": "^6.3.1"
       },
       "peerDependencies": {
@@ -9639,9 +9639,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.55",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.55.tgz",
-      "integrity": "sha512-6maZ2ASDOTBtjt9FhqYPRnbvKU5tjG0IN9SztUOWYw2AzNDNpKJYLJmlK0/En4Hs/aiWnB+JZ+gW19PIGszgKg==",
+      "version": "1.5.57",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.57.tgz",
+      "integrity": "sha512-xS65H/tqgOwUBa5UmOuNSLuslDo7zho0y/lgQw35pnrqiZh7UOWHCeL/Bt6noJATbA6tpQJGCifsFsIRZj1Fqg==",
       "license": "ISC"
     },
     "node_modules/element-polyfill": {
@@ -9830,9 +9830,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
-      "integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
+      "version": "1.23.4",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.4.tgz",
+      "integrity": "sha512-HR1gxH5OaiN7XH7uiWH0RLw0RcFySiSoW1ctxmD1ahTw3uGBtkmm/ng0tDU1OtYx5OK6EOL5Y6O21cDflG3Jcg==",
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
@@ -9850,7 +9850,7 @@
         "function.prototype.name": "^1.1.6",
         "get-intrinsic": "^1.2.4",
         "get-symbol-description": "^1.0.2",
-        "globalthis": "^1.0.3",
+        "globalthis": "^1.0.4",
         "gopd": "^1.0.1",
         "has-property-descriptors": "^1.0.2",
         "has-proto": "^1.0.3",
@@ -9866,10 +9866,10 @@
         "is-string": "^1.0.7",
         "is-typed-array": "^1.1.13",
         "is-weakref": "^1.0.2",
-        "object-inspect": "^1.13.1",
+        "object-inspect": "^1.13.3",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.5",
-        "regexp.prototype.flags": "^1.5.2",
+        "regexp.prototype.flags": "^1.5.3",
         "safe-array-concat": "^1.1.2",
         "safe-regex-test": "^1.0.3",
         "string.prototype.trim": "^1.2.9",
@@ -19632,13 +19632,13 @@
       }
     },
     "node_modules/postcss-modules-local-by-default": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.5.tgz",
-      "integrity": "sha512-6MieY7sIfTK0hYfafw1OMEG+2bg8Q1ocHCpoWLqOKj3JXlKu4G7btkmM/B7lFubYkYWmRSPLZi5chid63ZaZYw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.1.0.tgz",
+      "integrity": "sha512-rm0bdSv4jC3BDma3s9H19ZddW0aHX6EoqwDYU2IfZhRN+53QrufTRo2IdkAbRqLx4R2IYbZnbjKKxg4VN5oU9Q==",
       "license": "MIT",
       "dependencies": {
         "icss-utils": "^5.0.0",
-        "postcss-selector-parser": "^6.0.2",
+        "postcss-selector-parser": "^7.0.0",
         "postcss-value-parser": "^4.1.0"
       },
       "engines": {
@@ -19648,19 +19648,45 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/postcss-modules-local-by-default/node_modules/postcss-selector-parser": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
+      "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/postcss-modules-scope": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.2.0.tgz",
-      "integrity": "sha512-oq+g1ssrsZOsx9M96c5w8laRmvEu9C3adDSjI8oTcbfkrTE8hx/zfyobUoWIxaKPO8bt6S62kxpw5GqypEw1QQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.2.1.tgz",
+      "integrity": "sha512-m9jZstCVaqGjTAuny8MdgE88scJnCiQSlSrOWcTQgM2t32UBe+MUmFSO5t7VMSfAf/FJKImAxBav8ooCHJXCJA==",
       "license": "ISC",
       "dependencies": {
-        "postcss-selector-parser": "^6.0.4"
+        "postcss-selector-parser": "^7.0.0"
       },
       "engines": {
         "node": "^10 || ^12 || >= 14"
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-scope/node_modules/postcss-selector-parser": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
+      "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/postcss-modules-values": {
@@ -25658,7 +25684,7 @@
     },
     "packages/sui-bundler": {
       "name": "@s-ui/bundler",
-      "version": "9.69.0",
+      "version": "9.70.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -25784,7 +25810,7 @@
     },
     "packages/sui-critical-css": {
       "name": "@s-ui/critical-css",
-      "version": "1.28.0",
+      "version": "1.29.0",
       "license": "ISC",
       "dependencies": {
         "@s-ui/critical-css-middleware": "1",
@@ -25796,7 +25822,7 @@
     },
     "packages/sui-critical-css-middleware": {
       "name": "@s-ui/critical-css-middleware",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "path-to-regexp": "0.1.10"
       }
@@ -26079,7 +26105,7 @@
     },
     "packages/sui-js": {
       "name": "@s-ui/js",
-      "version": "2.35.0",
+      "version": "2.36.0",
       "license": "MIT",
       "dependencies": {
         "bowser": "2.11.0",
@@ -26654,7 +26680,7 @@
     },
     "packages/sui-pde": {
       "name": "@s-ui/pde",
-      "version": "2.30.0",
+      "version": "2.31.0",
       "license": "MIT",
       "dependencies": {
         "@optimizely/optimizely-sdk": "5.3.4",
@@ -26886,7 +26912,7 @@
     },
     "packages/sui-sass-loader": {
       "name": "@s-ui/sass-loader",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "dependencies": {
         "cli-source-preview": "1.1.0",
         "co": "4.6.0",
@@ -26976,7 +27002,7 @@
     },
     "packages/sui-studio": {
       "name": "@s-ui/studio",
-      "version": "11.46.0",
+      "version": "11.47.0",
       "license": "MIT",
       "dependencies": {
         "@babel/cli": "7",
@@ -26984,7 +27010,7 @@
         "@s-ui/helpers": "1",
         "@s-ui/react-context": "1",
         "@s-ui/react-router": "1",
-        "@s-ui/test": "8",
+        "@s-ui/test": "no-coverage-inline",
         "@testing-library/react": "10.4.9",
         "@testing-library/react-hooks": "4.0.1",
         "@testing-library/user-event": "13.5.0",
@@ -27032,6 +27058,120 @@
         "@s-ui/i18n": "1"
       }
     },
+    "packages/sui-studio/node_modules/@babel/core": {
+      "version": "7.18.10",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.10.tgz",
+      "integrity": "sha512-JQM6k6ENcBFKVtWvLavlvi/mPcpYZ3+R+2EySDEMSMbp7Mn4FexlbbJVrx2R7Ijhr01T8gyqrOaABWIOgxeUyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.1.0",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.18.10",
+        "@babel/helper-compilation-targets": "^7.18.9",
+        "@babel/helper-module-transforms": "^7.18.9",
+        "@babel/helpers": "^7.18.9",
+        "@babel/parser": "^7.18.10",
+        "@babel/template": "^7.18.10",
+        "@babel/traverse": "^7.18.10",
+        "@babel/types": "^7.18.10",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.1",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "packages/sui-studio/node_modules/@s-ui/test": {
+      "version": "8.41.0-no-coverage-inline.0",
+      "resolved": "https://registry.npmjs.org/@s-ui/test/-/test-8.41.0-no-coverage-inline.0.tgz",
+      "integrity": "sha512-ksuoEFvoVa3zSXVScLCPYWp/1bnXriCXxGoz+c2rEIupO2+X7JVYeZtXWIeOVhhJNLDx7stTYZzXK7bc7ZiE1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "7.18.10",
+        "@babel/plugin-transform-modules-commonjs": "7.24.8",
+        "@babel/register": "7.18.9",
+        "@faker-js/faker": "8.0.2",
+        "@s-ui/compiler-config": "1",
+        "@s-ui/helpers": "1",
+        "@swc/core": "1.3.14",
+        "@swc/register": "0.1.10",
+        "babel-loader": "8.3.0",
+        "babel-plugin-dynamic-import-node": "2.3.3",
+        "babel-plugin-istanbul": "6.0.0",
+        "babel-preset-sui": "3",
+        "chai": "3.5.0",
+        "commander": "8.3.0",
+        "diff": "5.1.0",
+        "karma": "6.4.3",
+        "karma-chrome-launcher": "3.2.0",
+        "karma-coverage": "2.2.1",
+        "karma-firefox-launcher": "2.1.2",
+        "karma-mocha": "2.0.1",
+        "karma-spec-reporter": "0.0.34",
+        "karma-webpack": "5.0.0",
+        "mocha": "10.0.0",
+        "process": "0.11.10",
+        "stream-browserify": "3.0.0",
+        "swc-loader": "0.2.6",
+        "tty-browserify": "0.0.1",
+        "util": "0.12.4",
+        "webpack": "5.94.0"
+      },
+      "bin": {
+        "sui-test": "bin/sui-test.js"
+      }
+    },
+    "packages/sui-studio/node_modules/@s-ui/test/node_modules/chai": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "integrity": "sha512-eRYY0vPS2a9zt5w5Z0aCeWbrXTEyvk7u/Xf71EzNObrjSCPgMm1Nku/D/u2tiqHBX5j40wWhj54YJLtgn8g55A==",
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.0.1",
+        "deep-eql": "^0.1.3",
+        "type-detect": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "packages/sui-studio/node_modules/@s-ui/test/node_modules/deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha512-6sEotTRGBFiNcqVoeHwnfopbSpi5NbH1VWJmYCVkmxMmaVTT0bUTrNaGyBwhgP4MZL012W/mkzIn3Da+iDYweg==",
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "0.1.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "packages/sui-studio/node_modules/@s-ui/test/node_modules/deep-eql/node_modules/type-detect": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+      "integrity": "sha512-5rqszGVwYgBoDkIm2oUtvkfZMQ0vk29iDMU0W2qCa3rG0vPDNczCMT4hV/bLBgLg8k8ri6+u3Zbt+S/14eMzlA==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "packages/sui-studio/node_modules/@s-ui/test/node_modules/type-detect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha512-f9Uv6ezcpvCQjJU0Zqbg+65qdcszv3qUQsZfjdRbWiZ7AMenrX1u0lNk9EoWWX6e1F+NULyg27mtdeZ5WhpljA==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "packages/sui-studio/node_modules/chai": {
       "version": "4.3.10",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
@@ -27050,6 +27190,12 @@
         "node": ">=4"
       }
     },
+    "packages/sui-studio/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "license": "MIT"
+    },
     "packages/sui-studio/node_modules/deep-eql": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
@@ -27064,7 +27210,7 @@
     },
     "packages/sui-svg": {
       "name": "@s-ui/svg",
-      "version": "3.25.0",
+      "version": "3.26.0",
       "license": "MIT",
       "dependencies": {
         "@s-ui/react-atom-icon": "1",
@@ -27086,7 +27232,7 @@
     },
     "packages/sui-test": {
       "name": "@s-ui/test",
-      "version": "8.39.0",
+      "version": "8.40.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "7.18.10",
@@ -27143,7 +27289,7 @@
     },
     "packages/sui-test-e2e": {
       "name": "@s-ui/test-e2e",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "license": "MIT",
       "dependencies": {
         "@testing-library/cypress": "8.0.3",

--- a/packages/sui-studio/bin/sui-studio-test.js
+++ b/packages/sui-studio/bin/sui-studio-test.js
@@ -13,6 +13,7 @@ program
   .option('-W, --watch', 'Watch mode')
   .option('-T, --timeout <timeout>', 'Timeout')
   .option('--coverage', 'Create coverage', false)
+  .option('--no-coverage-inline', 'Save the coverage summary in a text file', false)
   .on('--help', () => {
     console.log('  Examples:')
     console.log('')
@@ -23,7 +24,7 @@ program
   })
   .parse(process.argv)
 
-const {coverage, watch, ci, headless, timeout} = program.opts()
+const {coverage, coverageInline, watch, ci, headless, timeout} = program.opts()
 
 const relPath = path.relative(
   process.cwd(),
@@ -39,6 +40,7 @@ const run = async () => {
           '--pattern',
           path.join(relPath, 'node_modules', '@s-ui', 'studio', 'src', 'runtime-mocha', 'index.js'),
           coverage && '--coverage',
+          !coverageInline && '--no-coverage-inline',
           watch && '--watch',
           ci && '--ci',
           headless && '--headless',

--- a/packages/sui-studio/package.json
+++ b/packages/sui-studio/package.json
@@ -14,7 +14,7 @@
     "@s-ui/helpers": "1",
     "@s-ui/react-context": "1",
     "@s-ui/react-router": "1",
-    "@s-ui/test": "8",
+    "@s-ui/test": "no-coverage-inline",
     "@testing-library/react": "10.4.9",
     "@testing-library/react-hooks": "4.0.1",
     "@testing-library/user-event": "13.5.0",

--- a/packages/sui-studio/package.json
+++ b/packages/sui-studio/package.json
@@ -14,7 +14,7 @@
     "@s-ui/helpers": "1",
     "@s-ui/react-context": "1",
     "@s-ui/react-router": "1",
-    "@s-ui/test": "no-coverage-inline",
+    "@s-ui/test": "8",
     "@testing-library/react": "10.4.9",
     "@testing-library/react-hooks": "4.0.1",
     "@testing-library/user-event": "13.5.0",

--- a/packages/sui-test/bin/karma/index.js
+++ b/packages/sui-test/bin/karma/index.js
@@ -6,7 +6,17 @@ const {
 const config = require('./config.js')
 const CWD = process.cwd()
 
-module.exports = async ({ci, coverage, headless, ignorePattern, pattern, srcPattern, timeout, watch}) => {
+module.exports = async ({
+  ci,
+  coverage,
+  coverageInline,
+  headless,
+  ignorePattern,
+  pattern,
+  srcPattern,
+  timeout,
+  watch
+}) => {
   if (timeout) config.browserDisconnectTimeout = timeout
   if (ignorePattern) config.exclude = [ignorePattern]
 
@@ -38,7 +48,13 @@ module.exports = async ({ci, coverage, headless, ignorePattern, pattern, srcPatt
         {type: 'cobertura', subdir: '.', file: 'coverage.xml'},
         {type: 'html', subdir: 'report-html'},
         {type: 'json-summary', subdir: '.', file: 'coverage.json'},
-        {type: 'text-summary'}
+        {
+          type: 'text-summary',
+          ...(!coverageInline && {
+            subdir: '.',
+            file: 'coverage.txt'
+          })
+        }
       ]
     }
   }

--- a/packages/sui-test/bin/sui-test-browser.js
+++ b/packages/sui-test/bin/sui-test-browser.js
@@ -14,6 +14,7 @@ program
   .option('--src-pattern <srcPattern>', 'Define the source directory', false)
   .option('-T, --timeout <ms>', 'Timeout', 2000)
   .option('--coverage', 'Run the coverage preprocessor', false)
+  .option('--no-coverage-inline', 'Save the coverage summary in a text file', false)
   .on('--help', () => {
     console.log('  Description:')
     console.log('')
@@ -22,15 +23,19 @@ program
     console.log('  Examples:')
     console.log('')
     console.log('    $ sui-test browser')
+    console.log('    $ sui-test browser --headless')
+    console.log('    $ sui-test browser --coverage')
+    console.log('    $ sui-test browser --coverage --no-coverage-inline')
     console.log('')
   })
   .parse(process.argv)
 
-const {ci, coverage, headless, ignorePattern, pattern, srcPattern, timeout, watch} = program.opts()
+const {ci, coverage, coverageInline, headless, ignorePattern, pattern, srcPattern, timeout, watch} = program.opts()
 
 runner({
   ci,
   coverage,
+  coverageInline,
   headless,
   ignorePattern,
   pattern,


### PR DESCRIPTION
Add a command option `--no-coverage-inline` for the binary `sui-test browser` in order to save the coverage summary into a text file instead of attaching it at the end of the standard output.

<img width="1037" alt="no coverage inline" src="https://github.com/user-attachments/assets/3e124b16-ab97-4ad7-a1df-68ce6badee16">
