### PR TITLE
feat(packages/sui-segment-wrapper): DENIE consent if it fails to retrieve it

### DIFF
--- a/packages/sui-segment-wrapper/src/repositories/googleRepository.js
+++ b/packages/sui-segment-wrapper/src/repositories/googleRepository.js
@@ -15,6 +15,7 @@ const CONSENT_STATES = {
 }
 
 const CONSENT_STATE_GRANTED_VALUE = 1
+const CONSENT_STATE_DENIED_VALUE = 2
 
 const STC = {
   QUERY: 'stc',
@@ -132,9 +133,19 @@ export const getGoogleSessionId = async () => {
   return sessionId
 }
 export const getConsentState = () => {
-  return window.google_tag_data?.ics?.getConsentState?.('analytics_storage') === CONSENT_STATE_GRANTED_VALUE
-    ? CONSENT_STATES.granted
-    : CONSENT_STATES.denied
+  let consentValue = CONSENT_STATE_DENIED_VALUE
+
+  try {
+    consentValue = window.google_tag_data?.ics?.getConsentState?.('analytics_storage')
+  } catch (error) {
+    // Detected an issue getting the consent state when user rejects the consent
+    // due to a bug in Google Tag Manager
+    // After that first rejection the code works as expected
+    console.error('Error getting consent state', error)
+    consentValue = CONSENT_STATE_DENIED_VALUE
+  }
+
+  return consentValue === CONSENT_STATE_GRANTED_VALUE ? CONSENT_STATES.granted : CONSENT_STATES.denied
 }
 
 export const setGoogleUserId = userId => {

--- a/packages/sui-segment-wrapper/test/segmentWrapperSpec.js
+++ b/packages/sui-segment-wrapper/test/segmentWrapperSpec.js
@@ -890,7 +890,7 @@ describe('Segment Wrapper', function () {
       stubDocumentCookie(`${XANDR_ID_COOKIE}=${givenXandrId}`)
     })
 
-    it('should send analytics storage GRANTED if userr has accepted consent', async () => {
+    it('should send analytics storage GRANTED if user has accepted consent', async () => {
       await simulateUserAcceptConsents()
       window.google_tag_data = {
         ics: {
@@ -903,6 +903,23 @@ describe('Segment Wrapper', function () {
       const {context} = getDataFromLastTrack()
 
       expect(context.analytics_storage).to.equal('GRANTED')
+    })
+
+    it('should send analytics storage DENIED if fail to read it', async () => {
+      await simulateUserAcceptConsents()
+      window.google_tag_data = {
+        ics: {
+          getConsentState: () => {
+            throw new Error("ERROR: Couldn't read the consent state")
+          }
+        }
+      }
+
+      await suiAnalytics.track('fakeEvent')
+
+      const {context} = getDataFromLastTrack()
+
+      expect(context.analytics_storage).to.equal('DENIED')
     })
 
     it('should send the xandrId as externalId, that where stored in a cookie', async () => {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Due to an error when user rejects consents that we do not fully understand, we decided to catch any error and reject the analytics_storage for those cases in order to unblock the problem as a workaround


