### PR TITLE
feat(packages/sui-compiler-config): preserve webpack magic comments in TS compilation

### DIFF
--- a/packages/sui-bundler/shared/module-rules-compiler.js
+++ b/packages/sui-bundler/shared/module-rules-compiler.js
@@ -36,7 +36,7 @@ module.exports = ({isServer = false, isDevelopment = false, supportLegacyBrowser
         use: [
           {
             loader: require.resolve('swc-loader'),
-            options: getSWCConfig({isModern: false, isTypeScript: true, minify: false})
+            options: getSWCConfig({isModern: false, isTypeScript: true, preserveComments: true})
           }
         ]
       }

--- a/packages/sui-bundler/shared/module-rules-compiler.js
+++ b/packages/sui-bundler/shared/module-rules-compiler.js
@@ -36,7 +36,7 @@ module.exports = ({isServer = false, isDevelopment = false, supportLegacyBrowser
         use: [
           {
             loader: require.resolve('swc-loader'),
-            options: getSWCConfig({isModern: false, isTypeScript: true})
+            options: getSWCConfig({isModern: false, isTypeScript: true, minify: false})
           }
         ]
       }

--- a/packages/sui-compiler-config/src/index.js
+++ b/packages/sui-compiler-config/src/index.js
@@ -10,13 +10,13 @@ const DEFAULT_BROWSER_TARGETS = {
   ios: '14.5'
 }
 
-const getSWCConfig = ({isModern = false, isTypeScript = false, compileToCJS = false}) => {
+const getSWCConfig = ({isModern = false, isTypeScript = false, compileToCJS = false, minify = false}) => {
   const targets = isModern ? DEFAULT_BROWSER_TARGETS : DEFAULT_LEGACY_BROWSER_TARGETS
   const syntaxOptions = isTypeScript ? {syntax: 'typescript', tsx: true} : {syntax: 'ecmascript', jsx: true}
   const moduleOptions = compileToCJS ? {module: {type: 'commonjs'}} : {}
 
   return {
-    minify: true,
+    minify,
     jsc: {
       parser: {
         ...syntaxOptions,

--- a/packages/sui-compiler-config/src/index.js
+++ b/packages/sui-compiler-config/src/index.js
@@ -10,13 +10,13 @@ const DEFAULT_BROWSER_TARGETS = {
   ios: '14.5'
 }
 
-const getSWCConfig = ({isModern = false, isTypeScript = false, compileToCJS = false, minify = false}) => {
+const getSWCConfig = ({isModern = false, isTypeScript = false, compileToCJS = false, preserveComments = false}) => {
   const targets = isModern ? DEFAULT_BROWSER_TARGETS : DEFAULT_LEGACY_BROWSER_TARGETS
   const syntaxOptions = isTypeScript ? {syntax: 'typescript', tsx: true} : {syntax: 'ecmascript', jsx: true}
   const moduleOptions = compileToCJS ? {module: {type: 'commonjs'}} : {}
+  const minifyOptions = preserveComments ? {minify: {format: {comments: 'all'}}} : {}
 
   return {
-    minify,
     jsc: {
       parser: {
         ...syntaxOptions,
@@ -37,6 +37,7 @@ const getSWCConfig = ({isModern = false, isTypeScript = false, compileToCJS = fa
           runtime: 'automatic'
         }
       },
+      ...minifyOptions,
       loose: true,
       externalHelpers: true
     },


### PR DESCRIPTION
## Description

SWC's `minify: true` was hardcoded in `getSWCConfig`, causing it to run minification
inside webpack's `swc-loader` **before** webpack processes magic comments like
`/* webpackChunkName: "..." */`. This strips the comments, resulting in unnamed chunks
and broken CSS loading in SSR.

## Changes

Two small, focused changes:

1. **`sui-compiler-config/src/index.js`** — Removed the hardcoded `minify: true` from `getSWCConfig()` and added a new `preserveComments` option. When `true`, it outputs `minify: { format: { comments: 'all' } }` to instruct SWC to keep all comments (including webpack magic comments).

2. **`sui-bundler/shared/module-rules-compiler.js`** — The TypeScript SWC rule now passes `preserveComments: true` so that webpack magic comments survive the loader phase.

## Before / After

```js
// packages/sui-compiler-config/src/index.js — before
const getSWCConfig = ({isModern, isTypeScript, compileToCJS}) => {
  return { minify: true, jsc: { ... } }
}

// packages/sui-compiler-config/src/index.js — after
const getSWCConfig = ({isModern, isTypeScript, compileToCJS, preserveComments = false}) => {
  const minifyOptions = preserveComments ? {minify: {format: {comments: 'all'}}} : {}
  return { jsc: { ..., ...minifyOptions, ... } }
}

// packages/sui-bundler/shared/module-rules-compiler.js — before
options: getSWCConfig({isModern: false, isTypeScript: true})

// packages/sui-bundler/shared/module-rules-compiler.js — after
options: getSWCConfig({isModern: false, isTypeScript: true, preserveComments: true})
```

### Context

Fotocasa wants to implement TypeScript in their project and the removal of magic comments causes that chunking does not work properly for CSS, producing flickering in dev and broken production bundles.

## Impact analysis

- The hardcoded `minify: true` has been removed. This is safe because production minification is handled independently by TerserPlugin/esbuild in a later webpack phase (`sui-bundler/shared/minify-js.js`).
- Only the TypeScript compilation path in `sui-bundler` passes `preserveComments: true`. Other callers (`sui-js-compiler`, `sui-test`) are unaffected — they get the same behaviour as before minus the redundant SWC-level minification.
- The change is **2 files, +4 / -3 lines**.
