### PR TITLE
fix(deps): update axios to 1.16.0 to fix security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6842,12 +6842,12 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
-      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -27088,7 +27088,7 @@
       "version": "2.22.0",
       "license": "MIT",
       "dependencies": {
-        "axios": "1.15.1"
+        "axios": "1.16.0"
       },
       "devDependencies": {
         "@s-ui/js-compiler": "1"
@@ -27762,27 +27762,8 @@
         "sinon": "10.0.0"
       },
       "devDependencies": {
-        "axios": "1.12.2"
+        "axios": "1.16.0"
       }
-    },
-    "packages/sui-mockmock/node_modules/axios": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
-      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "packages/sui-mockmock/node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true,
-      "license": "MIT"
     },
     "packages/sui-mono": {
       "name": "@s-ui/mono",
@@ -28121,7 +28102,7 @@
     },
     "packages/sui-segment-wrapper": {
       "name": "@s-ui/segment-wrapper",
-      "version": "4.41.0",
+      "version": "4.42.0",
       "license": "ISC",
       "dependencies": {
         "@s-ui/js": "2",
@@ -28281,7 +28262,7 @@
     },
     "packages/sui-svg": {
       "name": "@s-ui/svg",
-      "version": "3.28.0",
+      "version": "3.29.0",
       "license": "MIT",
       "dependencies": {
         "@s-ui/react-atom-icon": "1",

--- a/packages/sui-domain/package.json
+++ b/packages/sui-domain/package.json
@@ -20,6 +20,6 @@
     "@s-ui/js-compiler": "1"
   },
   "dependencies": {
-    "axios": "1.15.1"
+    "axios": "1.16.0"
   }
 }

--- a/packages/sui-mockmock/package.json
+++ b/packages/sui-mockmock/package.json
@@ -22,7 +22,7 @@
     "sinon": "10.0.0"
   },
   "devDependencies": {
-    "axios": "1.12.2"
+    "axios": "1.16.0"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Description
Update `axios` dependency to the latest stable version `1.16.0` (from `1.15.1` in `sui-domain` and `1.12.2` in `sui-mockmock`) to address security vulnerabilities.

## Related Issue
<!-- No specific issue, proactive security update -->

## Example
<!-- No behavior change, dependency version bump only -->