### PR TITLE
feat(packages/sui-segment-wrapper): add data layer name configuration

### DIFF
--- a/packages/sui-segment-wrapper/src/index.js
+++ b/packages/sui-segment-wrapper/src/index.js
@@ -6,7 +6,7 @@ import {defaultContextProperties} from './middlewares/source/defaultContextPrope
 import {pageReferrer} from './middlewares/source/pageReferrer.js'
 import {userScreenInfo} from './middlewares/source/userScreenInfo.js'
 import {userTraits} from './middlewares/source/userTraits.js'
-import {getCampaignDetails, loadGoogleAnalytics} from './repositories/googleRepository.js'
+import {getCampaignDetails, loadGoogleAnalytics, DEFAULT_DATA_LAYER_NAME} from './repositories/googleRepository.js'
 import {checkAnonymousId} from './utils/checkAnonymousId.js'
 import {getConfig, isClient} from './config.js'
 import analytics from './segmentWrapper.js'
@@ -41,15 +41,16 @@ const addMiddlewares = () => {
 if (isClient && window.analytics) {
   // Initialize Google Analtyics if needed
   const googleAnalyticsMeasurementId = getConfig('googleAnalyticsMeasurementId')
+  const dataLayerName = getConfig('googleAnalyticsDataLayer') || DEFAULT_DATA_LAYER_NAME
 
   if (googleAnalyticsMeasurementId) {
     const googleAnalyticsConfig = getConfig('googleAnalyticsConfig')
 
-    window.dataLayer = window.dataLayer || []
+    window[dataLayerName] = window[dataLayerName] || []
     window.gtag =
       window.gtag ||
       function gtag() {
-        window.dataLayer.push(arguments)
+        window[dataLayerName].push(arguments)
       }
 
     window.gtag('js', new Date())

--- a/packages/sui-segment-wrapper/src/repositories/googleRepository.js
+++ b/packages/sui-segment-wrapper/src/repositories/googleRepository.js
@@ -9,6 +9,8 @@ const FIELDS = {
   sessionId: 'session_id'
 }
 
+export const DEFAULT_DATA_LAYER_NAME = 'dataLayer'
+
 const CONSENT_STATES = {
   granted: 'GRANTED',
   denied: 'DENIED'
@@ -49,11 +51,12 @@ const loadScript = async src =>
 
 export const loadGoogleAnalytics = async () => {
   const googleAnalyticsMeasurementId = getConfig('googleAnalyticsMeasurementId')
+  const dataLayerName = getConfig('googleAnalyticsDataLayer') || DEFAULT_DATA_LAYER_NAME
 
   // Check we have the needed config to load the script
   if (!googleAnalyticsMeasurementId) return Promise.resolve(false)
   // Create the `gtag` script
-  const gtagScript = `https://www.googletagmanager.com/gtag/js?id=${googleAnalyticsMeasurementId}`
+  const gtagScript = `https://www.googletagmanager.com/gtag/js?id=${googleAnalyticsMeasurementId}&l=${dataLayerName}`
   // Load it and retrieve the `clientId` from Google
   return loadScript(gtagScript)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR enables a way of changing the default data layer name for google analytics

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
