### PR TITLE
test(packages/sui-segment-wrapper): Added tests for getCampaignDetais

### DIFF
--- a/packages/sui-segment-wrapper/package.json
+++ b/packages/sui-segment-wrapper/package.json
@@ -9,8 +9,8 @@
     "postlib": "npm run set:version",
     "prepublishOnly": "npm run umd && npm run lib",
     "set:version": "sed -i.bak \"s/process\\.env\\.VERSION/\\\"$npm_package_version\\\"/g\" lib/segmentWrapper.js && rm lib/segmentWrapper.js.bak",
-    "test:client:watch": "npm run test:client -- --watch",
-    "test:client": "sui-test browser --src-pattern=src/index.js -H",
+    "test:client:watch": "VERSION=0.0.0 npm run test:client -- --watch",
+    "test:client": "VERSION=0.0.0 sui-test browser --src-pattern=src/index.js -H",
     "test": "npm run test:client",
     "test:umd": "npm run umd && npx servor ./umd",
     "umd": "VERSION=$npm_package_version sui-bundler lib src-umd/index.js -o umd/ -p --root"

--- a/packages/sui-segment-wrapper/test/repositories/googleRepositorySpec.js
+++ b/packages/sui-segment-wrapper/test/repositories/googleRepositorySpec.js
@@ -1,0 +1,70 @@
+import {expect} from 'chai'
+
+import {getCampaignDetails} from '../../src/repositories/googleRepository.js'
+describe('GoogleRepository', () => {
+  function setupLocation(queryParams) {
+    const url = `/?${queryParams}`
+    window.history.pushState({}, '', url)
+  }
+
+  it('should get campaign details with all details from STC', async () => {
+    setupLocation('stc=em-source_type-campaign_name-content_type-term_type')
+
+    const details = await getCampaignDetails()
+
+    expect(details).to.not.be.null
+    expect(details.campaign).to.have.property('medium', 'email')
+    expect(details.campaign).to.have.property('name', 'campaign_name')
+    expect(details.campaign).to.have.property('source', 'source_type')
+    expect(details.campaign).to.have.property('content', 'content_type')
+    expect(details.campaign).to.have.property('term', 'term_type')
+  })
+
+  it('should get medium without transformation from STC', async () => {
+    setupLocation('stc=custom_medium-source_type-campaign_id:campaing_name-content_type')
+
+    const details = await getCampaignDetails({needsTransformation: false})
+
+    expect(details.campaign).to.have.property('medium', 'custom_medium')
+  })
+
+  it('should get campaign id from STC', async () => {
+    setupLocation('stc=em-source_type-campaign_id:campaing_name-content_type')
+
+    const details = await getCampaignDetails()
+
+    expect(details.campaign).to.have.property('name', 'campaing_name')
+  })
+
+  it('should not return content with invalid content type', async () => {
+    setupLocation('stc=em-source_type-campaign_name-na')
+
+    const details = await getCampaignDetails()
+
+    expect(details.campaign).to.not.have.property('content')
+  })
+
+  it('should return null when no STC param present', async () => {
+    setupLocation('')
+
+    const details = await getCampaignDetails()
+
+    expect(details).to.be.null
+  })
+
+  it('should return null when have no campaign in STC', async () => {
+    setupLocation('?stc=em-source_type')
+
+    const details = await getCampaignDetails()
+
+    expect(details).to.be.null
+  })
+
+  it('should return null when having invalid campaign name no campaign in STC', async () => {
+    setupLocation('?stc=em-source_type-:')
+
+    const details = await getCampaignDetails()
+
+    expect(details).to.be.null
+  })
+})


### PR DESCRIPTION
## Description

Added several tests for getCampaignDetais in segment-wrapper which I intend to improve soon, to ensure the funcionality remains working properly.

Also in order to fix test for segment-wrapper I added the Env variable "VERSION" to fix a the failing test: 

"sends an event with the actual context and traits when the consents are declined", which confusion the clientVersion from "segment-wrapper@0.0.0" getting "segment-wrapper@false"