### PR TITLE
fix(packages/sui-pde): Pass application attributes when getting feature variables

### DIFF
--- a/packages/sui-pde/src/adapters/optimizely/index.js
+++ b/packages/sui-pde/src/adapters/optimizely/index.js
@@ -217,7 +217,10 @@ export default class OptimizelyAdapter {
    * @returns {object}
    */
   getAllFeatureVariables({featureKey, attributes}) {
-    return this._optimizely.getAllFeatureVariables(featureKey, this._userId, attributes)
+    return this._optimizely.getAllFeatureVariables(featureKey, this._userId, {
+      ...this._applicationAttributes,
+      ...attributes
+    })
   }
 
   updateConsents({hasUserConsents}) {


### PR DESCRIPTION
Fixed a bug where feature variables failed to evaluate correctly without application attributes, resolving audience targeting issues.