### PR TITLE
fix(sui-domain): upgrade axios 1.12.2 → 1.15.1 to fix security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6037,6 +6037,7 @@
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
       "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -11415,15 +11416,16 @@
       "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -11482,9 +11484,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -19043,7 +19045,8 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "node_modules/psl": {
       "version": "1.15.0",
@@ -24590,10 +24593,30 @@
       "version": "2.21.0",
       "license": "MIT",
       "dependencies": {
-        "axios": "1.12.2"
+        "axios": "1.15.1"
       },
       "devDependencies": {
         "@s-ui/js-compiler": "1"
+      }
+    },
+    "packages/sui-domain/node_modules/axios": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "packages/sui-domain/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "packages/sui-helpers": {
@@ -25578,7 +25601,7 @@
     },
     "packages/sui-react-web-vitals": {
       "name": "@s-ui/react-web-vitals",
-      "version": "2.9.0",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "@s-ui/react-hooks": "1",

--- a/packages/sui-domain/package.json
+++ b/packages/sui-domain/package.json
@@ -20,6 +20,6 @@
     "@s-ui/js-compiler": "1"
   },
   "dependencies": {
-    "axios": "1.12.2"
+    "axios": "1.15.1"
   }
 }


### PR DESCRIPTION
## Description

Upgrades `axios` from `1.12.2` to `1.15.1` in `@s-ui/domain` to resolve three high-severity security vulnerabilities:

- **[GHSA-43fc-jf86-j433](https://github.com/advisories/GHSA-43fc-jf86-j433)** (High): Denial of Service via `__proto__` key in `mergeConfig`
- **[GHSA-3p68-rc4w-qgx5](https://github.com/advisories/GHSA-3p68-rc4w-qgx5)** (High): `NO_PROXY` hostname normalization bypass leading to SSRF
- **[GHSA-fvcv-3m26-pcqx](https://github.com/advisories/GHSA-fvcv-3m26-pcqx)** (High): Unrestricted cloud metadata exfiltration via header injection chain

The upgrade is low-risk: `@s-ui/domain` only uses `axios.create(config)` and the five basic HTTP instance methods (`.get`, `.post`, `.put`, `.patch`, `.delete`). No interceptors, adapters, or deprecated APIs are in use.

## Related Issue

Resolves axios CVEs: GHSA-43fc-jf86-j433, GHSA-3p68-rc4w-qgx5, GHSA-fvcv-3m26-pcqx

## Example

Before:
```
axios  1.0.0 - 1.14.0
Severity: high — 3 vulnerabilities
```

After:
```
npm audit → found 0 vulnerabilities (axios-related)
```