### PR TITLE
Feat modify sui mono no interactive

### DIFF
--- a/packages/sui-mono/bin/sui-mono-commit.js
+++ b/packages/sui-mono/bin/sui-mono-commit.js
@@ -1,8 +1,24 @@
 /* eslint no-console:0 */
 const {promisify} = require('util')
 const exec = promisify(require('child_process').exec)
+const {Command} = require('commander')
 
 const startMainCommitFlow = require('../src/prompter-manager.js')
+const {executeCommit} = startMainCommitFlow
+
+const program = new Command()
+program
+  .option('--no-interactive', 'Skip interactive prompts, requires --type, --scope, --subject')
+  .option('-t, --type <type>', 'Commit type (feat, fix, docs, refactor, perf, test, chore, release)')
+  .option('-s, --scope <scope>', 'Commit scope (package name or Root)')
+  .option('-m, --subject <subject>', 'Commit subject (short description)')
+  .option('-b, --body <body>', 'Commit body (optional, use | for newlines)')
+  .option('--breaking <breaking>', 'Breaking changes description (optional)')
+  .option('--footer <footer>', 'Issues closed (optional, e.g. #31, #34)')
+  .allowUnknownOption()
+  .parse(process.argv)
+
+const opts = program.opts()
 
 /**
  * Get the list of modified files by the user
@@ -32,6 +48,17 @@ async function initCommit() {
       console.log('Showing the files that you could add:')
       console.log(modified.files)
     }
+    return
+  }
+
+  if (opts.interactive === false) {
+    const {type, scope, subject, body, breaking, footer} = opts
+    if (!type || !scope || !subject) {
+      console.error('Error: --type, --scope, and --subject are required in non-interactive mode')
+      process.exit(1)
+    }
+    const extraArgs = program.args.join(' ')
+    await executeCommit({type, scope, subject, body, breaking, footer}, extraArgs)
     return
   }
 

--- a/packages/sui-mono/src/prompter-manager.js
+++ b/packages/sui-mono/src/prompter-manager.js
@@ -83,6 +83,17 @@ const checkIfHasChangedFiles = async path => {
   return stdout.trim() !== ''
 }
 
+async function executeCommit(answers, extraArgs = '') {
+  const commitMsg = buildCommit(answers)
+  const commitParams = commitMsg
+    .split('\n')
+    .filter(Boolean)
+    .map(msg => `-m "${msg}"`)
+    .join(' ')
+
+  await exec(`git commit ${commitParams} ${extraArgs}`, {cwd: process.cwd()})
+}
+
 module.exports = async function startMainCommitFlow() {
   const scopesWithChanges = await Promise.all(
     scopes.map(pkg => checkIfHasChangedFiles(pkg.name).then(hasFiles => hasFiles && pkg))
@@ -93,17 +104,11 @@ module.exports = async function startMainCommitFlow() {
   })
 
   if (answers && answers.confirmCommit === true) {
-    const commitMsg = buildCommit(answers)
-    const commitParams = commitMsg
-      .split('\n') // separate each new line to
-      .filter(Boolean) // filter empty strings
-      .map(msg => `-m "${msg}"`)
-      .join(' ')
-
     const commitArgs = process.argv.slice(2).join(' ')
-
-    await exec(`git commit ${commitParams} ${commitArgs}`, {cwd: process.cwd()})
+    await executeCommit(answers, commitArgs)
   } else {
     console.log(colors.red('Commit has been canceled.'))
   }
 }
+
+module.exports.executeCommit = executeCommit

--- a/packages/sui-mono/test/server/commitSpec.js
+++ b/packages/sui-mono/test/server/commitSpec.js
@@ -1,0 +1,106 @@
+import {expect} from 'chai'
+
+import buildCommit from '../../src/build-commit.js'
+
+describe('build-commit', () => {
+  it('builds a basic commit message', () => {
+    const msg = buildCommit({type: 'feat', scope: 'Root', subject: 'add feature'})
+    expect(msg).to.equal('feat(Root): add feature')
+  })
+
+  it('lowercases the first letter of subject', () => {
+    // buildCommit itself does not lowercase — that is done by the enquirer filter.
+    // In non-interactive mode the subject is passed as-is, so this test confirms
+    // the raw output.
+    const msg = buildCommit({type: 'fix', scope: 'Root', subject: 'Fix bug'})
+    expect(msg).to.equal('fix(Root): Fix bug')
+  })
+
+  it('appends body when provided', () => {
+    const msg = buildCommit({type: 'feat', scope: 'Root', subject: 'add feature', body: 'details'})
+    expect(msg).to.include('\n\ndetails')
+  })
+
+  it('replaces | with newlines in body', () => {
+    const msg = buildCommit({
+      type: 'feat',
+      scope: 'Root',
+      subject: 'add feature',
+      body: 'line1|line2'
+    })
+    expect(msg).to.include('line1\nline2')
+  })
+
+  it('appends breaking changes section when provided', () => {
+    const msg = buildCommit({
+      type: 'feat',
+      scope: 'Root',
+      subject: 'new api',
+      breaking: 'old api removed'
+    })
+    expect(msg).to.include('BREAKING CHANGES: \nold api removed')
+  })
+
+  it('appends issues closed section when footer provided', () => {
+    const msg = buildCommit({type: 'fix', scope: 'Root', subject: 'fix', footer: '#42'})
+    expect(msg).to.include('ISSUES CLOSED: #42')
+  })
+
+  it('omits breaking changes section when breaking is empty', () => {
+    const msg = buildCommit({type: 'feat', scope: 'Root', subject: 'add feature', breaking: ''})
+    expect(msg).to.not.include('BREAKING CHANGES')
+  })
+
+  it('omits issues closed section when footer is empty', () => {
+    const msg = buildCommit({type: 'feat', scope: 'Root', subject: 'add feature', footer: ''})
+    expect(msg).to.not.include('ISSUES CLOSED')
+  })
+
+  it('builds the -m params string used by executeCommit', () => {
+    const msg = buildCommit({
+      type: 'feat',
+      scope: 'packages/sui-mono',
+      subject: 'add non-interactive mode',
+      body: 'useful for scripting'
+    })
+    const commitParams = msg
+      .split('\n')
+      .filter(Boolean)
+      .map(m => `-m "${m}"`)
+      .join(' ')
+
+    expect(commitParams).to.include('-m "feat(packages/sui-mono): add non-interactive mode"')
+    expect(commitParams).to.include('-m "useful for scripting"')
+  })
+})
+
+describe('non-interactive CLI validation', () => {
+  // Mirrors the validation logic in bin/sui-mono-commit.js initCommit()
+  const REQUIRED = ['type', 'scope', 'subject']
+
+  const validate = opts => REQUIRED.filter(f => !opts[f])
+
+  it('passes when type, scope and subject are all provided', () => {
+    expect(validate({type: 'feat', scope: 'Root', subject: 'test'})).to.deep.equal([])
+  })
+
+  it('fails when type is missing', () => {
+    expect(validate({scope: 'Root', subject: 'test'})).to.include('type')
+  })
+
+  it('fails when scope is missing', () => {
+    expect(validate({type: 'feat', subject: 'test'})).to.include('scope')
+  })
+
+  it('fails when subject is missing', () => {
+    expect(validate({type: 'feat', scope: 'Root'})).to.include('subject')
+  })
+
+  it('fails with all three when nothing is provided', () => {
+    expect(validate({})).to.deep.equal(['type', 'scope', 'subject'])
+  })
+
+  it('body, breaking and footer are optional — no validation error', () => {
+    expect(validate({type: 'chore', scope: 'Root', subject: 'update'})).to.have.length(0)
+  })
+})


### PR DESCRIPTION
SUI Mono

## Description
  ---
  Title: feat(packages/sui-mono): add non-interactive mode to sui-mono commit

  ---
  Feature Description

  Add a --no-interactive flag to sui-mono commit that allows passing all
  commit parameters via CLI arguments, enabling programmatic use from scripts,
   skills, and CI pipelines.

  Motivation

  sui-mono commit was fully interactive via enquirer, making it impossible to
  use programmatically. Skills like /sui-commit and automated workflows need
  to create semantic commits without user prompts.

  Implementation Details

  - Added commander CLI parsing to bin/sui-mono-commit.js with flags:
  --no-interactive, -t/--type, -s/--scope, -m/--subject, -b/--body,
  --breaking, --footer
  - Extracted commit execution logic into a standalone executeCommit(answers,
  extraArgs) function in src/prompter-manager.js and exported it as a named
  export
  - When --no-interactive is set, validates required fields (type, scope,
  subject) and calls executeCommit directly, bypassing the enquirer flow
  - Interactive mode is unchanged

  Usage

  # Non-interactive
  ```
  sui-mono commit --no-interactive \
    --type feat \
    --scope packages/sui-mono \
    --subject "add new feature" \
    --body "optional longer description" \
    --breaking "optional breaking change" \
    --footer "#123"
  ```

  Testing

  - Unit tests added — build-commit pure function and non-interactive CLI
  validation
  - Manual testing completed
  - Interactive mode regression tested

  Breaking Changes

  None — interactive mode is fully preserved.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
