### PR TITLE
fix(sui-bundler): don't force sass-loader on plainCssPackages when linking

### DIFF
--- a/packages/sui-bundler/loaders/linkLoaderConfigBuilder.js
+++ b/packages/sui-bundler/loaders/linkLoaderConfigBuilder.js
@@ -83,6 +83,21 @@ module.exports = ({config, packagesToLink, linkAll}) => {
 
     if (!regex.test('.css')) return rule
 
+    // Rules matching .css that don't already run through @s-ui/sass-loader
+    // (e.g. the plainCssPackages passthrough rule, see module-rules-sass.js)
+    // must be left alone — otherwise this force-injects the sass loader
+    // into plain CSS files, breaking packages that ship pre-built CSS
+    // (Tailwind v4 output, etc.) when they're consumed via -l/-L linking.
+    // Compared by resolved path rather than package-name substring so this
+    // also works when @s-ui/sass-loader itself is symlinked/linked (e.g.
+    // inside this monorepo), where its resolved path won't contain the
+    // package name.
+    const sassLoaderPath = require.resolve('@s-ui/sass-loader')
+    const usesSassLoader = use.some(
+      loaderUse => (typeof loaderUse === 'string' ? loaderUse : loaderUse.loader) === sassLoaderPath
+    )
+    if (!usesSassLoader) return rule
+
     return {
       ...rule,
       use: [...use.slice(0, -1), sassLoaderWithLinkImporter]

--- a/packages/sui-bundler/test/server/linkLoaderConfigBuilderSpec.js
+++ b/packages/sui-bundler/test/server/linkLoaderConfigBuilderSpec.js
@@ -1,0 +1,74 @@
+const {expect} = require('chai')
+
+const linkLoaderConfigBuilder = require('../../loaders/linkLoaderConfigBuilder.js')
+
+describe('linkLoaderConfigBuilder', () => {
+  const packagesToLink = [__dirname]
+
+  it('injects the sass link importer into rules that already use @s-ui/sass-loader', () => {
+    const config = {
+      module: {
+        rules: [
+          {
+            test: /(\.css|\.scss)$/,
+            exclude: /node_modules/,
+            use: [
+              'mini-css-extract-plugin-loader',
+              'css-loader',
+              'postcss-loader',
+              require.resolve('@s-ui/sass-loader')
+            ]
+          }
+        ]
+      },
+      resolve: {alias: {}}
+    }
+
+    const nextConfig = linkLoaderConfigBuilder({config, packagesToLink})
+    const sassRule = nextConfig.module.rules[0]
+
+    expect(sassRule.use).to.have.lengthOf(4)
+    expect(sassRule.use[3]).to.be.an('object')
+    expect(sassRule.use[3].loader).to.equal(require.resolve('@s-ui/sass-loader'))
+    expect(sassRule.use[3].options.sassOptions).to.have.property('importer')
+  })
+
+  it('leaves the plainCssPackages passthrough rule untouched', () => {
+    const config = {
+      module: {
+        rules: [
+          {
+            test: /(\.css|\.scss)$/,
+            exclude: /node_modules[\\/](@adv-mt\/ui)[\\/]/,
+            use: [
+              'mini-css-extract-plugin-loader',
+              'css-loader',
+              'postcss-loader',
+              require.resolve('@s-ui/sass-loader')
+            ]
+          },
+          {
+            test: /\.css$/,
+            include: /node_modules[\\/](@adv-mt\/ui)[\\/]/,
+            use: ['mini-css-extract-plugin-loader', 'css-loader']
+          }
+        ]
+      },
+      resolve: {alias: {}}
+    }
+
+    const nextConfig = linkLoaderConfigBuilder({config, packagesToLink})
+    const plainCssRule = nextConfig.module.rules[1]
+
+    // Before the fix, this rule's last loader (css-loader) was replaced with
+    // @s-ui/sass-loader, breaking pre-built CSS (e.g. Tailwind v4 output)
+    // from plainCssPackages when consumed via -l/-L linking.
+    expect(plainCssRule.use).to.deep.equal(['mini-css-extract-plugin-loader', 'css-loader'])
+  })
+
+  it('returns the original config unmodified when there is nothing to link', () => {
+    const config = {module: {rules: []}}
+    const nextConfig = linkLoaderConfigBuilder({config, packagesToLink: [], linkAll: false})
+    expect(nextConfig).to.equal(config)
+  })
+})


### PR DESCRIPTION
## Summary
- `linkLoaderConfigBuilder` (used by `sui-bundler dev -l/-L` and `sui-bundler build -l/-L` for local package linking) rewrites the last loader of every module rule whose `test` matches `.css`, injecting `@s-ui/sass-loader` with the link importer.
- This unconditionally includes the `plainCssPackages` passthrough rule added in #1988, which exists specifically to make webpack treat certain packages' `.css` as plain CSS and skip sass-loader entirely.
- Net effect: any consumer linking local packages (a standard monorepo dev workflow) while also using `plainCssPackages` for a dependency shipping modern CSS (e.g. Tailwind v4's `@layer`/`@supports` syntax) gets that CSS silently routed through sass-loader anyway, which can't parse it → `Module parse failed` at dev-server startup.
- Fix: only rewrite rules whose `use` chain already includes `@s-ui/sass-loader`, compared by `require.resolve`d path (not a package-name substring — needed so this still works when `@s-ui/sass-loader` itself is linked, where its resolved path is `packages/sui-sass-loader/src/index.js` and doesn't contain the package name).

## Test plan
- [x] Added `packages/sui-bundler/test/server/linkLoaderConfigBuilderSpec.js`: asserts the sass-loader rule still gets the link importer injected, the `plainCssPackages` passthrough rule is left untouched, and the no-op case (nothing to link) returns config unchanged.
- [x] `npx @s-ui/test server -P 'packages/sui-bundler/test/server/*Spec.js'` — 15 passing (includes pre-existing `linkLoaderSpec`, `plainCssSplitChunksSpec`, integration specs).
- [x] `sui-lint js --fix` — 0 errors (pre-existing `sui/commonjs` warnings elsewhere in the package, not introduced by this change).
- [x] Full pre-push suite (`npm run test && npm run types:check`) passed: 595 client tests, 18 server tests, typecheck clean.
- [x] Reproduced against a real consumer (`frontend-mt--web-app`, running `dev:coches` with `-l ../packages/domain -l ../packages/literals -l ../packages/segment-wrapper -l ../packages/theme -L ../packages/ui` and `plainCssPackages: ["@adv-mt/ui", "@adv-mt/theme"]`): before the fix, dev server failed to compile with `Module parse failed: Unexpected token` on `@adv-mt/theme/dist/tokens.css` and `@adv-mt/ui/dist/basic/button/styles.css`; after patching locally, dev server compiled and served correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)