### PR TITLE
Upgrade typescript package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22442,6 +22442,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
       "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -24250,7 +24251,7 @@
     },
     "packages/sui-bundler": {
       "name": "@s-ui/bundler",
-      "version": "9.71.0",
+      "version": "9.72.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -24393,7 +24394,7 @@
     },
     "packages/sui-dashboard": {
       "name": "@s-ui/dashboard",
-      "version": "1.35.0",
+      "version": "1.36.0",
       "license": "MIT",
       "dependencies": {
         "@s-ui/helpers": "1",
@@ -24697,7 +24698,7 @@
         "commander": "8.3.0",
         "fast-glob": "3.2.12",
         "fs-extra": "10.1.0",
-        "typescript": "5.0.4"
+        "typescript": "^5.8.2"
       },
       "bin": {
         "sui-js-compiler": "index.js"
@@ -24716,6 +24717,19 @@
       },
       "engines": {
         "node": ">=8.6.0"
+      }
+    },
+    "packages/sui-js-compiler/node_modules/typescript": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "packages/sui-js/node_modules/cookie": {
@@ -25263,7 +25277,7 @@
     },
     "packages/sui-polyfills": {
       "name": "@s-ui/polyfills",
-      "version": "1.22.0",
+      "version": "1.24.0",
       "license": "MIT",
       "dependencies": {
         "core-js": "3",
@@ -25334,7 +25348,7 @@
     },
     "packages/sui-react-initial-props": {
       "name": "@s-ui/react-initial-props",
-      "version": "2.23.0",
+      "version": "2.24.0",
       "license": "MIT",
       "devDependencies": {
         "@s-ui/js-compiler": "1",
@@ -25472,7 +25486,7 @@
     },
     "packages/sui-segment-wrapper": {
       "name": "@s-ui/segment-wrapper",
-      "version": "4.13.0",
+      "version": "4.15.0",
       "license": "ISC",
       "dependencies": {
         "@s-ui/js": "2",
@@ -25486,7 +25500,7 @@
     },
     "packages/sui-ssr": {
       "name": "@s-ui/ssr",
-      "version": "8.32.0",
+      "version": "8.34.0",
       "license": "MIT",
       "dependencies": {
         "@s-ui/critical-css-middleware": "1",

--- a/packages/sui-js-compiler/package.json
+++ b/packages/sui-js-compiler/package.json
@@ -18,6 +18,6 @@
     "commander": "8.3.0",
     "fast-glob": "3.2.12",
     "fs-extra": "10.1.0",
-    "typescript": "5.0.4"
+    "typescript": "5.8.2"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Upgrade TypeScript package from 5.0.4 to 5.8.2. After upgrading it, the test failed.

The problem is in the `compileTypes` function where options are passed directly to `createProgram` without properly parsing the TypeScript configuration.

Refactor TypeScript compilation to use `parseJsonConfigFileContent`
