### PR TITLE
feat(packages/sui-mono): add --skip-checks flag to release command

### DIFF
--- a/packages/sui-mono/README.md
+++ b/packages/sui-mono/README.md
@@ -172,6 +172,24 @@ If you want the `package-lock.json` to be committed once the packages are releas
 sui-mono release --lock
 ```
 
+To append `[skip ci]` to release commit messages (skips CI pipeline for the release commits):
+
+```sh
+sui-mono release --skip-ci
+```
+
+To append a `skip-checks: true` trailer to release commit messages (skips GitHub branch protection check runs):
+
+```sh
+sui-mono release --skip-checks
+```
+
+Both flags can be combined:
+
+```sh
+sui-mono release --skip-ci --skip-checks
+```
+
 ## How to configure your project
 
 First you need to install the `@s-ui/mono` package in your project

--- a/packages/sui-mono/bin/sui-mono-release.js
+++ b/packages/sui-mono/bin/sui-mono-release.js
@@ -17,6 +17,7 @@ program
   .option('-E, --github-email <email>', 'github email')
   .option('-L, --lock', 'Commit lock file', false)
   .option('--skip-ci', 'Add [skip ci] to release commit message', false)
+  .option('--skip-checks', 'Add skip-checks: true trailer to release commit message', false)
   .on('--help', () => {
     console.log('  Description:')
     console.log('')
@@ -39,7 +40,7 @@ program
   })
   .parse(process.argv)
 
-const {scope: packageScope, githubEmail, githubToken, githubUser, lock, skipCi} = program.opts()
+const {scope: packageScope, githubEmail, githubToken, githubUser, lock, skipCi, skipChecks} = program.opts()
 
 const BASE_DIR = process.cwd()
 
@@ -69,7 +70,7 @@ const getCwd = ({pkg}) => {
   return isMonoPackage ? BASE_DIR : path.join(process.cwd(), pkg)
 }
 
-const commit = async ({pkg, code, skipCi}) => {
+const commit = async ({pkg, code, skipCi, skipChecks}) => {
   const isMonoPackage = checkIsMonoPackage()
   const cwd = getCwd({pkg})
 
@@ -84,8 +85,10 @@ const commit = async ({pkg, code, skipCi}) => {
   // Add [skip ci] to the commit message to avoid CI build
   // https://docs.travis-ci.com/user/customizing-the-build/#skipping-a-build
   const skipCiSuffix = skipCi ? ' [skip ci]' : ''
-  const commitMsg = `release(${packageScope}): v${version}${skipCiSuffix}`
-  await exec(`git commit -m "${commitMsg}"`, {cwd})
+  const skipChecksSuffix = skipChecks ? '\n\n\nskip-checks: true' : ''
+  const commitMsg = `release(${packageScope}): v${version}${skipCiSuffix}${skipChecksSuffix}`
+  const cleanupFlag = skipChecks ? ' --cleanup=verbatim' : ''
+  await exec(`git commit -m "${commitMsg}"${cleanupFlag}`, {cwd})
 
   await exec(`${suiMonoBinPath} changelog ${cwd}`)
   await exec(`git add ${path.join(cwd, changelogFilename)}`, {cwd})
@@ -163,7 +166,7 @@ checkShouldRelease()
       const packagesToRelease = releasesByPackages({status}).filter(({code}) => code !== 0)
 
       for (const pkg of packagesToRelease) {
-        await commit({...pkg, skipCi})
+        await commit({...pkg, skipCi, skipChecks})
       }
 
       if (packagesToRelease.length > 0) {


### PR DESCRIPTION
## Description

Adds a new `--skip-checks` flag to `sui-mono release` that appends a `skip-checks: true` trailer to release commit messages. This allows skipping GitHub branch protection check runs for individual release commits.

Also documents the existing (previously undocumented) `--skip-ci` flag in the README.

See: https://docs.github.com/es/enterprise-server@3.19/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks#skipping-and-requesting-checks-for-individual-commits

## Related Issue

N/A

## Example

```sh
# Skip GitHub check runs for release commits
sui-mono release --skip-checks

# Can be combined with --skip-ci
sui-mono release --skip-ci --skip-checks

# Full CI usage
npx @s-ui/mono release --github-user $GITHUB_USER --github-email $GITHUB_EMAIL --github-token $GITHUB_TOKEN --lock --skip-checks
```