### PR TITLE
feat(sui-bundler): add plainCssPackages config to bypass sass-loader

### DIFF
--- a/packages/sui-bundler/README.md
+++ b/packages/sui-bundler/README.md
@@ -184,6 +184,10 @@ This tool works with zero configuration out the box but you could use some confi
 
 `disableTypeScriptLoader`: Flag to determine if typescript loader should be used. (default: `false`)
 
+`plainCssPackages`: Array of npm package names whose `.css` files should bypass `@s-ui/sass-loader` and `postcss-loader`. Use this for packages that ship pre-compiled CSS (e.g. Tailwind CSS v4 output) that would cause Sass parse errors. (default: `[]`)
+
+`cssInAppStyles`: Array of npm package names whose CSS modules should be forced into the `AppStyles` chunk. This prevents webpack's `splitChunks` from extracting them into separate async chunks that `@s-ui/ssr` doesn't know about — avoiding Flash of Unstyled Content. (default: `[]`)
+
 ```json
 {
   "config": {
@@ -202,6 +206,8 @@ This tool works with zero configuration out the box but you could use some confi
         "dev": "cheap-module-eval-source-map",
         "prod": "hidden-source-map"
       },
+      "plainCssPackages": ["@adv-mt/ui", "@adv-mt/theme"],
+      "cssInAppStyles": ["@adv-mt/ui", "@adv-mt/theme"],
       "disableTypeScriptLoader": true // Only if you want to disable typescript loader
     }
   }

--- a/packages/sui-bundler/shared/module-rules-sass.js
+++ b/packages/sui-bundler/shared/module-rules-sass.js
@@ -2,8 +2,17 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 
 const {cleanList, config, when, isTailwindEnabled} = require('./index')
 
-module.exports = {
+const plainCssPackages = config.plainCssPackages || []
+
+const plainCssExclude = plainCssPackages.length
+  ? new RegExp(
+      `node_modules[\\\\/](${plainCssPackages.map(p => p.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})[\\\\/]`
+    )
+  : null
+
+const sassRule = {
   test: /(\.css|\.scss)$/,
+  ...(plainCssExclude ? {exclude: plainCssExclude} : {}),
   use: cleanList([
     MiniCssExtractPlugin.loader,
     require.resolve('css-loader'),
@@ -29,3 +38,13 @@ module.exports = {
     require.resolve('@s-ui/sass-loader')
   ])
 }
+
+const plainCssRule = plainCssExclude
+  ? {
+      test: /\.css$/,
+      include: plainCssExclude,
+      use: [MiniCssExtractPlugin.loader, require.resolve('css-loader')]
+    }
+  : null
+
+module.exports = plainCssRule ? [sassRule, plainCssRule] : sassRule

--- a/packages/sui-bundler/shared/plain-css-split-chunks.js
+++ b/packages/sui-bundler/shared/plain-css-split-chunks.js
@@ -1,0 +1,25 @@
+const {config} = require('./index')
+
+const cssInAppStyles = config.cssInAppStyles || []
+
+exports.plainCssSplitChunks = () => {
+  if (!cssInAppStyles.length) return {}
+
+  const testRegex = new RegExp(
+    `[\\\\/]node_modules[\\\\/](${cssInAppStyles.map(p => p.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})[\\\\/]`
+  )
+
+  return {
+    splitChunks: {
+      cacheGroups: {
+        plainCssInEntry: {
+          type: 'css/mini-extract',
+          test: testRegex,
+          name: 'AppStyles',
+          chunks: 'all',
+          enforce: true
+        }
+      }
+    }
+  }
+}

--- a/packages/sui-bundler/shared/plain-css-split-chunks.js
+++ b/packages/sui-bundler/shared/plain-css-split-chunks.js
@@ -5,21 +5,45 @@ const cssInAppStyles = config.cssInAppStyles || []
 exports.plainCssSplitChunks = () => {
   if (!cssInAppStyles.length) return {}
 
-  const testRegex = new RegExp(
-    `[\\\\/]node_modules[\\\\/](${cssInAppStyles.map(p => p.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})[\\\\/]`
-  )
-
   return {
-    splitChunks: {
-      cacheGroups: {
-        plainCssInEntry: {
-          type: 'css/mini-extract',
-          test: testRegex,
-          name: 'AppStyles',
-          chunks: 'all',
-          enforce: true
+    plugins: [
+      {
+        apply(compiler) {
+          const pkgPattern = cssInAppStyles.map(p => p.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')
+          const pkgRegex = new RegExp(`[\\\\/]node_modules[\\\\/](${pkgPattern})[\\\\/]`)
+
+          compiler.hooks.thisCompilation.tap('CssInAppStyles', compilation => {
+            compilation.hooks.afterOptimizeChunks.tap('CssInAppStyles', chunks => {
+              let appStylesChunk = null
+              for (const chunk of chunks) {
+                if (chunk.name === 'AppStyles') {
+                  appStylesChunk = chunk
+                  break
+                }
+              }
+              if (!appStylesChunk) return
+
+              for (const chunk of chunks) {
+                if (chunk === appStylesChunk) continue
+                const modulesToMove = []
+                for (const module of compilation.chunkGraph.getChunkModulesIterable(chunk)) {
+                  if (module.type !== 'css/mini-extract') continue
+                  const name = module.nameForCondition && module.nameForCondition()
+                  if (name && pkgRegex.test(name)) {
+                    modulesToMove.push(module)
+                  }
+                }
+                for (const module of modulesToMove) {
+                  compilation.chunkGraph.disconnectChunkAndModule(chunk, module)
+                  if (!compilation.chunkGraph.isModuleInChunk(module, appStylesChunk)) {
+                    compilation.chunkGraph.connectChunkAndModule(appStylesChunk, module)
+                  }
+                }
+              }
+            })
+          })
         }
       }
-    }
+    ]
   }
 }

--- a/packages/sui-bundler/test/server/plainCssSplitChunksSpec.js
+++ b/packages/sui-bundler/test/server/plainCssSplitChunksSpec.js
@@ -1,0 +1,74 @@
+const {expect} = require('chai')
+const path = require('path')
+
+const CONFIG_PATH = require.resolve('../../shared/config.js')
+const INDEX_PATH = require.resolve('../../shared/index.js')
+const MODULE_PATH = require.resolve('../../shared/plain-css-split-chunks.js')
+
+function loadWithConfig(cssInAppStyles = []) {
+  delete require.cache[CONFIG_PATH]
+  delete require.cache[INDEX_PATH]
+  delete require.cache[MODULE_PATH]
+
+  require.cache[CONFIG_PATH] = {
+    id: CONFIG_PATH,
+    filename: CONFIG_PATH,
+    loaded: true,
+    exports: {
+      config: {cssInAppStyles},
+      extractComments: false,
+      sourceMap: false,
+      supportLegacyBrowsers: true,
+      cacheDirectory: path.resolve(process.cwd(), '.sui/cache')
+    }
+  }
+
+  return require('../../shared/plain-css-split-chunks.js')
+}
+
+describe('plainCssSplitChunks', () => {
+  afterEach(() => {
+    delete require.cache[CONFIG_PATH]
+    delete require.cache[INDEX_PATH]
+    delete require.cache[MODULE_PATH]
+  })
+
+  it('returns empty object when cssInAppStyles is not configured', () => {
+    const {plainCssSplitChunks} = loadWithConfig([])
+    expect(plainCssSplitChunks()).to.deep.equal({})
+  })
+
+  it('returns plugins array with one plugin when cssInAppStyles has packages', () => {
+    const {plainCssSplitChunks} = loadWithConfig(['@adv-mt/ui', '@adv-mt/theme'])
+    const result = plainCssSplitChunks()
+
+    expect(result).to.have.property('plugins')
+    expect(result.plugins).to.be.an('array').with.lengthOf(1)
+  })
+
+  it('plugin has an apply method', () => {
+    const {plainCssSplitChunks} = loadWithConfig(['@adv-mt/ui'])
+    const result = plainCssSplitChunks()
+
+    expect(result.plugins[0]).to.have.property('apply')
+    expect(result.plugins[0].apply).to.be.a('function')
+  })
+
+  it('plugin taps into thisCompilation hook', () => {
+    const {plainCssSplitChunks} = loadWithConfig(['@adv-mt/ui'])
+    const result = plainCssSplitChunks()
+
+    const taps = []
+    const fakeCompiler = {
+      hooks: {
+        thisCompilation: {
+          tap: (name, fn) => taps.push({name, fn})
+        }
+      }
+    }
+
+    result.plugins[0].apply(fakeCompiler)
+    expect(taps).to.have.lengthOf(1)
+    expect(taps[0].name).to.equal('CssInAppStyles')
+  })
+})

--- a/packages/sui-bundler/webpack.config.client.dev.js
+++ b/packages/sui-bundler/webpack.config.client.dev.js
@@ -9,9 +9,10 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const HtmlWebpackInjectAttributesPlugin = require('html-webpack-inject-attributes-plugin')
 const {withHydrationOverlayWebpack} = require('@builder.io/react-hydration-overlay/webpack')
 
-const {envVars, MAIN_ENTRY_POINT, config, cleanList, when, isTailwindEnabled} = require('./shared/index.js')
+const {envVars, MAIN_ENTRY_POINT, config, cleanList, when} = require('./shared/index.js')
 const definePlugin = require('./shared/define.js')
 const manifestLoaderRules = require('./shared/module-rules-manifest-loader.js')
+const sassRules = require('./shared/module-rules-sass.js')
 const createSVGSpritemapPlugin = require('./shared/svg-spritemap')
 const {aliasFromConfig, defaultAlias} = require('./shared/resolve-alias.js')
 const {supportLegacyBrowsers, cacheDirectory} = require('./shared/config.js')
@@ -96,33 +97,7 @@ const webpackConfig = {
   module: {
     rules: cleanList([
       createCompilerRules({supportLegacyBrowsers, isDevelopment: true}),
-      {
-        test: /(\.css|\.scss)$/,
-        use: cleanList([
-          MiniCssExtractPlugin.loader,
-          require.resolve('css-loader'),
-          when(config['externals-manifest'], () => ({
-            loader: 'externals-manifest-loader',
-            options: {
-              manifestURL: config['externals-manifest']
-            }
-          })),
-          {
-            loader: require.resolve('postcss-loader'),
-            options: {
-              postcssOptions: {
-                plugins: [
-                  ...(isTailwindEnabled() ? [require('tailwindcss')()] : []),
-                  require('autoprefixer')({
-                    overrideBrowserslist: config.targets
-                  })
-                ]
-              }
-            }
-          },
-          require.resolve('@s-ui/sass-loader')
-        ])
-      },
+      ...(Array.isArray(sassRules) ? sassRules : [sassRules]),
       when(config['externals-manifest'], () => manifestLoaderRules(config['externals-manifest']))
     ])
   },

--- a/packages/sui-bundler/webpack.config.dev.js
+++ b/packages/sui-bundler/webpack.config.dev.js
@@ -14,6 +14,13 @@ const {supportLegacyBrowsers, cacheDirectory} = require('./shared/config.js')
 const {resolveLoader} = require('./shared/resolve-loader.js')
 const createCompilerRules = require('./shared/module-rules-compiler.js')
 
+const plainCssPackages = config.plainCssPackages || []
+const plainCssExclude = plainCssPackages.length
+  ? new RegExp(
+      `node_modules[\\\\/](${plainCssPackages.map(p => p.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})[\\\\/]`
+    )
+  : null
+
 const outputPath = path.join(process.cwd(), 'dist')
 
 const {CI = false} = process.env
@@ -90,6 +97,7 @@ const webpackConfig = {
       createCompilerRules({supportLegacyBrowsers, isDevelopment: true}),
       {
         test: /(\.css|\.scss)$/,
+        ...(plainCssExclude ? {exclude: plainCssExclude} : {}),
         use: cleanList([
           require.resolve('style-loader'),
           when(config['externals-manifest'], () => ({
@@ -115,6 +123,15 @@ const webpackConfig = {
           require.resolve('@s-ui/sass-loader')
         ])
       },
+      ...(plainCssExclude
+        ? [
+            {
+              test: /\.css$/,
+              include: plainCssExclude,
+              use: [require.resolve('style-loader'), require.resolve('css-loader')]
+            }
+          ]
+        : []),
       when(config['externals-manifest'], () => manifestLoaderRules(config['externals-manifest']))
     ])
   },

--- a/packages/sui-bundler/webpack.config.lib.js
+++ b/packages/sui-bundler/webpack.config.lib.js
@@ -60,7 +60,7 @@ module.exports = ({chunkCss} = {}) => {
       definePlugin()
     ]),
     module: {
-      rules: [createCompilerRules({supportLegacyBrowsers}), sassRules]
+      rules: [createCompilerRules({supportLegacyBrowsers}), ...(Array.isArray(sassRules) ? sassRules : [sassRules])]
     }
   }
 }

--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -10,6 +10,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const InlineChunkHtmlPlugin = require('./shared/inline-chunk-html-plugin.js')
 
 const {when, cleanList, envVars, MAIN_ENTRY_POINT, config} = require('./shared/index.js')
+const {plainCssSplitChunks} = require('./shared/plain-css-split-chunks.js')
 const {aliasFromConfig} = require('./shared/resolve-alias.js')
 const {extractComments, sourceMap, supportLegacyBrowsers, cacheDirectory} = require('./shared/config.js')
 const {resolveLoader} = require('./shared/resolve-loader.js')
@@ -65,7 +66,8 @@ const webpackConfig = {
     checkWasmTypes: false,
     minimize: true,
     minimizer: [minifyJs({extractComments, sourceMap}), minifyCss()].filter(Boolean),
-    runtimeChunk: true
+    runtimeChunk: true,
+    ...plainCssSplitChunks()
   },
   cache: {
     type: 'filesystem',

--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -106,7 +106,7 @@ const webpackConfig = {
   module: {
     rules: cleanList([
       createCompilerRules({supportLegacyBrowsers}),
-      sassRules,
+      ...(Array.isArray(sassRules) ? sassRules : [sassRules]),
       when(config['externals-manifest'], () => manifestLoaderRules(config['externals-manifest']))
     ])
   },

--- a/packages/sui-bundler/webpack.config.prod.js
+++ b/packages/sui-bundler/webpack.config.prod.js
@@ -66,8 +66,7 @@ const webpackConfig = {
     checkWasmTypes: false,
     minimize: true,
     minimizer: [minifyJs({extractComments, sourceMap}), minifyCss()].filter(Boolean),
-    runtimeChunk: true,
-    ...plainCssSplitChunks()
+    runtimeChunk: true
   },
   cache: {
     type: 'filesystem',
@@ -75,6 +74,7 @@ const webpackConfig = {
     compression: false
   },
   plugins: cleanList([
+    ...(plainCssSplitChunks().plugins || []),
     new webpack.ProvidePlugin({
       process: 'process/browser.js'
     }),


### PR DESCRIPTION
## Summary

Adds two new config options to `sui-bundler`:

1. **`plainCssPackages`** — allows consumer apps to specify npm packages whose `.css` files should be loaded with **only `css-loader`**, completely bypassing `@s-ui/sass-loader` and `postcss-loader`.
2. **`cssInAppStyles`** — forces CSS modules from specified packages into the `AppStyles` chunk, preventing webpack's `splitChunks` from extracting them into separate async chunks that `@s-ui/ssr` doesn't inject — avoiding Flash of Unstyled Content (FOUC).

## Problem

### Sass parse errors on modern CSS

`sui-bundler` routes **all** `.css` and `.scss` files through the full Sass + PostCSS pipeline — including third-party packages that ship pre-compiled Tailwind CSS v4 output. Dart Sass interprets valid CSS constructs (like `transition-property: transform, ...`) as Sass spread syntax, causing fatal build errors:

\`\`\`
Error: expected ";"
  ╷
  │ transition-property:transform,...;
  │                               ^^^
  ╵
\`\`\`

This blocks any consumer app from importing packages that emit modern CSS not compatible with the Sass parser (e.g. `@adv-mt/ui` which uses Tailwind CSS v4).

### Flash of Unstyled Content

When importing CSS from packages like `@adv-mt/ui/styles.css` via JS, webpack's `splitChunks` extracts it into a separate async chunk (e.g. `7100.css`) because it exceeds the 30KB threshold. `@s-ui/ssr` only injects the configured `AppStyles` chunk, so DS styles arrive ~1.5s after first paint — components render without styles and visually "jump".

## Solution

Two new config keys under `config.sui-bundler` in the consumer's `package.json`:

```json
{
  "config": {
    "sui-bundler": {
      "plainCssPackages": ["@adv-mt/ui", "@adv-mt/theme"],
      "cssInAppStyles": ["@adv-mt/ui", "@adv-mt/theme"]
    }
  }
}
```

### `plainCssPackages`

When set, the bundler:
1. **Excludes** those packages from the main Sass/PostCSS rule via a regex on `node_modules/<package>/`
2. **Adds** a separate rule that matches only `.css` files from those packages, using just `css-loader` (+ `MiniCssExtractPlugin.loader` or `style-loader` depending on the webpack config)

### `cssInAppStyles`

When set, the bundler adds a webpack plugin that:
1. Hooks into `afterOptimizeChunks` in the compilation
2. Finds all `css/mini-extract` modules from the configured packages
3. Moves them from their assigned chunk into the `AppStyles` chunk, so `@s-ui/ssr` injects them in the initial HTML

## Files changed

| File | Change |
|------|--------|
| `shared/module-rules-sass.js` | Core logic — builds exclude regex, creates separate plain CSS rule, exports array when needed |
| `shared/plain-css-split-chunks.js` | Webpack plugin that moves CSS modules into AppStyles chunk |
| `webpack.config.client.dev.js` | Uses shared `sassRules` (was duplicating inline rules) |
| `webpack.config.dev.js` | Adds `plainCssPackages` support with `style-loader` (SPA dev mode) |
| `webpack.config.prod.js` | Spreads `sassRules` as array + integrates `cssInAppStyles` plugin |
| `webpack.config.lib.js` | Spreads `sassRules` as array |
| `test/server/plainCssSplitChunksSpec.js` | Smoke tests for `cssInAppStyles` plugin |
| `README.md` | Documents both new config options |

## Usage

```json
{
  "config": {
    "sui-bundler": {
      "plainCssPackages": ["@adv-mt/ui", "@adv-mt/theme"],
      "cssInAppStyles": ["@adv-mt/ui", "@adv-mt/theme"]
    }
  }
}
```

Then `import '@adv-mt/ui/styles.css'` works without Sass errors, and the styles are bundled into `AppStyles.css` — no FOUC.

## Test plan

- [x] Verified locally: `@adv-mt/ui@2.3.0` CSS builds without Sass errors
- [x] Verified in consumer app (`frontend-ma--web-app#7667`): build passes, styles in `AppStyles` chunk, no FOUC
- [x] Lint passes (0 errors)
- [x] Smoke tests pass (`plainCssSplitChunksSpec.js`)
- [ ] CI (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)