### PR TITLE
fix(packages/sui-segment-wrapper): Remove adobeCloudVisitorId from GA4

### DIFF
--- a/packages/sui-segment-wrapper/src/events.js
+++ b/packages/sui-segment-wrapper/src/events.js
@@ -1,0 +1,3 @@
+export const EVENTS = {
+  GA4_INIT_EVENT_SENT: 'ga4InitEventSent'
+}

--- a/packages/sui-segment-wrapper/src/index.js
+++ b/packages/sui-segment-wrapper/src/index.js
@@ -5,13 +5,12 @@ import {defaultContextProperties} from './middlewares/source/defaultContextPrope
 import {pageReferrer} from './middlewares/source/pageReferrer.js'
 import {userScreenInfo} from './middlewares/source/userScreenInfo.js'
 import {userTraits} from './middlewares/source/userTraits.js'
+import {getCampaignDetails, loadGoogleAnalytics} from './repositories/googleRepository.js'
 import {checkAnonymousId} from './utils/checkAnonymousId.js'
 import {getConfig, isClient} from './config.js'
 import analytics from './segmentWrapper.js'
 import initTcfTracking from './tcf.js'
 import {getUserDataAndNotify} from './universalId.js'
-import {loadGoogleAnalytics, getCampaignDetails} from './repositories/googleRepository.js'
-import {getAdobeMCVisitorID} from './repositories/adobeRepository.js'
 
 // Initialize TCF Tracking with Segment
 initTcfTracking()
@@ -47,15 +46,11 @@ if (isClient && window.analytics) {
       }
 
     window.gtag('js', new Date())
-
-    getAdobeMCVisitorID().then(marketingCloudVisitorId => {
-      window.gtag('config', googleAnalyticsMeasurementId, {
-        cookie_prefix: 'segment',
-        send_page_view: false,
-        ...googleAnalyticsConfig,
-        ...getCampaignDetails(),
-        mcvid: marketingCloudVisitorId
-      })
+    window.gtag('config', googleAnalyticsMeasurementId, {
+      cookie_prefix: 'segment',
+      send_page_view: false,
+      ...googleAnalyticsConfig,
+      ...getCampaignDetails()
     })
     loadGoogleAnalytics().catch(error => {
       console.error(error)
@@ -69,3 +64,4 @@ if (isClient && window.analytics) {
 export default analytics
 export {getAdobeVisitorData, getAdobeMCVisitorID} from './repositories/adobeRepository.js'
 export {getUniversalId} from './universalId.js'
+export {EVENTS} from './events.js'

--- a/packages/sui-segment-wrapper/src/repositories/googleRepository.js
+++ b/packages/sui-segment-wrapper/src/repositories/googleRepository.js
@@ -1,5 +1,8 @@
-import {utils} from '../middlewares/source/pageReferrer.js'
+import {dispatchEvent} from '@s-ui/js/lib/events'
+
 import {getConfig} from '../config.js'
+import {EVENTS} from '../events.js'
+import {utils} from '../middlewares/source/pageReferrer.js'
 
 const FIELDS = {
   clientId: 'client_id',
@@ -60,6 +63,7 @@ const triggerGoogleAnalyticsInitEvent = sessionId => {
 
     // And then save a new GA session hit in local storage.
     localStorage.setItem(eventKey, 'true')
+    dispatchEvent({eventName: EVENTS.GA4_INIT_EVENT_SENT, detail: {eventName, sessionId}})
   }
 
   // Clean old GA sessions hits from the storage.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The gtag config now was being loaded async due to the function to get the adobeCloudVisitorId and was causing problems when trying to retrieve the session_id outside this lib

## Description
Removed the adobeCloudVisitorId from GA4 since it is not needed any more and it was added for debugging

