### PR TITLE
Feature/response to context

### DIFF
--- a/packages/sui-react-initial-props/src/createServerContextFactoryParams.ts
+++ b/packages/sui-react-initial-props/src/createServerContextFactoryParams.ts
@@ -1,8 +1,9 @@
 import {type ContextFactoryParams} from './types'
 
-export default (req: IncomingMessage.ServerRequest): ContextFactoryParams => ({
+export default (req: IncomingMessage.ServerRequest, res: IncomingMessage.ClientResponse): ContextFactoryParams => ({
   appConfig: req.appConfig,
   req,
+  res,
   cookies: req.headers.cookie,
   isClient: false,
   // that's a native Express path, we might consider use another one instead

--- a/packages/sui-react-initial-props/src/types.d.ts
+++ b/packages/sui-react-initial-props/src/types.d.ts
@@ -15,6 +15,7 @@ export interface ContextFactoryParams {
   pathName: string
   userAgent: string
   req?: object
+  res?: object
 }
 
 export type ClientPageComponent = React.ComponentType<any> &

--- a/packages/sui-ssr/server/hooksFactory/index.js
+++ b/packages/sui-ssr/server/hooksFactory/index.js
@@ -117,7 +117,7 @@ export const hooksFactory = async () => {
       const startContextCreationTime = process.hrtime()
       const {performance = {}} = req
 
-      req.context = await contextFactory(createServerContextFactoryParams(req))
+      req.context = await contextFactory(createServerContextFactoryParams(req, res))
 
       const diffContextCreationTime = process.hrtime(startContextCreationTime)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When requesting an end-point from server in the getInitialProps we need to forward the headers set-cookies from the end-point to the client

