### PR TITLE
feat(packages/sui-bundler): add disableTSLoader flag to control TypeScript loader usage

### DIFF
--- a/packages/sui-bundler/README.md
+++ b/packages/sui-bundler/README.md
@@ -167,6 +167,8 @@ This tool works with zero configuration out the box but you could use some confi
 
 `targets`: Object with information about the browser and version supported. (default: `see the next example`)
 
+`disableTSLoader`: Flag to determine if typescript loader should be used. (default: `false`)
+
 ```json
 {
   "config": {
@@ -184,7 +186,8 @@ This tool works with zero configuration out the box but you could use some confi
       "sourcemaps": {
         "dev": "cheap-module-eval-source-map",
         "prod": "hidden-source-map"
-      }
+      },
+      "disableTSLoader": true // Only if you want to disable typescript loader
     }
   }
 }
@@ -291,8 +294,7 @@ If in your CSS you have:
 ```css
 #app {
   color: blue;
-  background: url('https://spa-mock-statics.surge.sh/images/common/sprite-sheet/sprite-ma.png')
-    no-repeat scroll;
+  background: url('https://spa-mock-statics.surge.sh/images/common/sprite-sheet/sprite-ma.png') no-repeat scroll;
 }
 ```
 
@@ -301,17 +303,15 @@ After compile you will get:
 ```css
 #app {
   color: #00f;
-  background: url(https://spa-mock-statics.surge.sh/images/common/sprite-sheet/sprite-ma.72d1edb214.png)
-    no-repeat scroll;
+  background: url(https://spa-mock-statics.surge.sh/images/common/sprite-sheet/sprite-ma.72d1edb214.png) no-repeat
+    scroll;
 }
 ```
 
 Or if in your JS you have:
 
 ```jsx
-<img
-  src={'https://spa-mock-statics.surge.sh/images/common/mis-anuncios2.gif'}
-/>
+<img src={'https://spa-mock-statics.surge.sh/images/common/mis-anuncios2.gif'} />
 ```
 
 After compile will be:

--- a/packages/sui-bundler/README.md
+++ b/packages/sui-bundler/README.md
@@ -167,7 +167,7 @@ This tool works with zero configuration out the box but you could use some confi
 
 `targets`: Object with information about the browser and version supported. (default: `see the next example`)
 
-`disableTSLoader`: Flag to determine if typescript loader should be used. (default: `false`)
+`disableTypeScriptLoader`: Flag to determine if typescript loader should be used. (default: `false`)
 
 ```json
 {
@@ -187,7 +187,7 @@ This tool works with zero configuration out the box but you could use some confi
         "dev": "cheap-module-eval-source-map",
         "prod": "hidden-source-map"
       },
-      "disableTSLoader": true // Only if you want to disable typescript loader
+      "disableTypeScriptLoader": true // Only if you want to disable typescript loader
     }
   }
 }

--- a/packages/sui-bundler/shared/module-rules-compiler.js
+++ b/packages/sui-bundler/shared/module-rules-compiler.js
@@ -26,8 +26,8 @@ const getTSConfig = () => {
 
 module.exports = ({isServer = false, isDevelopment = false, supportLegacyBrowsers = true} = {}) => {
   const tsConfig = getTSConfig()
-  // If TS config exists in root dir, set TypeScript as enabled.
-  const isTypeScriptEnabled = Boolean(tsConfig)
+  // If config.disableTSLoader is not true and TS config exists in root dir, set TypeScript as enabled.
+  const isTypeScriptEnabled = !config.disableTSLoader && Boolean(tsConfig)
 
   return isTypeScriptEnabled
     ? {

--- a/packages/sui-bundler/shared/module-rules-compiler.js
+++ b/packages/sui-bundler/shared/module-rules-compiler.js
@@ -26,8 +26,8 @@ const getTSConfig = () => {
 
 module.exports = ({isServer = false, isDevelopment = false, supportLegacyBrowsers = true} = {}) => {
   const tsConfig = getTSConfig()
-  // If config.disableTSLoader is not true and TS config exists in root dir, set TypeScript as enabled.
-  const isTypeScriptEnabled = !config.disableTSLoader && Boolean(tsConfig)
+  // If config.disableTypeScriptLoader is not true and TS config exists in root dir, set TypeScript as enabled.
+  const isTypeScriptEnabled = !config.disableTypeScriptLoader && Boolean(tsConfig)
 
   return isTypeScriptEnabled
     ? {


### PR DESCRIPTION
## Description
When trying to integrate the **SUI Semantic Tokens** library into Milanuncios, we encountered a requirement that forces us to add **TypeScript** to the project.

During the integration attempt, we detected a **bug**: styles in **SSR** are not being applied correctly and are only loading on the client side, causing a **visual jump**.

I isolated the TypeScript integration in the web app, and the problem was coming from here.  

### **Problem Analysis**  
It seems that when compiling and bundling with **TypeScript + SWC**, the `routes.js` files **are not including the styles** with **magic comments** in the server-side chunks. As a result, the styles only load on the client side, causing the jump.  

When reviewing the **SUI Bundler** bundling process, it looks like TypeScript follows a different path:  
🔍 [[Relevant code in SUI Bundler](https://github.com/SUI-Components/sui/blob/267279e10d4189e7221d83058a28b418115de2ec/packages/sui-bundler/shared/module-rules-compiler.js#L32)](https://github.com/SUI-Components/sui/blob/267279e10d4189e7221d83058a28b418115de2ec/packages/sui-bundler/shared/module-rules-compiler.js#L32)  
🔍 [[SWC compiler config](https://github.com/SUI-Components/sui/blob/267279e10d4189e7221d83058a28b418115de2ec/packages/sui-compiler-config/src/index.js#L13)](https://github.com/SUI-Components/sui/blob/267279e10d4189e7221d83058a28b418115de2ec/packages/sui-compiler-config/src/index.js#L13)  

I've tried different options to prevent the **SWC** compiler from removing **magic comments**, including `preserveAllComments: true` ([see docs](https://swc.rs/docs/configuration/compilation#jscpreserveallcomments)), but I haven’t been able to get it to work for now.

The solution is to add a new config param to the sui-bundler to avoid using the TS + swc loader. This way, if we use the `"disableTSLoader": true` option in the sui-bundler config, it won't consider the TS loader at this [point](https://github.com/SUI-Components/sui/blob/267279e10d4189e7221d83058a28b418115de2ec/packages/sui-bundler/shared/module-rules-compiler.js#L32). In the meantime, we'll work on solving the TS + Style + SSR problem.

