### PR TITLE
fix(packages/sui-bundler): keep plainCssPackages rules out of the link sass loader

### DIFF
--- a/packages/sui-bundler/loaders/linkLoaderConfigBuilder.js
+++ b/packages/sui-bundler/loaders/linkLoaderConfigBuilder.js
@@ -83,6 +83,20 @@ module.exports = ({config, packagesToLink, linkAll}) => {
 
     if (!regex.test('.css')) return rule
 
+    if (!Array.isArray(use)) return rule
+
+    /**
+     * Only rules that already pipe through @s-ui/sass-loader need its importer
+     * replaced. Rules that don't (like the plainCssPackages passthrough) must be
+     * left untouched: injecting the sass loader there makes Sass parse plain CSS
+     * that isn't valid SCSS (e.g. Tailwind v4 output) and the build fails.
+     */
+    const usesSassLoader = use.some(loaderEntry =>
+      (typeof loaderEntry === 'string' ? loaderEntry : loaderEntry?.loader || '').includes('@s-ui/sass-loader')
+    )
+
+    if (!usesSassLoader) return rule
+
     return {
       ...rule,
       use: [...use.slice(0, -1), sassLoaderWithLinkImporter]


### PR DESCRIPTION
## Problem

`plainCssPackages` (added in #1988, released in v9.79.0) has no effect when the bundler runs with link flags (`-l` / `-L`).

`loaders/linkLoaderConfigBuilder.js` rewrote **every** rule whose `test` matched `.css`, swapping its last loader for `@s-ui/sass-loader` with the link importer. That also hit the `plainCssPackages` passthrough rule (`[style-loader, css-loader]`), turning it into `[style-loader, @s-ui/sass-loader]`. Plain CSS then went through Sass and the build died:

```
ERROR in node_modules/@adv-mt/ui/dist/basic/button/styles.css
Module build failed (from node_modules/@s-ui/sass-loader/src/index.js):
Error: Expected digit.
2 │ @layer properties{@supports (((-webkit-hyphens:none)) and ...
```

Reproduced in `frontend-mt--web-app`, whose `dev_coches` target passes `-l ../packages/domain … -L ../packages/ui` and declares `plainCssPackages: ["@adv-mt/ui", "@adv-mt/theme"]` (Tailwind v4 output — not valid SCSS).

## Fix

Only replace the sass importer on rules that **already** pipe through `@s-ui/sass-loader`. Any other rule is returned untouched, so the `plainCssPackages` passthrough survives link mode. Also bails out when `use` isn't an array.

## Verification

Ran the builder over a config mirroring `webpack.config.dev.js` (sass rule + plainCssPackages passthrough + a JS rule) with `packagesToLink` set:

- sass rule → last loader still swapped for the importer-aware `@s-ui/sass-loader` ✅
- plainCssPackages rule → `[style-loader, css-loader]`, unchanged ✅
- JS rule → unchanged ✅

Before the fix the second rule became `[style-loader, @s-ui/sass-loader]`. `sui-lint js` reports 0 errors on the touched file (only pre-existing `sui/commonjs` warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)