### PR TITLE
feat(packages/sui-svg): add role presentation to decorative svgs

### DIFF
--- a/packages/sui-svg/templates/icon-component.js
+++ b/packages/sui-svg/templates/icon-component.js
@@ -3,7 +3,7 @@ const template = content => {
 import AtomIcon from '@s-ui/react-atom-icon'
 
 const injectAccessibility = ({id, svg, title}) => {
-  if (!title || !id) return svg.replace(/<svg([^>]*)>/, '<svg$1 aria-hidden="true">')
+  if (!title || !id) return svg.replace(/<svg([^>]*)>/, '<svg$1 aria-hidden="true" role="presentation">')
 
   return svg.replace(
     /<svg([^>]*)>/,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request adds role="presentation" to decorative svgs that already have aria-hidden="true" to improve accessibility compliance and ensure a consistent experience across assistive technologies.

While aria-hidden="true" removes an element and its children from the accessibility tree, effectively hiding it from screen readers, adding role="presentation" serves a complementary purpose:

aria-hidden="true": Completely hides the element and its descendants from assistive technologies.

role="presentation": Removes the semantic meaning of the element but still exposes its content to assistive technologies. This is particularly useful for elements that are purely decorative and do not convey meaningful information.

The SVG is hidden from screen readers (aria-hidden="true").

The SVG does not add any semantic meaning to the accessibility tree (role="presentation").
