### PR TITLE
Update URL to retrieve xandrId to specify consent

### DIFF
--- a/packages/sui-segment-wrapper/src/repositories/xandrRepository.js
+++ b/packages/sui-segment-wrapper/src/repositories/xandrRepository.js
@@ -2,7 +2,7 @@ import {readCookie, removeCookie, saveCookie} from '../utils/cookies.js'
 import {isClient, setConfig} from '../config.js'
 import {USER_GDPR} from '../tcf.js'
 
-const XANDR_ID_SERVER_URL = 'https://secure.adnxs.com/getuidj'
+const XANDR_ID_SERVER_URL = 'https://secure.adnxs.com/getuidj?consent=1'
 const XANDR_ID_COOKIE = 'adit-xandr-id'
 
 const USER_OPTED_OUT_XANDR_ID_VALUE = 0
@@ -36,7 +36,7 @@ export function getXandrId({gdprPrivacyValueAdvertising}) {
   return isValidXandrId ? storedXandrId : null
 }
 
-export function getRemoteXandrId() {
+function getRemoteXandrId() {
   if (!isClient) return Promise.resolve(null)
 
   return window

--- a/packages/sui-segment-wrapper/test/xandrRepositorySpec.js
+++ b/packages/sui-segment-wrapper/test/xandrRepositorySpec.js
@@ -6,7 +6,7 @@ import {stubDocumentCookie, stubFetch} from './stubs.js'
 import {waitUntil} from './utils.js'
 
 describe('xandrRepository', () => {
-  const XANDR_ID_SERVER_URL = 'https://secure.adnxs.com/getuidj'
+  const XANDR_ID_SERVER_URL = 'https://secure.adnxs.com/getuidj?consent=1'
   const XANDR_ID_COOKIE = 'adit-xandr-id'
 
   const givenXandrId = 'someXandrId'


### PR DESCRIPTION
## Description

Due to an undocumented requirement in the endpoint that retrieves the xandrId, and after opening a ticket with Xandr, we need to add '?consent=1' to the endpoint URL.

*before*
![Screenshot 2025-05-28 at 11 24 22](https://github.com/user-attachments/assets/c5a7f328-b153-4bc4-91bd-c0909fe744e5)

*after*
![image](https://github.com/user-attachments/assets/b3daa978-051b-4c7a-b0bf-c23c8cb1cc58)


## Related Issue
[XCOMP-14829](https://jira.ets.mpi-internal.com/browse/XCOMP-14829)

