### PR TITLE
feat(packages/sui-mono): resolve git lock errors in commit-all when running from worktrees

### DIFF
--- a/packages/sui-mono/bin/sui-mono-commit-all.js
+++ b/packages/sui-mono/bin/sui-mono-commit-all.js
@@ -37,12 +37,12 @@ const {message, type} = program.opts()
  * @param  {String}  path Folder to check
  * @return {Promise<Boolean>}
  */
-const hasChangedFiles = async path => {
+const hasChangedFiles = async (pkgPath, repoRoot) => {
   let stdout = ''
 
   try {
-    await exec(`git add .`, {cwd: path})
-    const status = await exec(`git status ${path} --porcelain`)
+    await exec(`git add ${pkgPath}`, {cwd: repoRoot})
+    const status = await exec(`git status ${pkgPath} --porcelain`, {cwd: repoRoot})
     stdout = status.stdout || ''
   } catch (error) {
     console.error(error)
@@ -57,22 +57,26 @@ const hasChangedFiles = async path => {
  */
 let commitsCount = 0
 
-/**
- * Functions that executes the commit for each package
- * @type {Array<Function>}
- */
-const checkStageFuncs = getWorkspaces().map(pkg => {
-  return () =>
-    hasChangedFiles(pkg).then(hasChanges => {
-      if (hasChanges) {
-        const packageName = pkg === '.' ? 'Root' : pkg
-        const args = ['commit', `-m "${type}(${packageName}): ${message}"`]
-        commitsCount++ && args.push('--no-verify') // precommit only once
-        return getSpawnPromise('git', args)
-      }
+exec('git rev-parse --show-toplevel')
+  .then(({stdout}) => {
+    const repoRoot = stdout.trim()
+    /**
+     * Functions that executes the commit for each package
+     * @type {Array<Function>}
+     */
+    const checkStageFuncs = getWorkspaces().map(pkg => {
+      return () =>
+        hasChangedFiles(pkg, repoRoot).then(hasChanges => {
+          if (hasChanges) {
+            const packageName = pkg === '.' ? 'Root' : pkg
+            const args = ['commit', `-m "${type}(${packageName}): ${message}"`]
+            commitsCount++ && args.push('--no-verify') // precommit only once
+            return getSpawnPromise('git', args, {cwd: repoRoot})
+          }
+        })
     })
-})
 
-getSpawnPromise('git', ['reset']) // Unstage all prossible staged files
-  .then(() => checkStageFuncs.reduce((promise, func) => promise.then(func), Promise.resolve()))
+    return getSpawnPromise('git', ['reset'], {cwd: repoRoot}) // Unstage all possible staged files
+      .then(() => checkStageFuncs.reduce((promise, func) => promise.then(func), Promise.resolve()))
+  })
   .catch(showError)


### PR DESCRIPTION
## Description

  `sui-mono commit-all` fails with `index.lock` errors when executed from a `git worktree`. The root cause is that git commands within the script use inconsistent working directories — `git add` runs with `cwd` set to the package subdirectory (relative path), while `git status`, `git commit`, and `git reset` inherit `process.cwd()` with no explicit `cwd`. In worktrees, this inconsistency causes git to fail when acquiring the index lock.

  The fix resolves the repository root once at startup via `git rev-parse --show-toplevel` and passes it as an explicit `cwd` to all git commands, ensuring they all operate on the same git index. This works correctly in both regular repos and worktrees.

  ## Related Issue

  N/A

## Example


  #### Before (fails in worktrees):
```bash
  git worktree add ../my-feature -b my-feature
  cd ../my-feature
  sui-mono commit-all -t fix -m "some change"
  # => 
  cmd: 'git add .',
  stdout: '',
  stderr: "fatal: Unable to create '/Users/pablo.rey/workspace/code/adevinta-realestate/frontend-fc--web-server/.git/worktrees/tripoli/index.lock': File exists.\n" +
    '\n' +
    'Another git process seems to be running in this repository, e.g.\n' +
    "an editor opened by 'git commit'. Please make sure all processes\n" +
    'are terminated then try again. If it still fails, a git process\n' +
    'may have crashed in this repository earlier:\n' +
    'remove the file manually to continue.\n'
```

#### After (works in both regular repos and worktrees):
```
sui-mono commit-all -t fix -m "some change"
# => commits created successfully
```