### PR TITLE
feat(packages/sui-segment-wrapper): send always the ga4 init event

### DIFF
--- a/packages/sui-segment-wrapper/src/segmentWrapper.js
+++ b/packages/sui-segment-wrapper/src/segmentWrapper.js
@@ -57,14 +57,14 @@ const getTrackIntegrations = async ({gdprPrivacyValue, event}) => {
   let sessionId
   let clientId
 
-  if (isGdprAccepted) {
-    try {
-      ;[marketingCloudVisitorId, sessionId] = await Promise.all([getAdobeMCVisitorID(), getGoogleSessionId()])
-
-      clientId = await getGoogleClientId()
-    } catch (error) {
-      console.error(error)
+  try {
+    if (isGdprAccepted) {
+      marketingCloudVisitorId = await getAdobeMCVisitorID()
     }
+    sessionId = await getGoogleSessionId()
+    clientId = await getGoogleClientId()
+  } catch (error) {
+    console.error(error)
   }
 
   const restOfIntegrations = getRestOfIntegrations({isGdprAccepted, event})

--- a/packages/sui-segment-wrapper/test/segmentWrapperSpec.js
+++ b/packages/sui-segment-wrapper/test/segmentWrapperSpec.js
@@ -239,7 +239,7 @@ describe('Segment Wrapper', function () {
 
         expect(context.integrations).to.deep.includes({
           fakeIntegrationKey: 'fakeIntegrationValue',
-          'Google Analytics 4': true
+          'Google Analytics 4': {clientId: 'fakeClientId', sessionId: 'fakeSessionId'}
         })
       })
 


### PR DESCRIPTION
* Avoid GDPR restriction when sending GA4 the init event (by default `sui` event).