### PR TITLE
feat(packages/sui-mockmock): allow to force server mocker usage

### DIFF
--- a/packages/sui-mockmock/src/http/index.js
+++ b/packages/sui-mockmock/src/http/index.js
@@ -2,5 +2,18 @@ import ClientMocker from './clientMocker'
 import ServerMocker from './serverMocker'
 
 const isNode = Object.prototype.toString.call(typeof process !== 'undefined' ? process : 0) === '[object process]'
+const useServerMocker = typeof process !== 'undefined' && process.env && process.env.FORCE_SERVER_MOCKER
 
-export default isNode ? ServerMocker : ClientMocker
+let Mocker
+
+if (useServerMocker === 'true') {
+  Mocker = ServerMocker
+} else if (useServerMocker === 'false') {
+  Mocker = ClientMocker
+} else if (isNode) {
+  Mocker = ServerMocker
+} else {
+  Mocker = ClientMocker
+}
+
+export default Mocker


### PR DESCRIPTION
We need to iterate this tool because in a Vitest environment, condition `isNode` will be always `true` since `jsdom` or `happy-dom` are just browser emulators running on Node.

Suggestion to make this tool work when running client-side tests:
* Run on Vitest:`FORCE_SERVER_MOCKER=true npm run my-tests` // server mocker will be used
* Run on Vitest:`FORCE_SERVER_MOCKER=false npm run my-tests` // client mocker will be used
* Run on Mocha:`npm run my-tests` // server mocker will be used (default behavior)
* Run on Karma:`npm run my-tests` // client mocker will be used (default behavior)